### PR TITLE
fix: Break infinite wait when encountering many errors

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -281,8 +281,13 @@ func (sc *Syncer) eventCompleted() {
 func (sc *Syncer) wait() {
 	time.Sleep(time.Duration(sc.StageDelaySec) * time.Second)
 	for atomic.LoadInt32(&sc.inFlightOps) != 0 {
-		// TODO hack?
-		time.Sleep(1 * time.Millisecond)
+		select {
+		case <-sc.stopChan:
+			return
+		default:
+			// TODO hack?
+			time.Sleep(1 * time.Millisecond)
+		}
 	}
 }
 


### PR DESCRIPTION
I encountered a condition where decK would hang up indefinitely - after processing the first few entities it would not continue and not even a Ctrl+C would terminate it.

I started looking into it and a `kill -ABRT` showed it was in an infinite loop in `diff/diff.go`:
```ShellSession
$ deck sync -s .
creating consumer acl22
creating consumer gold-partner
creating consumer jwt-user
creating consumer acl11
creating consumer myConsumer
creating consumer oauthApp
creating consumer external
creating consumer acl12
creating consumer partner
creating consumer silver-partner
creating consumer oauthUser
^Creceived interrupt , terminating...
SIGABRT: abort
PC=0x7fff69344882 m=0 sigcode=0

goroutine 0 [idle]:
runtime.pthread_cond_wait(0x1b044a8, 0x1b04468, 0x7ffe00000000)
	/usr/local/Cellar/go/1.14.6/libexec/src/runtime/sys_darwin.go:390 +0x39
runtime.semasleep(0xffffffffffffffff, 0x7ffeefbfeda0)
	/usr/local/Cellar/go/1.14.6/libexec/src/runtime/os_darwin.go:63 +0x85
runtime.notesleep(0x1b04268)
	/usr/local/Cellar/go/1.14.6/libexec/src/runtime/lock_sema.go:173 +0xe0
runtime.stoplockedm()
	/usr/local/Cellar/go/1.14.6/libexec/src/runtime/proc.go:1977 +0x88
runtime.schedule()
	/usr/local/Cellar/go/1.14.6/libexec/src/runtime/proc.go:2460 +0x4a6
runtime.park_m(0xc000001c80)
	/usr/local/Cellar/go/1.14.6/libexec/src/runtime/proc.go:2696 +0x9d
runtime.mcall(0x1061e16)
	/usr/local/Cellar/go/1.14.6/libexec/src/runtime/asm_amd64.s:318 +0x5b

goroutine 1 [semacquire]:
sync.runtime_Semacquire(0xc000210008)
	/usr/local/Cellar/go/1.14.6/libexec/src/runtime/sema.go:56 +0x42
sync.(*WaitGroup).Wait(0xc000210000)
	/usr/local/Cellar/go/1.14.6/libexec/src/sync/waitgroup.go:130 +0x64
github.com/kong/deck/cmd.Execute()
	/Users/cwurm/git/hbagdi/deck/cmd/root.go:64 +0xc8
main.main()
	/Users/cwurm/git/hbagdi/deck/main.go:29 +0x25

goroutine 6 [syscall]:
os/signal.signal_recv(0x172e600)
	/usr/local/Cellar/go/1.14.6/libexec/src/runtime/sigqueue.go:144 +0x96
os/signal.loop()
	/usr/local/Cellar/go/1.14.6/libexec/src/os/signal/signal_unix.go:23 +0x22
created by os/signal.Notify.func1
	/usr/local/Cellar/go/1.14.6/libexec/src/os/signal/signal.go:127 +0x44

goroutine 20 [chan receive]:
github.com/kong/deck/diff.(*Syncer).Run(0xc00007b040, 0xc000030120, 0xb, 0xc00000f520, 0x1731600, 0xc0004fa098, 0x0)
	/Users/cwurm/git/hbagdi/deck/diff/diff.go:347 +0x34f
github.com/kong/deck/solver.Solve(0xc000030120, 0xc00007b040, 0xc000476000, 0xb, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/cwurm/git/hbagdi/deck/solver/solver.go:36 +0xfd
github.com/kong/deck/cmd.syncMain(0xc000212050, 0x1, 0x1, 0xc00020e200, 0xb, 0x0, 0x0, 0x0, 0x0, 0x0)
	/Users/cwurm/git/hbagdi/deck/cmd/common.go:158 +0x446
github.com/kong/deck/cmd.glob..func7(0x1afa240, 0xc00021c100, 0x0, 0x4, 0x0, 0x0)
	/Users/cwurm/git/hbagdi/deck/cmd/sync.go:24 +0x7e
github.com/spf13/cobra.(*Command).execute(0x1afa240, 0xc00021c080, 0x4, 0x4, 0x1afa240, 0xc00021c080)
	/Users/cwurm/go/pkg/mod/github.com/spf13/cobra@v0.0.7/command.go:838 +0x453
github.com/spf13/cobra.(*Command).ExecuteC(0x1af9fa0, 0x0, 0x0, 0x0)
	/Users/cwurm/go/pkg/mod/github.com/spf13/cobra@v0.0.7/command.go:943 +0x317
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/cwurm/go/pkg/mod/github.com/spf13/cobra@v0.0.7/command.go:883
github.com/kong/deck/cmd.Execute.func2(0xc000212000, 0xc000210000)
	/Users/cwurm/git/hbagdi/deck/cmd/root.go:60 +0x2d
created by github.com/kong/deck/cmd.Execute
	/Users/cwurm/git/hbagdi/deck/cmd/root.go:59 +0xba

goroutine 61 [IO wait]:
internal/poll.runtime_pollWait(0x9315f18, 0x72, 0xffffffffffffffff)
	/usr/local/Cellar/go/1.14.6/libexec/src/runtime/netpoll.go:203 +0x55
internal/poll.(*pollDesc).wait(0xc00015c798, 0x72, 0x1000, 0x1000, 0xffffffffffffffff)
	/usr/local/Cellar/go/1.14.6/libexec/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
	/usr/local/Cellar/go/1.14.6/libexec/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc00015c780, 0xc0000fd000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/Cellar/go/1.14.6/libexec/src/internal/poll/fd_unix.go:169 +0x201
net.(*netFD).Read(0xc00015c780, 0xc0000fd000, 0x1000, 0x1000, 0xc000021080, 0xc000746da8, 0xc000746c38)
	/usr/local/Cellar/go/1.14.6/libexec/src/net/fd_unix.go:202 +0x4f
net.(*conn).Read(0xc0001fabd8, 0xc0000fd000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/Cellar/go/1.14.6/libexec/src/net/net.go:184 +0x8e
net/http.(*persistConn).Read(0xc000123440, 0xc0000fd000, 0x1000, 0x1000, 0xc000746eb0, 0x1061610, 0xc000746eb0)
	/usr/local/Cellar/go/1.14.6/libexec/src/net/http/transport.go:1825 +0x75
bufio.(*Reader).fill(0xc0000cf7a0)
	/usr/local/Cellar/go/1.14.6/libexec/src/bufio/bufio.go:100 +0x103
bufio.(*Reader).Peek(0xc0000cf7a0, 0x1, 0x2, 0x0, 0x0, 0xc000231a00, 0x0)
	/usr/local/Cellar/go/1.14.6/libexec/src/bufio/bufio.go:138 +0x4f
net/http.(*persistConn).readLoop(0xc000123440)
	/usr/local/Cellar/go/1.14.6/libexec/src/net/http/transport.go:1978 +0x1a8
created by net/http.(*Transport).dialConn
	/usr/local/Cellar/go/1.14.6/libexec/src/net/http/transport.go:1647 +0xc56

goroutine 62 [select]:
net/http.(*persistConn).writeLoop(0xc000123440)
	/usr/local/Cellar/go/1.14.6/libexec/src/net/http/transport.go:2277 +0x11c
created by net/http.(*Transport).dialConn
	/usr/local/Cellar/go/1.14.6/libexec/src/net/http/transport.go:1648 +0xc7b

goroutine 121 [IO wait]:
internal/poll.runtime_pollWait(0x9315658, 0x72, 0xffffffffffffffff)
	/usr/local/Cellar/go/1.14.6/libexec/src/runtime/netpoll.go:203 +0x55
internal/poll.(*pollDesc).wait(0xc0004d2498, 0x72, 0x1000, 0x1000, 0xffffffffffffffff)
	/usr/local/Cellar/go/1.14.6/libexec/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
	/usr/local/Cellar/go/1.14.6/libexec/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc0004d2480, 0xc000668000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/Cellar/go/1.14.6/libexec/src/internal/poll/fd_unix.go:169 +0x201
net.(*netFD).Read(0xc0004d2480, 0xc000668000, 0x1000, 0x1000, 0x1036fac, 0xc000095b70, 0x1060d20)
	/usr/local/Cellar/go/1.14.6/libexec/src/net/fd_unix.go:202 +0x4f
net.(*conn).Read(0xc000656018, 0xc000668000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/Cellar/go/1.14.6/libexec/src/net/net.go:184 +0x8e
net/http.(*persistConn).Read(0xc000548000, 0xc000668000, 0x1000, 0x1000, 0xc000644660, 0xc000095c70, 0x1006e25)
	/usr/local/Cellar/go/1.14.6/libexec/src/net/http/transport.go:1825 +0x75
bufio.(*Reader).fill(0xc0006486c0)
	/usr/local/Cellar/go/1.14.6/libexec/src/bufio/bufio.go:100 +0x103
bufio.(*Reader).Peek(0xc0006486c0, 0x1, 0x0, 0x0, 0x1, 0xc0001b4000, 0x0)
	/usr/local/Cellar/go/1.14.6/libexec/src/bufio/bufio.go:138 +0x4f
net/http.(*persistConn).readLoop(0xc000548000)
	/usr/local/Cellar/go/1.14.6/libexec/src/net/http/transport.go:1978 +0x1a8
created by net/http.(*Transport).dialConn
	/usr/local/Cellar/go/1.14.6/libexec/src/net/http/transport.go:1647 +0xc56

goroutine 162 [IO wait]:
internal/poll.runtime_pollWait(0x93153b8, 0x72, 0xffffffffffffffff)
	/usr/local/Cellar/go/1.14.6/libexec/src/runtime/netpoll.go:203 +0x55
internal/poll.(*pollDesc).wait(0xc00015ce18, 0x72, 0x1000, 0x1000, 0xffffffffffffffff)
	/usr/local/Cellar/go/1.14.6/libexec/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
	/usr/local/Cellar/go/1.14.6/libexec/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc00015ce00, 0xc0004fe000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/Cellar/go/1.14.6/libexec/src/internal/poll/fd_unix.go:169 +0x201
net.(*netFD).Read(0xc00015ce00, 0xc0004fe000, 0x1000, 0x1000, 0x1036fac, 0xc000066b70, 0x1060d20)
	/usr/local/Cellar/go/1.14.6/libexec/src/net/fd_unix.go:202 +0x4f
net.(*conn).Read(0xc0004fa000, 0xc0004fe000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/Cellar/go/1.14.6/libexec/src/net/net.go:184 +0x8e
net/http.(*persistConn).Read(0xc000652000, 0xc0004fe000, 0x1000, 0x1000, 0xc0002aa0c0, 0xc000066c70, 0x1006e25)
	/usr/local/Cellar/go/1.14.6/libexec/src/net/http/transport.go:1825 +0x75
bufio.(*Reader).fill(0xc0004f8060)
	/usr/local/Cellar/go/1.14.6/libexec/src/bufio/bufio.go:100 +0x103
bufio.(*Reader).Peek(0xc0004f8060, 0x1, 0x0, 0x0, 0x1, 0xc0001ae000, 0x0)
	/usr/local/Cellar/go/1.14.6/libexec/src/bufio/bufio.go:138 +0x4f
net/http.(*persistConn).readLoop(0xc000652000)
	/usr/local/Cellar/go/1.14.6/libexec/src/net/http/transport.go:1978 +0x1a8
created by net/http.(*Transport).dialConn
	/usr/local/Cellar/go/1.14.6/libexec/src/net/http/transport.go:1647 +0xc56

goroutine 122 [select]:
net/http.(*persistConn).writeLoop(0xc000548000)
	/usr/local/Cellar/go/1.14.6/libexec/src/net/http/transport.go:2277 +0x11c
created by net/http.(*Transport).dialConn
	/usr/local/Cellar/go/1.14.6/libexec/src/net/http/transport.go:1648 +0xc7b

goroutine 163 [select]:
net/http.(*persistConn).writeLoop(0xc000652000)
	/usr/local/Cellar/go/1.14.6/libexec/src/net/http/transport.go:2277 +0x11c
created by net/http.(*Transport).dialConn
	/usr/local/Cellar/go/1.14.6/libexec/src/net/http/transport.go:1648 +0xc7b

goroutine 178 [sleep]:
time.Sleep(0xf4240)
	/usr/local/Cellar/go/1.14.6/libexec/src/runtime/time.go:188 +0xba
github.com/kong/deck/diff.(*Syncer).wait(0xc00007b040)
	/Users/cwurm/git/hbagdi/deck/diff/diff.go:285 +0x45
github.com/kong/deck/diff.(*Syncer).createUpdate(0xc00007b040, 0x1, 0x0)
	/Users/cwurm/git/hbagdi/deck/diff/diff.go:200 +0xb3
github.com/kong/deck/diff.(*Syncer).diff(0xc00007b040, 0x1, 0x0)
	/Users/cwurm/git/hbagdi/deck/diff/diff.go:65 +0x2f
github.com/kong/deck/diff.(*Syncer).Run.func2(0xc00007b040, 0xc0002c0ed0)
	/Users/cwurm/git/hbagdi/deck/diff/diff.go:318 +0x2f
created by github.com/kong/deck/diff.(*Syncer).Run
	/Users/cwurm/git/hbagdi/deck/diff/diff.go:317 +0x1cf

goroutine 179 [semacquire]:
sync.runtime_Semacquire(0xc0002c0ed8)
	/usr/local/Cellar/go/1.14.6/libexec/src/runtime/sema.go:56 +0x42
sync.(*WaitGroup).Wait(0xc0002c0ed0)
	/usr/local/Cellar/go/1.14.6/libexec/src/sync/waitgroup.go:130 +0x64
github.com/kong/deck/diff.(*Syncer).Run.func3(0xc0002c0ed0, 0xc00007b040)
	/Users/cwurm/git/hbagdi/deck/diff/diff.go:328 +0x2b
created by github.com/kong/deck/diff.(*Syncer).Run
	/Users/cwurm/git/hbagdi/deck/diff/diff.go:327 +0x201

rax    0x104
rbx    0x2
rcx    0x7ffeefbfebc8
rdx    0x400
rdi    0x1b044a8
rsi    0x50100000600
rbp    0x7ffeefbfec60
rsp    0x7ffeefbfebc8
r8     0x0
r9     0xa0
r10    0x0
r11    0x202
r12    0x1b044a8
r13    0x16
r14    0x50100000600
r15    0xf23adc0
rip    0x7fff69344882
rflags 0x203
cs     0x7
fs     0x0
gs     0x0

```

I inserted some debug statements and what seemed to be happening is that `inFlightOps` never go down to 0 and therefore `sc.wait()` never returns. All consumers have exited, yet the producer is still alive and waiting for those ops to be processed to shut down.

With some more experimentation, I found out that this only happens with `--parallelism` set to values between 10 (default) and 19. Anything below 10 and anything 20 or above is fine.

What seems to happen is:
- Consumers stop when they encounter an error. In this case, the Kong consumers cannot be created so each decK consumer stops after processing one event.
- If there are enough consumers for the producer to reach `sc.wait()` on line 200, it will enter an infinite loop checking if `inFlightOps` is 0 and there are no consumers alive to process events.
- Checking if `stopChan` has been closed fixes the problem.