### PR TITLE
feat: reimplement workspaceExists() without the /workspaces endpoint

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -37,6 +37,11 @@ func SetStopCh(stopCh chan struct{}) {
 
 // workspaceExists checks if workspace exists in Kong.
 func workspaceExists(config utils.KongClientConfig) (bool, error) {
+	if config.Workspace == "" {
+		// default workspace always exists
+		return true, nil
+	}
+
 	if config.SkipWorkspaceCrud {
 		// if RBAC user, skip check
 		return true, nil

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -19,8 +19,8 @@ can connect to Kong's Admin API or not.`,
 	Args: validateNoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
-		config.Workspace = pingWorkspace
-		version, err := kongVersion(config)
+		rootConfig.Workspace = pingWorkspace
+		version, err := kongVersion(rootConfig)
 		if err != nil {
 			return errors.Wrap(err, "reading Kong version")
 		}

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -19,8 +20,8 @@ can connect to Kong's Admin API or not.`,
 	Args: validateNoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
-		rootConfig.Workspace = pingWorkspace
-		version, err := kongVersion(rootConfig)
+		wsConfig := rootConfig.ForWorkspace(pingWorkspace)
+		version, err := kongVersion(wsConfig)
 		if err != nil {
 			return errors.Wrap(err, "reading Kong version")
 		}

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -39,17 +39,17 @@ By default, this command will ask for a confirmation prompt.`,
 			}
 		}
 
-		client, err := utils.GetKongClient(config)
+		rootClient, err := utils.GetKongClient(rootConfig)
 		if err != nil {
 			return err
 		}
 		// Kong OSS or default workspace
 		if !resetAllWorkspaces && resetWorkspace == "" {
-			state, err := dump.Get(client, dumpConfig)
+			state, err := dump.Get(rootClient, dumpConfig)
 			if err != nil {
 				return err
 			}
-			err = reset.Reset(state, client)
+			err = reset.Reset(state, rootClient)
 			if err != nil {
 				return err
 			}
@@ -63,15 +63,13 @@ By default, this command will ask for a confirmation prompt.`,
 		// Kong Enterprise
 		var workspaces []string
 		if resetAllWorkspaces {
-			workspaces, err = listWorkspaces(client, config.Address)
+			workspaces, err = listWorkspaces(rootClient, rootConfig.Address)
 			if err != nil {
 				return err
 			}
 		}
 		if resetWorkspace != "" {
-			config.Workspace = resetWorkspace
-
-			exists, err := workspaceExists(config)
+			exists, err := workspaceExists(rootConfig.ForWorkspace(resetWorkspace))
 			if err != nil {
 				return err
 			}
@@ -83,16 +81,15 @@ By default, this command will ask for a confirmation prompt.`,
 		}
 
 		for _, workspace := range workspaces {
-			config.Workspace = workspace
-			client, err := utils.GetKongClient(config)
+			wsClient, err := utils.GetKongClient(rootConfig.ForWorkspace(workspace))
 			if err != nil {
 				return err
 			}
-			state, err := dump.Get(client, dumpConfig)
+			state, err := dump.Get(wsClient, dumpConfig)
 			if err != nil {
 				return err
 			}
-			err = reset.Reset(state, client)
+			err = reset.Reset(state, wsClient)
 			if err != nil {
 				return err
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,10 +16,10 @@ import (
 )
 
 var (
-	cfgFile string
-	config  utils.KongClientConfig
-	verbose int
-	noColor bool
+	cfgFile    string
+	rootConfig utils.KongClientConfig
+	verbose    int
+	noColor    bool
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -32,7 +32,7 @@ configuration file.
 It can be used to export, import or sync entities to Kong.`,
 	SilenceUsage: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		if _, err := url.ParseRequestURI(config.Address); err != nil {
+		if _, err := url.ParseRequestURI(rootConfig.Address); err != nil {
 			return errors.WithStack(errors.Wrap(err, "invalid URL"))
 		}
 		if noColor {
@@ -154,14 +154,15 @@ func initConfig() {
 			fmt.Println(err)
 		}
 	}
-	config.Address = viper.GetString("kong-addr")
-	config.TLSServerName = viper.GetString("tls-server-name")
-	config.TLSSkipVerify = viper.GetBool("tls-skip-verify")
-	config.TLSCACert = viper.GetString("ca-cert")
-	config.Headers = viper.GetStringSlice("headers")
+
+	rootConfig.Address = viper.GetString("kong-addr")
+	rootConfig.TLSServerName = viper.GetString("tls-server-name")
+	rootConfig.TLSSkipVerify = viper.GetBool("tls-skip-verify")
+	rootConfig.TLSCACert = viper.GetString("ca-cert")
+	rootConfig.Headers = viper.GetStringSlice("headers")
+	rootConfig.SkipWorkspaceCrud = viper.GetBool("skip-workspace-crud")
+	rootConfig.Debug = verbose >= 1
+
 	verbose = viper.GetInt("verbose")
 	noColor = viper.GetBool("no-color")
-	config.SkipWorkspaceCrud = viper.GetBool("skip-workspace-crud")
-
-	config.Debug = verbose >= 1
 }

--- a/utils/types.go
+++ b/utils/types.go
@@ -79,6 +79,13 @@ type KongClientConfig struct {
 	Headers []string
 }
 
+// ForWorkspace returns a copy of KongClientConfig that produces a KongClient for the workspace specified by argument.
+func (kc *KongClientConfig) ForWorkspace(name string) KongClientConfig {
+	result := *kc
+	result.Workspace = name
+	return result
+}
+
 // HeaderRoundTripper injects Headers into requests
 // made via RT.
 type HeaderRoundTripper struct {


### PR DESCRIPTION
fixes #218 
replaces #219 

This PR:
- cleans up deck's usage of non-workspaced ("root") and workspaced clients and configs,
- makes workspaceExists() GET `/<workspaceName>/routes/` instead of `/workspaces/<workspaceName>` because users of deck are much more likely to have permissions to access the latter endpoint, rather than the former (e.g. in a case where the calling user is a workspace admin and has permissions only within the namespace)

The change seems justified because it appears impractical to use deck on a workspace without read permissions to the `/<workspaceName>/routes/` endpoint.