### PR TITLE
feat: Print detailed entity information when it already exists

### DIFF
--- a/file/reader.go
+++ b/file/reader.go
@@ -47,7 +47,11 @@ func Get(fileContent *Content, opt RenderConfig) (*utils.KongRawState, error) {
 	}
 	builder.defaulter = d
 
-	return builder.build()
+	state, err := builder.build()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading state file(s)")
+	}
+	return state, nil
 }
 
 func ensureJSON(m map[string]interface{}) map[string]interface{} {

--- a/file/reader.go
+++ b/file/reader.go
@@ -49,7 +49,7 @@ func Get(fileContent *Content, opt RenderConfig) (*utils.KongRawState, error) {
 
 	state, err := builder.build()
 	if err != nil {
-		return nil, errors.Wrap(err, "error building state")
+		return nil, errors.Wrap(err, "building state")
 	}
 	return state, nil
 }

--- a/file/reader.go
+++ b/file/reader.go
@@ -49,7 +49,7 @@ func Get(fileContent *Content, opt RenderConfig) (*utils.KongRawState, error) {
 
 	state, err := builder.build()
 	if err != nil {
-		return nil, errors.Wrapf(err, "error reading state file(s)")
+		return nil, errors.Wrap(err, "error building state")
 	}
 	return state, nil
 }

--- a/state/aclgroup.go
+++ b/state/aclgroup.go
@@ -75,7 +75,7 @@ func insertACLGroup(txn *memdb.Txn, aclGroup ACLGroup) error {
 	// err out if group with same ID is present
 	_, err := getACLGroupByID(txn, *aclGroup.ID)
 	if err == nil {
-		return ErrAlreadyExists
+		return errors.Errorf("acl-group %v already exists", aclGroup.Console())
 	} else if err != ErrNotFound {
 		return err
 	}
@@ -89,7 +89,7 @@ func insertACLGroup(txn *memdb.Txn, aclGroup ACLGroup) error {
 	}
 	_, err = getACLGroup(txn, *aclGroup.Consumer.ID, *aclGroup.Group)
 	if err == nil {
-		return ErrAlreadyExists
+		return errors.Errorf("acl-group %v already exists", aclGroup.Console())
 	} else if err != ErrNotFound {
 		return err
 	}

--- a/state/aclgroup.go
+++ b/state/aclgroup.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"fmt"
+
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/kong/deck/state/indexers"
 	"github.com/kong/deck/utils"
@@ -75,7 +77,7 @@ func insertACLGroup(txn *memdb.Txn, aclGroup ACLGroup) error {
 	// err out if group with same ID is present
 	_, err := getACLGroupByID(txn, *aclGroup.ID)
 	if err == nil {
-		return errors.Errorf("acl-group %v already exists", aclGroup.Console())
+		return fmt.Errorf("inserting acl-group %v: %w", aclGroup.Console(), ErrAlreadyExists)
 	} else if err != ErrNotFound {
 		return err
 	}
@@ -89,7 +91,7 @@ func insertACLGroup(txn *memdb.Txn, aclGroup ACLGroup) error {
 	}
 	_, err = getACLGroup(txn, *aclGroup.Consumer.ID, *aclGroup.Group)
 	if err == nil {
-		return errors.Errorf("acl-group %v already exists", aclGroup.Console())
+		return fmt.Errorf("inserting acl-group %v: %w", aclGroup.Console(), ErrAlreadyExists)
 	} else if err != ErrNotFound {
 		return err
 	}

--- a/state/cacert.go
+++ b/state/cacert.go
@@ -1,10 +1,11 @@
 package state
 
 import (
+	"fmt"
+
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/kong/deck/state/indexers"
 	"github.com/kong/deck/utils"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -49,7 +50,7 @@ func (k *CACertificatesCollection) Add(caCert CACertificate) error {
 	}
 	_, err := getCACert(txn, searchBy...)
 	if err == nil {
-		return errors.Errorf("ca-cert %v already exists", caCert.Console())
+		return fmt.Errorf("inserting ca-cert %v: %w", caCert.Console(), ErrAlreadyExists)
 	} else if err != ErrNotFound {
 		return err
 	}

--- a/state/cacert.go
+++ b/state/cacert.go
@@ -4,6 +4,7 @@ import (
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/kong/deck/state/indexers"
 	"github.com/kong/deck/utils"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -48,7 +49,7 @@ func (k *CACertificatesCollection) Add(caCert CACertificate) error {
 	}
 	_, err := getCACert(txn, searchBy...)
 	if err == nil {
-		return ErrAlreadyExists
+		return errors.Errorf("ca-cert %v already exists", caCert.Console())
 	} else if err != ErrNotFound {
 		return err
 	}

--- a/state/certificate.go
+++ b/state/certificate.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"fmt"
+
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/kong/deck/state/indexers"
 	"github.com/kong/deck/utils"
@@ -58,7 +60,7 @@ func (k *CertificatesCollection) Add(certificate Certificate) error {
 
 	_, err := getCertificate(txn, *certificate.ID)
 	if err == nil {
-		return errors.Errorf("certificate %v already exists", certificate.Console())
+		return fmt.Errorf("inserting certificate %v: %w", certificate.Console(), ErrAlreadyExists)
 	} else if err != ErrNotFound {
 		return err
 	}

--- a/state/certificate.go
+++ b/state/certificate.go
@@ -58,7 +58,7 @@ func (k *CertificatesCollection) Add(certificate Certificate) error {
 
 	_, err := getCertificate(txn, *certificate.ID)
 	if err == nil {
-		return ErrAlreadyExists
+		return errors.Errorf("certificate %v already exists", certificate.Console())
 	} else if err != ErrNotFound {
 		return err
 	}

--- a/state/consumer.go
+++ b/state/consumer.go
@@ -1,9 +1,10 @@
 package state
 
 import (
+	"fmt"
+
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/kong/deck/utils"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -48,7 +49,7 @@ func (k *ConsumersCollection) Add(consumer Consumer) error {
 	}
 	_, err := getConsumer(txn, searchBy...)
 	if err == nil {
-		return errors.Errorf("consumer %v already exists", consumer.Console())
+		return fmt.Errorf("inserting consumer %v: %w", consumer.Console(), ErrAlreadyExists)
 	} else if err != ErrNotFound {
 		return err
 	}

--- a/state/consumer.go
+++ b/state/consumer.go
@@ -3,6 +3,7 @@ package state
 import (
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/kong/deck/utils"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -47,7 +48,7 @@ func (k *ConsumersCollection) Add(consumer Consumer) error {
 	}
 	_, err := getConsumer(txn, searchBy...)
 	if err == nil {
-		return ErrAlreadyExists
+		return errors.Errorf("consumer %v already exists", consumer.Console())
 	} else if err != ErrNotFound {
 		return err
 	}

--- a/state/credentials.go
+++ b/state/credentials.go
@@ -3,6 +3,7 @@ package state
 import (
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/kong/deck/state/indexers"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -78,7 +79,7 @@ func (k *credentialsCollection) Add(cred entity) error {
 
 	_, err := k.getCred(txn, cred.GetID(), cred.GetID2())
 	if err == nil {
-		return ErrAlreadyExists
+		return errors.Errorf("credential %v already exists", cred.GetID())
 	} else if err != ErrNotFound {
 		return err
 	}

--- a/state/credentials.go
+++ b/state/credentials.go
@@ -1,9 +1,10 @@
 package state
 
 import (
+	"fmt"
+
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/kong/deck/state/indexers"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -79,7 +80,7 @@ func (k *credentialsCollection) Add(cred entity) error {
 
 	_, err := k.getCred(txn, cred.GetID(), cred.GetID2())
 	if err == nil {
-		return errors.Errorf("credential %v already exists", cred.GetID())
+		return fmt.Errorf("inserting credential %v: %w", cred.GetID(), ErrAlreadyExists)
 	} else if err != ErrNotFound {
 		return err
 	}

--- a/state/plugin.go
+++ b/state/plugin.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"fmt"
+
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/kong/deck/state/indexers"
 	"github.com/kong/deck/utils"
@@ -127,7 +129,7 @@ func insertPlugin(txn *memdb.Txn, plugin Plugin) error {
 	// err out if plugin with same ID is present
 	_, err := getPluginByID(txn, *plugin.ID)
 	if err == nil {
-		return errors.Errorf("plugin %v already exists", plugin.Console())
+		return fmt.Errorf("inserting plugin %v: %w", plugin.Console(), ErrAlreadyExists)
 	} else if err != ErrNotFound {
 		return err
 	}
@@ -145,7 +147,7 @@ func insertPlugin(txn *memdb.Txn, plugin Plugin) error {
 	}
 	_, err = getPluginBy(txn, *plugin.Name, sID, rID, cID)
 	if err == nil {
-		return errors.Errorf("plugin %v already exists", plugin.Console())
+		return fmt.Errorf("inserting plugin %v: %w", plugin.Console(), ErrAlreadyExists)
 	} else if err != ErrNotFound {
 		return err
 	}

--- a/state/plugin.go
+++ b/state/plugin.go
@@ -127,7 +127,7 @@ func insertPlugin(txn *memdb.Txn, plugin Plugin) error {
 	// err out if plugin with same ID is present
 	_, err := getPluginByID(txn, *plugin.ID)
 	if err == nil {
-		return ErrAlreadyExists
+		return errors.Errorf("plugin %v already exists", plugin.Console())
 	} else if err != ErrNotFound {
 		return err
 	}
@@ -145,7 +145,7 @@ func insertPlugin(txn *memdb.Txn, plugin Plugin) error {
 	}
 	_, err = getPluginBy(txn, *plugin.Name, sID, rID, cID)
 	if err == nil {
-		return ErrAlreadyExists
+		return errors.Errorf("plugin %v already exists", plugin.Console())
 	} else if err != ErrNotFound {
 		return err
 	}

--- a/state/route.go
+++ b/state/route.go
@@ -4,6 +4,7 @@ import (
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/kong/deck/state/indexers"
 	"github.com/kong/deck/utils"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -63,7 +64,7 @@ func (k *RoutesCollection) Add(route Route) error {
 	}
 	_, err := getRoute(txn, searchBy...)
 	if err == nil {
-		return ErrAlreadyExists
+		return errors.Errorf("route %v already exists", route.Console())
 	} else if err != ErrNotFound {
 		return err
 	}

--- a/state/route.go
+++ b/state/route.go
@@ -1,10 +1,11 @@
 package state
 
 import (
+	"fmt"
+
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/kong/deck/state/indexers"
 	"github.com/kong/deck/utils"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -64,7 +65,7 @@ func (k *RoutesCollection) Add(route Route) error {
 	}
 	_, err := getRoute(txn, searchBy...)
 	if err == nil {
-		return errors.Errorf("route %v already exists", route.Console())
+		return fmt.Errorf("inserting route %v: %w", route.Console(), ErrAlreadyExists)
 	} else if err != ErrNotFound {
 		return err
 	}

--- a/state/service.go
+++ b/state/service.go
@@ -3,6 +3,7 @@ package state
 import (
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/kong/deck/utils"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -47,7 +48,7 @@ func (k *ServicesCollection) Add(service Service) error {
 	}
 	_, err := getService(txn, searchBy...)
 	if err == nil {
-		return ErrAlreadyExists
+		return errors.Errorf("service %v already exists", service.Console())
 	} else if err != ErrNotFound {
 		return err
 	}

--- a/state/service.go
+++ b/state/service.go
@@ -1,9 +1,10 @@
 package state
 
 import (
+	"fmt"
+
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/kong/deck/utils"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -48,7 +49,7 @@ func (k *ServicesCollection) Add(service Service) error {
 	}
 	_, err := getService(txn, searchBy...)
 	if err == nil {
-		return errors.Errorf("service %v already exists", service.Console())
+		return fmt.Errorf("inserting service %v: %w", service.Console(), ErrAlreadyExists)
 	} else if err != ErrNotFound {
 		return err
 	}

--- a/state/sni.go
+++ b/state/sni.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"fmt"
+
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/kong/deck/state/indexers"
 	"github.com/kong/deck/utils"
@@ -77,7 +79,7 @@ func (k *SNIsCollection) Add(sni SNI) error {
 	}
 	_, err := getSNI(txn, searchBy...)
 	if err == nil {
-		return errors.Errorf("sni %v already exists", sni.Console())
+		return fmt.Errorf("inserting sni %v: %w", sni.Console(), ErrAlreadyExists)
 	} else if err != ErrNotFound {
 		return err
 	}

--- a/state/sni.go
+++ b/state/sni.go
@@ -77,7 +77,7 @@ func (k *SNIsCollection) Add(sni SNI) error {
 	}
 	_, err := getSNI(txn, searchBy...)
 	if err == nil {
-		return ErrAlreadyExists
+		return errors.Errorf("sni %v already exists", sni.Console())
 	} else if err != ErrNotFound {
 		return err
 	}

--- a/state/target.go
+++ b/state/target.go
@@ -82,7 +82,7 @@ func (k *TargetsCollection) Add(target Target) error {
 	}
 	_, err := getTarget(txn, *target.Upstream.ID, searchBy...)
 	if err == nil {
-		return ErrAlreadyExists
+		return errors.Errorf("target %v already exists", target.Console())
 	} else if err != ErrNotFound {
 		return err
 	}

--- a/state/target.go
+++ b/state/target.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"fmt"
+
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/kong/deck/state/indexers"
 	"github.com/kong/deck/utils"
@@ -82,7 +84,7 @@ func (k *TargetsCollection) Add(target Target) error {
 	}
 	_, err := getTarget(txn, *target.Upstream.ID, searchBy...)
 	if err == nil {
-		return errors.Errorf("target %v already exists", target.Console())
+		return fmt.Errorf("inserting target %v: %w", target.Console(), ErrAlreadyExists)
 	} else if err != ErrNotFound {
 		return err
 	}

--- a/state/upstream.go
+++ b/state/upstream.go
@@ -3,6 +3,7 @@ package state
 import (
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/kong/deck/utils"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -46,7 +47,7 @@ func (k *UpstreamsCollection) Add(upstream Upstream) error {
 	}
 	_, err := getUpstream(txn, searchBy...)
 	if err == nil {
-		return ErrAlreadyExists
+		return errors.Errorf("upstream %v already exists", upstream.Console())
 	} else if err != ErrNotFound {
 		return err
 	}

--- a/state/upstream.go
+++ b/state/upstream.go
@@ -1,9 +1,10 @@
 package state
 
 import (
+	"fmt"
+
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/kong/deck/utils"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -47,7 +48,7 @@ func (k *UpstreamsCollection) Add(upstream Upstream) error {
 	}
 	_, err := getUpstream(txn, searchBy...)
 	if err == nil {
-		return errors.Errorf("upstream %v already exists", upstream.Console())
+		return fmt.Errorf("inserting upstream %v: %w", upstream.Console(), ErrAlreadyExists)
 	} else if err != ErrNotFound {
 		return err
 	}

--- a/state/utils.go
+++ b/state/utils.go
@@ -13,9 +13,6 @@ const (
 // returned when an entity is not found in the state.
 var ErrNotFound = errors.New("entity not found")
 
-// ErrAlreadyExists represents an entity is already present in the state.
-var ErrAlreadyExists = errors.New("entity already exists")
-
 // internal errors
 var errIDRequired = errors.New("ID is required")
 

--- a/state/utils.go
+++ b/state/utils.go
@@ -13,6 +13,9 @@ const (
 // returned when an entity is not found in the state.
 var ErrNotFound = errors.New("entity not found")
 
+// ErrAlreadyExists represents an entity is already present in the state.
+var ErrAlreadyExists = errors.New("entity already exists")
+
 // internal errors
 var errIDRequired = errors.New("ID is required")
 


### PR DESCRIPTION
Currently, when an entity is duplicated in the state file(s) the error message is not very helpful, e.g.:

```ShellSession
$ deck validate
Error: entity already exists
```

In a large and distributed configuration, it is often not easy to figure out which entity this is. Also, the error message itself does not say *where* the entity already exists - it could mean *exists in Kong*.

With this PR, the error message becomes a lot more helpful:

```ShellSession
$ ./deck validate
Error: error reading state file(s): consumer consumer1 already exists
```

This applies across `deck sync`, `deck diff`, and `deck validate`.