### PR TITLE
feat: Read multi-document YAML

### DIFF
--- a/file/reader.go
+++ b/file/reader.go
@@ -84,6 +84,21 @@ func yamlToJSON(m map[interface{}]interface{}) map[string]interface{} {
 		switch v2 := v.(type) {
 		case map[interface{}]interface{}:
 			res[fmt.Sprint(k)] = yamlToJSON(v2)
+		case []interface{}:
+			var array []interface{}
+			for _, element := range v2 {
+				switch el := element.(type) {
+				case map[interface{}]interface{}:
+					array = append(array, yamlToJSON(el))
+				default:
+					array = append(array, el)
+				}
+			}
+			if array != nil {
+				res[fmt.Sprint(k)] = array
+			} else {
+				res[fmt.Sprint(k)] = v
+			}
 		default:
 			res[fmt.Sprint(k)] = v
 		}

--- a/file/reader_test.go
+++ b/file/reader_test.go
@@ -99,12 +99,13 @@ func TestReadKongStateFromStdin(t *testing.T) {
 	os.Stdin = tmpfile
 
 	c, err := GetContentFromFiles(filenames)
-	assert.NotNil(c)
 	assert.Nil(err)
 
-	assert.Equal(kong.Service{
-		Name: kong.String("test service"),
-		Host: kong.String("test.com"),
-	},
-		c.Services[0].Service)
+	if assert.NotNil(c) && assert.NotEmpty(c.Services) {
+		assert.Equal(kong.Service{
+			Name: kong.String("test service"),
+			Host: kong.String("test.com"),
+		},
+			c.Services[0].Service)
+	}
 }

--- a/file/readfile.go
+++ b/file/readfile.go
@@ -2,7 +2,9 @@ package file
 
 import (
 	"bufio"
+	"bytes"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -26,7 +28,16 @@ func getContent(filenames []string) (*Content, error) {
 	}
 	var res Content
 	for _, r := range allReaders {
-		contents, err := readContents(r)
+		rawContents, err := ioutil.ReadAll(r)
+		if err != nil {
+			return nil, err
+		}
+		err = validate(rawContents)
+		if err != nil {
+			return nil, errors.Wrap(err, "validating file content")
+		}
+
+		contents, err := readContents(bytes.NewReader(rawContents))
 		if err != nil {
 			return nil, errors.Wrap(err, "reading file")
 		}

--- a/file/readfile_test.go
+++ b/file/readfile_test.go
@@ -310,7 +310,7 @@ func Test_getContent(t *testing.T) {
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getContent() = %v, want %v", got, tt.want)
+				t.Errorf("getContent() = %v\nwant = %v", got, tt.want)
 			}
 		})
 	}

--- a/file/readfile_test.go
+++ b/file/readfile_test.go
@@ -154,7 +154,13 @@ func Test_getContent(t *testing.T) {
 		},
 		{
 			name:    "bad yaml",
-			args:    args{[]string{"testdata/badyaml"}},
+			args:    args{[]string{"testdata/badyaml/bar.yml"}},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "bad multi yaml",
+			args:    args{[]string{"testdata/badyaml/multi.yml"}},
 			want:    nil,
 			wantErr: true,
 		},

--- a/file/testdata/badyaml/multi.yml
+++ b/file/testdata/badyaml/multi.yml
@@ -1,0 +1,10 @@
+services:
+- name: svc2
+  host: 2.example.com
+  routes:
+  - name: r2
+    paths:
+    - /r2
+---
+services:
+- host: 3.example.com

--- a/file/testdata/valid/bar.yml
+++ b/file/testdata/valid/bar.yml
@@ -5,5 +5,6 @@ services:
   - name: r2
     paths:
     - /r2
+---
 plugins:
 - name: prometheus

--- a/file/types.go
+++ b/file/types.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kong/deck/utils"
 	"github.com/kong/go-kong/kong"
 	"github.com/pkg/errors"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // Format is a file format for Kong's configuration.
@@ -501,4 +502,9 @@ type Content struct {
 	CACertificates []FCACertificate `json:"ca_certificates,omitempty" yaml:"ca_certificates,omitempty"`
 
 	PluginConfigs map[string]kong.Configuration `json:"_plugin_configs,omitempty" yaml:"_plugin_configs,omitempty"`
+}
+
+func (c Content) String() string {
+	s, _ := yaml.Marshal(c)
+	return string(s)
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ require (
 	github.com/blang/semver v0.0.0-20190414102917-ba2c2ddd8906
 	github.com/fatih/color v1.9.0
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
-	github.com/ghodss/yaml v1.0.0
 	github.com/hashicorp/go-immutable-radix v1.2.0 // indirect
 	github.com/hashicorp/go-memdb v1.1.2
 	github.com/hashicorp/golang-lru v0.5.4 // indirect


### PR DESCRIPTION
This change allows decK to read multi-document YAML files correctly, i.e. all contents/documents. Currently, only the first document is read.

While decK will not write out multi-document YAML itself, this makes it easier to work with third-party YAML e.g. generated by tools such as `ytt`. My concrete use case was generating a very large Kong configuration using `ytt` and I could find no straightforward way around it generating a multi-document YAML.

Some notes on the implementation:
1. While the go-yaml README [says](https://github.com/go-yaml/yaml/blob/v2/README.md) it does not support multi-document unmarshaling it actually does. There is an open [issue](https://github.com/go-yaml/yaml/issues/361) and [PR](https://github.com/go-yaml/yaml/pull/425) to clarify this.
2. Rather than add a new testfile I modified an existing testfile to be multi-document. We could add a new testfile as well, but this was simpler.
3. The `Content.String()` function and modification to `readfile_test.go` is just to make the test failure output much easier to consume - formatted YAML instead of a bunch of (mostly `<nil>`) pointers.