### PR TITLE
Document changes for v1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [v1.2.3](#v122---20201118)
 - [v1.2.2](#v122---20201019)
 - [v1.2.1](#v121---20200804)
 - [v1.2.0](#v120---20200804)
@@ -21,6 +22,15 @@
 - [v0.3.0](#v030---20190514)
 - [v0.2.0](#v020---20190401)
 - [v0.1.0](#v010---20190112)
+
+## [v1.2.3] - 2020/11/18
+
+### Fixed
+
+- Sync operations now handle plugins with array configuration correctly.
+  [#229](https://github.com/hbagdi/deck/pull/229)
+- Removed unecessary permissions requirement for checking workspace existence.
+  [#225](https://github.com/hbagdi/deck/pull/225)
 
 ## [v1.2.2] - 2020/10/19
 
@@ -510,6 +520,7 @@ No breaking changes have been introduced in this release.
 
 Debut release of decK
 
+[v1.2.3]: https://github.com/kong/deck/compare/v1.2.2...v1.2.3
 [v1.2.2]: https://github.com/kong/deck/compare/v1.2.1...v1.2.2
 [v1.2.1]: https://github.com/hbagdi/deck/compare/v1.2.0...v1.2.1
 [v1.2.0]: https://github.com/hbagdi/deck/compare/v1.1.0...v1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,9 @@
 ### Fixed
 
 - Sync operations now handle plugins with array configuration correctly.
-  [#229](https://github.com/hbagdi/deck/pull/229)
+  [#229](https://github.com/Kong/deck/pull/229)
 - Removed unecessary permissions requirement for checking workspace existence.
-  [#225](https://github.com/hbagdi/deck/pull/225)
+  [#225](https://github.com/Kong/deck/pull/225)
 
 ## [v1.2.2] - 2020/10/19
 


### PR DESCRIPTION
Changelog updates to tentatively release this on Wednesday. Commits to a date in advance, but I'd expect that there isn't much that'd need to change, and the remainder of https://github.com/Kong/deck/blob/main/docs/development/release.md can be done independently after the changelog updates are merged.