### PR TITLE
docs(release) update release instructions

### DIFF
--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -3,28 +3,32 @@
 
 ## Prepare
 
+- Ensure your local Go version is up to date. It should match the Go version
+  in `Dockerfile`.
 - Create a `docs/changelog-v0.5.0` branch. Substitute v0.5.0 with the version
   you are releasing.
-- Write the changelog, ensure the links are all created correctly and
+- Write the changelog. Ensure the links are all created correctly and
   make sure to write the doc with end-user in mind.
 - Commit and push the branch to Github. Ensure that the Markdown is rendered
   correctly. Make changes as needed. The link on the version itself won't
   resolve correctly as the tag is not yet created.
-- Once the changelog looks good, push the commit to main branch.
 - Ensure you have Goreleaser and Docker installed locally.
+- Once the changelog looks good, open a PR to `main` and wait for review.
 
 ## Release
 
-- Tag the `HEAD` with your version. In our example, we will tag it `v0.5.0`.
-- Push the tag to remote (Github).
+- After the changelog is merged, `git checkout main; git pull`.
+- Tag the `HEAD` with your version, e.g. `git tag v0.5.0`
+- Push the tag to remote (Github), e.g. `git push --tags`
 - Run Goreleaser: `goreleaser release --rm-dist`. This will create
   a release in Github and upload all the artifacts.
 - Edit the release to remove all the commit messages as the content and
   instead add a link to the changelog. Refer to older releases for reference.
-- Homebrew release  
-  Copy the deck.rb file to `homebrew-deck` directory.
-  Make sure only version and checksum is changed and rest all is left as is.
-  Commit and push for the Homebrew release.
+- Clone https://github.com/Kong/homebrew-deck. Copy deck.rb from your deck repo
+  folder to homebrew-deck, e.g. `cp /path/to/deck/dist/deck.rb
+  /path/to/homebrew-deck/Formula/deck.rb`. `git diff` in homebrew-deck to
+  confirm that only the version and checksum have changed. Commit changes with
+  a "release v0.5.0" message and push master to origin.
 
 ## Docker release
 


### PR DESCRIPTION
Update release instructions with changes we found during the 1.2.2 release and additional examples.

As far as I know, nothing changed in the Docker release process, and the existing text already matches what we had in the temporary Google doc. @mflendrich as you took over following my computer issues, please let me know if that's not the case and I missed something that we need to update.