### PR TITLE
feat: Print entity identifier in errors

### DIFF
--- a/crud/registry.go
+++ b/crud/registry.go
@@ -119,7 +119,7 @@ func (r *Registry) Do(kind Kind, op Op, args ...Arg) (Arg, error) {
 	}
 
 	if err != nil {
-		return nil, errors.Wrapf(err, "%v failed", op)
+		return nil, err
 	}
 	return res, nil
 }

--- a/solver/solver.go
+++ b/solver/solver.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kong/deck/print"
 	"github.com/kong/deck/state"
 	"github.com/kong/go-kong/kong"
+	"github.com/pkg/errors"
 )
 
 // Stats holds the stats related to a Solve.
@@ -58,7 +59,7 @@ func Solve(doneCh chan struct{}, syncer *diff.Syncer,
 			// fire the request to Kong
 			result, err = r.Do(e.Kind, e.Op, e)
 			if err != nil {
-				return nil, err
+				return nil, errors.Wrapf(err, "%v %v %v failed", e.Op, e.Kind, c.Console())
 			}
 		} else {
 			// diff mode


### PR DESCRIPTION
When dealing with many errors, it can be hard to map the error messages (which all appear together at the very end of the output) to the entities (which appear all before). This PR adds information about the kind of entity and the entity identifier to the error messages.

*Before (showing just one error for brevity, and coincidentally the identifier is also in the error message - however, this really matters esp. when there are dozens of errors and the errors have less detail):*
```ShellSession
$ deck sync -s .
creating consumer acl21
Summary:
  Created: 0
  Updated: 0
  Deleted: 0
Error: 1 errors occurred:
		while processing event: {Create} failed: 409 Conflict {"message":"UNIQUE violation detected on '{username=\"acl21\"}'","name":"unique constraint violation","fields":{"username":"acl21"},"code":5}
```

*After:*
```ShellSession
$ deck sync -s .
creating consumer acl21
Summary:
  Created: 0
  Updated: 0
  Deleted: 0
Error: 1 errors occurred:
		while processing event: {Create} consumer acl21 failed: 409 Conflict {"message":"UNIQUE violation detected on '{username=\"acl21\"}'","name":"unique constraint violation","fields":{"username":"acl21"},"code":5}
```

Notice the additional detail in `while processing event: {Create} consumer acl21 failed:`.