### PR TITLE
feat(reset): do not Get() workspace when resetting

### DIFF
--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -69,16 +69,6 @@ By default, this command will ask for a confirmation prompt.`,
 			}
 		}
 		if resetWorkspace != "" {
-			config.Workspace = resetWorkspace
-
-			exists, err := workspaceExists(config)
-			if err != nil {
-				return err
-			}
-			if !exists {
-				return errors.Errorf("workspace '%v' does not exist in Kong", resetWorkspace)
-			}
-
 			workspaces = append(workspaces, resetWorkspace)
 		}
 


### PR DESCRIPTION
🚧 DRAFT because this needs to include Kong/go-kong#8 as a Go module. Otherwise ready for review 🚧

Part of #218 (handles `reset`).

Before this commit, `deck reset --workspace=X` performs a GET
on :8001/workspaces/<name> in order to tell whether the workspace
exists.

This prevents a user with full privileges _within_ the workspace
from resetting it, because a typical "workspace admin" role
(that is, having endpoint=* actions=* within the workspace) does
not permit GETting /workspaces/<name>.

After this commit, `deck reset` no longer tries to `GET` a workspace
before resetting it. Author's intention is that this change does not
modify workspace resetting semantics.

- When the calling user has endpoints=* actions=* on the workspace: no
change in behavior

- When the calling user has partial permissions to endpoints in the
workspace: workspace reset will fail with a partially reset state.
Removing the Get check does not change this behavior.

- When the calling user has no write permissions to any endpoints in the
workspace: no resetting takes place and the workspace is left intact. No
change in behavior here either.

There is one visible change, though:
- When the calling user has broad permissions but the workspace does not
exist: entity listing operations fail with 404 and a message that workspace
was not found)

Per #218.