### PR TITLE
fix(builder) reject creds without required fields

### DIFF
--- a/file/builder.go
+++ b/file/builder.go
@@ -268,6 +268,9 @@ func (b *stateBuilder) ingestKeyAuths(creds []kong.KeyAuth) error {
 	for _, cred := range creds {
 		cred := cred
 		if utils.Empty(cred.ID) {
+			if utils.Empty(cred.Key) {
+				return errors.Errorf("key-auth credential is invalid: no key")
+			}
 			existingCred, err := b.currentState.KeyAuths.Get(*cred.Key)
 			if err == state.ErrNotFound {
 				cred.ID = uuid()
@@ -289,6 +292,9 @@ func (b *stateBuilder) ingestBasicAuths(creds []kong.BasicAuth) error {
 	for _, cred := range creds {
 		cred := cred
 		if utils.Empty(cred.ID) {
+			if utils.Empty(cred.Username) {
+				return errors.Errorf("basic-auth credential is invalid: no username")
+			}
 			existingCred, err := b.currentState.BasicAuths.Get(*cred.Username)
 			if err == state.ErrNotFound {
 				cred.ID = uuid()
@@ -310,6 +316,9 @@ func (b *stateBuilder) ingestHMACAuths(creds []kong.HMACAuth) error {
 	for _, cred := range creds {
 		cred := cred
 		if utils.Empty(cred.ID) {
+			if utils.Empty(cred.Username) {
+				return errors.Errorf("hmac-auth credential is invalid: no username")
+			}
 			existingCred, err := b.currentState.HMACAuths.Get(*cred.Username)
 			if err == state.ErrNotFound {
 				cred.ID = uuid()
@@ -331,6 +340,9 @@ func (b *stateBuilder) ingestJWTAuths(creds []kong.JWTAuth) error {
 	for _, cred := range creds {
 		cred := cred
 		if utils.Empty(cred.ID) {
+			if utils.Empty(cred.Key) {
+				return errors.Errorf("jwt-auth credential is invalid: no key")
+			}
 			existingCred, err := b.currentState.JWTAuths.Get(*cred.Key)
 			if err == state.ErrNotFound {
 				cred.ID = uuid()
@@ -352,6 +364,9 @@ func (b *stateBuilder) ingestOauth2Creds(creds []kong.Oauth2Credential) error {
 	for _, cred := range creds {
 		cred := cred
 		if utils.Empty(cred.ID) {
+			if utils.Empty(cred.ClientID) {
+				return errors.Errorf("oauth2 credential is invalid: no client_id")
+			}
 			existingCred, err := b.currentState.Oauth2Creds.Get(*cred.ClientID)
 			if err == state.ErrNotFound {
 				cred.ID = uuid()
@@ -373,6 +388,9 @@ func (b *stateBuilder) ingestACLGroups(creds []kong.ACLGroup) error {
 	for _, cred := range creds {
 		cred := cred
 		if utils.Empty(cred.ID) {
+			if utils.Empty(cred.Group) {
+				return errors.Errorf("acl credential is invalid: no group")
+			}
 			existingCred, err := b.currentState.ACLGroups.Get(
 				*cred.Consumer.ID,
 				*cred.Group)


### PR DESCRIPTION
If attempting to search for a credential with no ID, reject the credential entirely if its search field is not present.

This addresses the fatal panic in https://github.com/Kong/kubernetes-ingress-controller/issues/532. These resources remain invalid, but now throw the controller into configuration sync failure loop instead of panicking, e.g.

```
time="2020-10-19T19:26:34Z" level=info msg="syncing configuration" component=controller
time="2020-10-19T19:26:34Z" level=error msg="failed to update kong configuration: building state: key-auth credential is invalid: no key" component=controller
time="2020-10-19T19:26:34Z" level=error msg="failed to sync: building state: key-auth credential is invalid: no key" component=sync-queue
```

Ideally, this should print either the Secret or KongConsumer name to help users find the problem resource, but we cannot handle that at the deck level, where we only know the contents of the proposed credential, and cannot really print anything meaningful about it (you only trigger this error if you provide neither the ID nor search field, which are de facto the only identifiers deck has).

The sync failure loop isn't ideal either, but I'm not sure there's any way we can avoid it, as the admission controller does not reject configuration that does reject invalid credentials on creation: the controller only attempts to load them after when processing the KongConsumer, and the linked invalid credential does not make the consumer itself invalid. Adding consumer or credential context to the log is the next best option.

No tests here as this is essentially a KIC-only issue: after accepting this we should add a new KIC card to add log context and tests to confirm the error appears as expected. I've tested this manually using a temporary KIC build that incorporates the deck module at cbc05ec.