### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ decK provides declarative configuration and drift detection for Kong.
 
 ## Compatibility
 
-decK is compatible with Kong 1.x and Kong Enterprise >= 0.35.
+decK is compatible with Kong Gateway >= 1.x and Kong Enterprise >= 0.35.
 
 ## Installation
 


### PR DESCRIPTION
Add `>=` to be clear that decK is compatible with Kong 2.2.x, not just Kong 1.

Change is consistent with https://docs.konghq.com/deck/overview/. 