### PR TITLE
feat(sync): Always print summary

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -156,14 +156,16 @@ func syncMain(filenames []string, dry bool, parallelism, delay int, workspace st
 	s, _ := diff.NewSyncer(currentState, targetState)
 	s.StageDelaySec = delay
 	stats, errs := solver.Solve(stopChannel, s, client, parallelism, dry)
-	if errs != nil {
-		return utils.ErrArray{Errors: errs}
-	}
 	printFn := color.New(color.FgGreen, color.Bold).PrintfFunc()
 	printFn("Summary:\n")
 	printFn("  Created: %v\n", stats.CreateOps)
 	printFn("  Updated: %v\n", stats.UpdateOps)
 	printFn("  Deleted: %v\n", stats.DeleteOps)
+	if errs != nil {
+		printErr := color.New(color.FgRed, color.Bold).PrintfFunc()
+		printErr("  Errors: %v\n\n", len(errs))
+		return utils.ErrArray{Errors: errs}
+	}
 	if diffCmdNonZeroExitCode &&
 		stats.CreateOps+stats.UpdateOps+stats.DeleteOps != 0 {
 		os.Exit(exitCodeDiffDetection)

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -162,8 +162,6 @@ func syncMain(filenames []string, dry bool, parallelism, delay int, workspace st
 	printFn("  Updated: %v\n", stats.UpdateOps)
 	printFn("  Deleted: %v\n", stats.DeleteOps)
 	if errs != nil {
-		printErr := color.New(color.FgRed, color.Bold).PrintfFunc()
-		printErr("  Errors: %v\n\n", len(errs))
 		return utils.ErrArray{Errors: errs}
 	}
 	if diffCmdNonZeroExitCode &&


### PR DESCRIPTION
When decK encounters an error (e.g. invalid plugin configuration) it will currently not print the summary, making it hard to know what was still changed despite the error.

This small change makes sure the summary is printed even in that case and adds an `Errors:` field when there was at least one error.

Sample output:
```ShellSession
$ ./deck sync -s .
creating consumer jwt-user
...
...
...
creating plugin openid-connect for route 8e4bf008-c470-4456-b333-7094c7089070
Summary:
  Created: 112
  Updated: 15
  Deleted: 0
  Errors: 2

Error: 2 errors occurred:
	while processing event: {Create} failed: 400 Bad Request {"message":"2 schema violations (only one of these fields must be non-empty: 'config.aws_region', 'config.host'; config.aws_region1: unknown field)","name":"schema violation","fields":{"config":{"aws_region1":"unknown field"},"@entity":["only one of these fields must be non-empty: 'config.aws_region', 'config.host'"]},"code":2}
	while processing event: {Create} failed: 400 Bad Request {"message":"3 schema violations (only one of these fields must be non-empty: 'config.allow', 'config.deny'; at least one of these fields must be non-empty: 'config.allow', 'config.deny'; config.whitelist1: unknown field)","name":"schema violation","fields":{"config":{"whitelist1":"unknown field"},"@entity":["only one of these fields must be non-empty: 'config.allow', 'config.deny'","at least one of these fields must be non-empty: 'config.allow', 'config.deny'"]},"code":2}
```