### PR TITLE
fix(types) ignore tag order for object comparisons

### DIFF
--- a/state/types.go
+++ b/state/types.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"reflect"
+	"sort"
 
 	"github.com/kong/go-kong/kong"
 )
@@ -95,6 +96,11 @@ func (s1 *Service) EqualWithOpts(s2 *Service,
 	s1Copy := s1.Service.DeepCopy()
 	s2Copy := s2.Service.DeepCopy()
 
+	// Cassandra can sometimes mess up tag order, but tag order doesn't actually matter: tags are sets
+	// even though we represent them with slices. Sort before comparison to avoid spurious diff detection.
+	sort.Slice(s1Copy.Tags, func(i, j int) bool { return *(s1Copy.Tags[i]) < *(s1Copy.Tags[j]) })
+	sort.Slice(s2Copy.Tags, func(i, j int) bool { return *(s2Copy.Tags[i]) < *(s2Copy.Tags[j]) })
+
 	if ignoreID {
 		s1Copy.ID = nil
 		s2Copy.ID = nil
@@ -143,6 +149,9 @@ func (r1 *Route) EqualWithOpts(r2 *Route, ignoreID,
 	ignoreTS, ignoreForeign bool) bool {
 	r1Copy := r1.Route.DeepCopy()
 	r2Copy := r2.Route.DeepCopy()
+
+	sort.Slice(r1Copy.Tags, func(i, j int) bool { return *(r1Copy.Tags[i]) < *(r1Copy.Tags[j]) })
+	sort.Slice(r2Copy.Tags, func(i, j int) bool { return *(r2Copy.Tags[i]) < *(r2Copy.Tags[j]) })
 
 	if ignoreID {
 		r1Copy.ID = nil
@@ -195,6 +204,9 @@ func (u1 *Upstream) EqualWithOpts(u2 *Upstream,
 	ignoreID bool, ignoreTS bool) bool {
 	u1Copy := u1.Upstream.DeepCopy()
 	u2Copy := u2.Upstream.DeepCopy()
+
+	sort.Slice(u1Copy.Tags, func(i, j int) bool { return *(u1Copy.Tags[i]) < *(u1Copy.Tags[j]) })
+	sort.Slice(u2Copy.Tags, func(i, j int) bool { return *(u2Copy.Tags[i]) < *(u2Copy.Tags[j]) })
 
 	if ignoreID {
 		u1Copy.ID = nil
@@ -251,6 +263,9 @@ func (t1 *Target) EqualWithOpts(t2 *Target, ignoreID,
 	t1Copy := t1.Target.DeepCopy()
 	t2Copy := t2.Target.DeepCopy()
 
+	sort.Slice(t1Copy.Tags, func(i, j int) bool { return *(t1Copy.Tags[i]) < *(t1Copy.Tags[j]) })
+	sort.Slice(t2Copy.Tags, func(i, j int) bool { return *(t2Copy.Tags[i]) < *(t2Copy.Tags[j]) })
+
 	if ignoreID {
 		t1Copy.ID = nil
 		t2Copy.ID = nil
@@ -301,6 +316,9 @@ func (c1 *Certificate) EqualWithOpts(c2 *Certificate,
 	c1Copy := c1.Certificate.DeepCopy()
 	c2Copy := c2.Certificate.DeepCopy()
 
+	sort.Slice(c1Copy.Tags, func(i, j int) bool { return *(c1Copy.Tags[i]) < *(c1Copy.Tags[j]) })
+	sort.Slice(c2Copy.Tags, func(i, j int) bool { return *(c2Copy.Tags[i]) < *(c2Copy.Tags[j]) })
+
 	if ignoreID {
 		c1Copy.ID = nil
 		c2Copy.ID = nil
@@ -346,6 +364,9 @@ func (s1 *SNI) EqualWithOpts(s2 *SNI, ignoreID,
 	ignoreTS, ignoreForeign bool) bool {
 	s1Copy := s1.SNI.DeepCopy()
 	s2Copy := s2.SNI.DeepCopy()
+
+	sort.Slice(s1Copy.Tags, func(i, j int) bool { return *(s1Copy.Tags[i]) < *(s1Copy.Tags[j]) })
+	sort.Slice(s2Copy.Tags, func(i, j int) bool { return *(s2Copy.Tags[i]) < *(s2Copy.Tags[j]) })
 
 	if ignoreID {
 		s1Copy.ID = nil
@@ -421,6 +442,9 @@ func (p1 *Plugin) EqualWithOpts(p2 *Plugin, ignoreID,
 	p1Copy := p1.Plugin.DeepCopy()
 	p2Copy := p2.Plugin.DeepCopy()
 
+	sort.Slice(p1Copy.Tags, func(i, j int) bool { return *(p1Copy.Tags[i]) < *(p1Copy.Tags[j]) })
+	sort.Slice(p2Copy.Tags, func(i, j int) bool { return *(p2Copy.Tags[i]) < *(p2Copy.Tags[j]) })
+
 	if ignoreID {
 		p1Copy.ID = nil
 		p2Copy.ID = nil
@@ -471,18 +495,21 @@ func (c1 *Consumer) Equal(c2 *Consumer) bool {
 // If ignoreTS is set to true, timestamp fields will be ignored.
 func (c1 *Consumer) EqualWithOpts(c2 *Consumer,
 	ignoreID bool, ignoreTS bool) bool {
-	c1Copt := c1.Consumer.DeepCopy()
+	c1Copy := c1.Consumer.DeepCopy()
 	c2Copy := c2.Consumer.DeepCopy()
 
+	sort.Slice(c1Copy.Tags, func(i, j int) bool { return *(c1Copy.Tags[i]) < *(c1Copy.Tags[j]) })
+	sort.Slice(c2Copy.Tags, func(i, j int) bool { return *(c2Copy.Tags[i]) < *(c2Copy.Tags[j]) })
+
 	if ignoreID {
-		c1Copt.ID = nil
+		c1Copy.ID = nil
 		c2Copy.ID = nil
 	}
 	if ignoreTS {
-		c1Copt.CreatedAt = nil
+		c1Copy.CreatedAt = nil
 		c2Copy.CreatedAt = nil
 	}
-	return reflect.DeepEqual(c1Copt, c2Copy)
+	return reflect.DeepEqual(c1Copy, c2Copy)
 }
 
 func forConsumerString(c *kong.Consumer) string {
@@ -532,6 +559,9 @@ func (k1 *KeyAuth) EqualWithOpts(k2 *KeyAuth, ignoreID,
 	ignoreTS, ignoreForeign bool) bool {
 	k1Copy := k1.KeyAuth.DeepCopy()
 	k2Copy := k2.KeyAuth.DeepCopy()
+
+	sort.Slice(k1Copy.Tags, func(i, j int) bool { return *(k1Copy.Tags[i]) < *(k1Copy.Tags[j]) })
+	sort.Slice(k2Copy.Tags, func(i, j int) bool { return *(k2Copy.Tags[i]) < *(k2Copy.Tags[j]) })
 
 	if ignoreID {
 		k1Copy.ID = nil
@@ -601,6 +631,9 @@ func (h1 *HMACAuth) EqualWithOpts(h2 *HMACAuth, ignoreID,
 	h1Copy := h1.HMACAuth.DeepCopy()
 	h2Copy := h2.HMACAuth.DeepCopy()
 
+	sort.Slice(h1Copy.Tags, func(i, j int) bool { return *(h1Copy.Tags[i]) < *(h1Copy.Tags[j]) })
+	sort.Slice(h2Copy.Tags, func(i, j int) bool { return *(h2Copy.Tags[i]) < *(h2Copy.Tags[j]) })
+
 	if ignoreID {
 		h1Copy.ID = nil
 		h2Copy.ID = nil
@@ -669,6 +702,9 @@ func (j1 *JWTAuth) EqualWithOpts(j2 *JWTAuth, ignoreID,
 	j1Copy := j1.JWTAuth.DeepCopy()
 	j2Copy := j2.JWTAuth.DeepCopy()
 
+	sort.Slice(j1Copy.Tags, func(i, j int) bool { return *(j1Copy.Tags[i]) < *(j1Copy.Tags[j]) })
+	sort.Slice(j2Copy.Tags, func(i, j int) bool { return *(j2Copy.Tags[i]) < *(j2Copy.Tags[j]) })
+
 	if ignoreID {
 		j1Copy.ID = nil
 		j2Copy.ID = nil
@@ -736,6 +772,9 @@ func (b1 *BasicAuth) EqualWithOpts(b2 *BasicAuth, ignoreID,
 	ignoreTS, ignorePassword, ignoreForeign bool) bool {
 	b1Copy := b1.BasicAuth.DeepCopy()
 	b2Copy := b2.BasicAuth.DeepCopy()
+
+	sort.Slice(b1Copy.Tags, func(i, j int) bool { return *(b1Copy.Tags[i]) < *(b1Copy.Tags[j]) })
+	sort.Slice(b2Copy.Tags, func(i, j int) bool { return *(b2Copy.Tags[i]) < *(b2Copy.Tags[j]) })
 
 	if ignoreID {
 		b1Copy.ID = nil
@@ -809,6 +848,9 @@ func (b1 *ACLGroup) EqualWithOpts(b2 *ACLGroup, ignoreID,
 	b1Copy := b1.ACLGroup.DeepCopy()
 	b2Copy := b2.ACLGroup.DeepCopy()
 
+	sort.Slice(b1Copy.Tags, func(i, j int) bool { return *(b1Copy.Tags[i]) < *(b1Copy.Tags[j]) })
+	sort.Slice(b2Copy.Tags, func(i, j int) bool { return *(b2Copy.Tags[i]) < *(b2Copy.Tags[j]) })
+
 	if ignoreID {
 		b1Copy.ID = nil
 		b2Copy.ID = nil
@@ -859,6 +901,9 @@ func (c1 *CACertificate) EqualWithOpts(c2 *CACertificate,
 	c1Copy := c1.CACertificate.DeepCopy()
 	c2Copy := c2.CACertificate.DeepCopy()
 
+	sort.Slice(c1Copy.Tags, func(i, j int) bool { return *(c1Copy.Tags[i]) < *(c1Copy.Tags[j]) })
+	sort.Slice(c2Copy.Tags, func(i, j int) bool { return *(c2Copy.Tags[i]) < *(c2Copy.Tags[j]) })
+
 	if ignoreID {
 		c1Copy.ID = nil
 		c2Copy.ID = nil
@@ -895,6 +940,9 @@ func (k1 *Oauth2Credential) EqualWithOpts(k2 *Oauth2Credential, ignoreID,
 	ignoreTS, ignoreForeign bool) bool {
 	k1Copy := k1.Oauth2Credential.DeepCopy()
 	k2Copy := k2.Oauth2Credential.DeepCopy()
+
+	sort.Slice(k1Copy.Tags, func(i, j int) bool { return *(k1Copy.Tags[i]) < *(k1Copy.Tags[j]) })
+	sort.Slice(k2Copy.Tags, func(i, j int) bool { return *(k2Copy.Tags[i]) < *(k2Copy.Tags[j]) })
 
 	if ignoreID {
 		k1Copy.ID = nil
@@ -963,6 +1011,9 @@ func (b1 *MTLSAuth) EqualWithOpts(b2 *MTLSAuth, ignoreID,
 	ignoreTS, ignoreForeign bool) bool {
 	b1Copy := b1.MTLSAuth.DeepCopy()
 	b2Copy := b2.MTLSAuth.DeepCopy()
+
+	sort.Slice(b1Copy.Tags, func(i, j int) bool { return *(b1Copy.Tags[i]) < *(b1Copy.Tags[j]) })
+	sort.Slice(b2Copy.Tags, func(i, j int) bool { return *(b2Copy.Tags[i]) < *(b2Copy.Tags[j]) })
 
 	if ignoreID {
 		b1Copy.ID = nil

--- a/state/types.go
+++ b/state/types.go
@@ -85,7 +85,7 @@ func (s1 *Service) Console() string {
 
 // Equal returns true if s1 and s2 are equal.
 func (s1 *Service) Equal(s2 *Service) bool {
-	return reflect.DeepEqual(s1.Service, s2.Service)
+	return s1.EqualWithOpts(s2, false, false)
 }
 
 // EqualWithOpts returns true if s1 and s2 are equal.
@@ -139,7 +139,7 @@ func (r1 *Route) Console() string {
 // Equal returns true if r1 and r2 are equal.
 // TODO add compare array without position
 func (r1 *Route) Equal(r2 *Route) bool {
-	return reflect.DeepEqual(r1.Route, r2.Route)
+	return r1.EqualWithOpts(r2, false, false, false)
 }
 
 // EqualWithOpts returns true if r1 and r2 are equal.
@@ -194,7 +194,7 @@ func (u1 *Upstream) Console() string {
 
 // Equal returns true if u1 and u2 are equal.
 func (u1 *Upstream) Equal(u2 *Upstream) bool {
-	return reflect.DeepEqual(u1.Upstream, u2.Upstream)
+	return u1.EqualWithOpts(u2, false, false)
 }
 
 // EqualWithOpts returns true if u1 and u2 are equal.
@@ -252,7 +252,7 @@ func (t1 *Target) Console() string {
 // Equal returns true if t1 and t2 are equal.
 // TODO add compare array without position
 func (t1 *Target) Equal(t2 *Target) bool {
-	return reflect.DeepEqual(t1.Target, t2.Target)
+	return t1.EqualWithOpts(t2, false, false, false)
 }
 
 // EqualWithOpts returns true if t1 and t2 are equal.
@@ -305,7 +305,7 @@ func (c1 *Certificate) Console() string {
 
 // Equal returns true if c1 and c2 are equal.
 func (c1 *Certificate) Equal(c2 *Certificate) bool {
-	return reflect.DeepEqual(c1.Certificate, c2.Certificate)
+	return c1.EqualWithOpts(c2, false, false)
 }
 
 // EqualWithOpts returns true if c1 and c2 are equal.
@@ -340,7 +340,7 @@ type SNI struct {
 // Equal returns true if s1 and s2 are equal.
 // TODO add compare array without position
 func (s1 *SNI) Equal(s2 *SNI) bool {
-	return reflect.DeepEqual(s1.SNI, s2.SNI)
+	return s1.EqualWithOpts(s2, false, false, false)
 }
 
 // Identifier returns the endpoint key name or ID.
@@ -431,7 +431,7 @@ func (p1 *Plugin) Console() string {
 // Equal returns true if r1 and r2 are equal.
 // TODO add compare array without position
 func (p1 *Plugin) Equal(p2 *Plugin) bool {
-	return reflect.DeepEqual(p1.Plugin, p2.Plugin)
+	return p1.EqualWithOpts(p2, false, false, false)
 }
 
 // EqualWithOpts returns true if p1 and p2 are equal.
@@ -487,7 +487,7 @@ func (c1 *Consumer) Console() string {
 
 // Equal returns true if c1 and c2 are equal.
 func (c1 *Consumer) Equal(c2 *Consumer) bool {
-	return reflect.DeepEqual(c1.Consumer, c2.Consumer)
+	return c1.EqualWithOpts(c2, false, false)
 }
 
 // EqualWithOpts returns true if c1 and c2 are equal.
@@ -549,7 +549,7 @@ func (k1 *KeyAuth) Console() string {
 
 // Equal returns true if k1 and k2 are equal.
 func (k1 *KeyAuth) Equal(k2 *KeyAuth) bool {
-	return reflect.DeepEqual(k1.KeyAuth, k2.KeyAuth)
+	return k1.EqualWithOpts(k2, false, false, false)
 }
 
 // EqualWithOpts returns true if k1 and k2 are equal.
@@ -620,7 +620,7 @@ func (h1 *HMACAuth) Console() string {
 
 // Equal returns true if h1 and h2 are equal.
 func (h1 *HMACAuth) Equal(h2 *HMACAuth) bool {
-	return reflect.DeepEqual(h1.HMACAuth, h2.HMACAuth)
+	return h1.EqualWithOpts(h2, false, false, false)
 }
 
 // EqualWithOpts returns true if h1 and h2 are equal.
@@ -691,7 +691,7 @@ func (j1 *JWTAuth) Console() string {
 
 // Equal returns true if j1 and j2 are equal.
 func (j1 *JWTAuth) Equal(j2 *JWTAuth) bool {
-	return reflect.DeepEqual(j1.JWTAuth, j2.JWTAuth)
+	return j1.EqualWithOpts(j2, false, false, false)
 }
 
 // EqualWithOpts returns true if j1 and j2 are equal.
@@ -762,7 +762,7 @@ func (b1 *BasicAuth) Console() string {
 
 // Equal returns true if b1 and b2 are equal.
 func (b1 *BasicAuth) Equal(b2 *BasicAuth) bool {
-	return reflect.DeepEqual(b1.BasicAuth, b2.BasicAuth)
+	return b1.EqualWithOpts(b2, false, false, false, false)
 }
 
 // EqualWithOpts returns true if j1 and j2 are equal.
@@ -837,7 +837,7 @@ func (b1 *ACLGroup) Console() string {
 
 // Equal returns true if b1 and b2 are equal.
 func (b1 *ACLGroup) Equal(b2 *ACLGroup) bool {
-	return reflect.DeepEqual(b1.ACLGroup, b2.ACLGroup)
+	return b1.EqualWithOpts(b2, false, false, false)
 }
 
 // EqualWithOpts returns true if j1 and j2 are equal.
@@ -890,7 +890,7 @@ func (c1 *CACertificate) Console() string {
 
 // Equal returns true if c1 and c2 are equal.
 func (c1 *CACertificate) Equal(c2 *CACertificate) bool {
-	return reflect.DeepEqual(c1.CACertificate, c2.CACertificate)
+	return c1.EqualWithOpts(c2, false, false)
 }
 
 // EqualWithOpts returns true if c1 and c2 are equal.
@@ -930,7 +930,7 @@ func (k1 *Oauth2Credential) Console() string {
 
 // Equal returns true if k1 and k2 are equal.
 func (k1 *Oauth2Credential) Equal(k2 *Oauth2Credential) bool {
-	return reflect.DeepEqual(k1.Oauth2Credential, k2.Oauth2Credential)
+	return k1.EqualWithOpts(k2, false, false, false)
 }
 
 // EqualWithOpts returns true if k1 and k2 are equal.
@@ -1001,7 +1001,7 @@ func (b1 *MTLSAuth) Console() string {
 
 // Equal returns true if b1 and b2 are equal.
 func (b1 *MTLSAuth) Equal(b2 *MTLSAuth) bool {
-	return reflect.DeepEqual(b1.MTLSAuth, b2.MTLSAuth)
+	return b1.EqualWithOpts(b2, false, false, false)
 }
 
 // EqualWithOpts returns true if j1 and j2 are equal.

--- a/state/types_test.go
+++ b/state/types_test.go
@@ -7,6 +7,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// getTags returns a slice of test tags. If reversed is true, the tags are backwards!
+// backwards tag slices are useful for confirming that our equality checks ignore tag order
+func getTags(reversed bool) []*string {
+	fooString := "foo"
+	barString := "bar"
+	if reversed {
+		return []*string{&barString, &fooString}
+	}
+	return []*string{&fooString, &barString}
+}
+
 func TestMeta(t *testing.T) {
 	assert := assert.New(t)
 
@@ -49,6 +60,9 @@ func TestServiceEqual(t *testing.T) {
 	s2.Name = kong.String("bar")
 	assert.True(s1.Equal(&s2))
 	assert.True(s1.EqualWithOpts(&s2, false, false))
+	s1.Tags = getTags(true)
+	s2.Tags = getTags(false)
+	assert.True(s1.EqualWithOpts(&s2, false, false))
 
 	s1.ID = kong.String("fuu")
 	assert.False(s1.EqualWithOpts(&s2, false, false))
@@ -75,6 +89,9 @@ func TestRouteEqual(t *testing.T) {
 
 	r2.Name = kong.String("bar")
 	assert.True(r1.Equal(&r2))
+	assert.True(r1.EqualWithOpts(&r2, false, false, false))
+	r1.Tags = getTags(true)
+	r2.Tags = getTags(false)
 	assert.True(r1.EqualWithOpts(&r2, false, false, false))
 
 	r1.ID = kong.String("fuu")
@@ -121,6 +138,9 @@ func TestUpstreamEqual(t *testing.T) {
 	u2.Name = kong.String("bar")
 	assert.True(u1.Equal(&u2))
 	assert.True(u1.EqualWithOpts(&u2, false, false))
+	u1.Tags = getTags(true)
+	u2.Tags = getTags(false)
+	assert.True(u1.EqualWithOpts(&u2, false, false))
 
 	u1.ID = kong.String("fuu")
 	assert.False(u1.EqualWithOpts(&u2, false, false))
@@ -147,6 +167,9 @@ func TestTargetEqual(t *testing.T) {
 
 	t2.Target.Target = kong.String("bar")
 	assert.True(t1.Equal(&t2))
+	assert.True(t1.EqualWithOpts(&t2, false, false, false))
+	t1.Tags = getTags(true)
+	t2.Tags = getTags(false)
 	assert.True(t1.EqualWithOpts(&t2, false, false, false))
 
 	t1.ID = kong.String("fuu")
@@ -185,6 +208,9 @@ func TestCertificateEqual(t *testing.T) {
 	c2.Key = kong.String("keyfoo")
 	assert.True(c1.Equal(&c2))
 	assert.True(c1.EqualWithOpts(&c2, false, false))
+	c1.Tags = getTags(true)
+	c2.Tags = getTags(false)
+	assert.True(c1.EqualWithOpts(&c2, false, false))
 
 	c1.ID = kong.String("fuu")
 	assert.False(c1.EqualWithOpts(&c2, false, false))
@@ -211,6 +237,9 @@ func TestSNIEqual(t *testing.T) {
 
 	s2.Name = kong.String("bar")
 	assert.True(s1.Equal(&s2))
+	assert.True(s1.EqualWithOpts(&s2, false, false, false))
+	s1.Tags = getTags(true)
+	s2.Tags = getTags(false)
 	assert.True(s1.EqualWithOpts(&s2, false, false, false))
 
 	s1.ID = kong.String("fuu")
@@ -247,6 +276,9 @@ func TestPluginEqual(t *testing.T) {
 	p2.Name = kong.String("bar")
 	assert.True(p1.Equal(&p2))
 	assert.True(p1.EqualWithOpts(&p2, false, false, false))
+	p1.Tags = getTags(true)
+	p2.Tags = getTags(false)
+	assert.True(p1.EqualWithOpts(&p2, false, false, false))
 
 	p1.ID = kong.String("fuu")
 	assert.False(p1.EqualWithOpts(&p2, false, false, false))
@@ -282,6 +314,9 @@ func TestConsumerEqual(t *testing.T) {
 	c2.Username = kong.String("bar")
 	assert.True(c1.Equal(&c2))
 	assert.True(c1.EqualWithOpts(&c2, false, false))
+	c1.Tags = getTags(true)
+	c2.Tags = getTags(false)
+	assert.True(c1.EqualWithOpts(&c2, false, false))
 
 	c1.ID = kong.String("fuu")
 	assert.False(c1.EqualWithOpts(&c2, false, false))
@@ -308,6 +343,9 @@ func TestKeyAuthEqual(t *testing.T) {
 
 	k2.Key = kong.String("bar")
 	assert.True(k1.Equal(&k2))
+	assert.True(k1.EqualWithOpts(&k2, false, false, false))
+	k1.Tags = getTags(true)
+	k2.Tags = getTags(false)
 	assert.True(k1.EqualWithOpts(&k2, false, false, false))
 
 	k1.ID = kong.String("fuu")
@@ -339,6 +377,9 @@ func TestHMACAuthEqual(t *testing.T) {
 	k2.Username = kong.String("bar")
 	assert.True(k1.Equal(&k2))
 	assert.True(k1.EqualWithOpts(&k2, false, false, false))
+	k1.Tags = getTags(true)
+	k2.Tags = getTags(false)
+	assert.True(k1.EqualWithOpts(&k2, false, false, false))
 
 	k1.ID = kong.String("fuu")
 	assert.False(k1.EqualWithOpts(&k2, false, false, false))
@@ -368,6 +409,9 @@ func TestJWTAuthEqual(t *testing.T) {
 
 	k2.Key = kong.String("bar")
 	assert.True(k1.Equal(&k2))
+	assert.True(k1.EqualWithOpts(&k2, false, false, false))
+	k1.Tags = getTags(true)
+	k2.Tags = getTags(false)
 	assert.True(k1.EqualWithOpts(&k2, false, false, false))
 
 	k1.ID = kong.String("fuu")
@@ -400,6 +444,9 @@ func TestBasicAuthEqual(t *testing.T) {
 	assert.True(k1.Equal(&k2))
 	assert.True(k1.EqualWithOpts(&k2, false, false, false, false))
 	assert.True(k1.EqualWithOpts(&k2, false, false, false, true))
+	k1.Tags = getTags(true)
+	k2.Tags = getTags(false)
+	assert.True(k1.EqualWithOpts(&k2, false, false, false, false))
 
 	k1.ID = kong.String("fuu")
 	assert.False(k1.EqualWithOpts(&k2, false, false, false, false))
@@ -429,6 +476,9 @@ func TestACLGroupEqual(t *testing.T) {
 
 	k2.Group = kong.String("bar")
 	assert.True(k1.Equal(&k2))
+	assert.True(k1.EqualWithOpts(&k2, false, false, false))
+	k1.Tags = getTags(true)
+	k2.Tags = getTags(false)
 	assert.True(k1.EqualWithOpts(&k2, false, false, false))
 
 	k1.ID = kong.String("fuu")


### PR DESCRIPTION
Ignore tag order for object comparisons by sorting the string slices that contain them before checking object equality. This avoids issues with spurious diffs resulting in unnecessary changes when the tag order constructed by deck from dump YAML and the tag order reported by admin API JSON differ.

Because Kong object tags are logical string sets, their order does not matter: it is only a perceived difference because JSON and YAML lack set types and represent them with ordered arrays.

Fix #239 and a minor typo ("Copt" to "Copy" in one of the functions).

**Implementation notes/questions:**

We have `Equal()` and `EqualWithOpts()` functions for each object. The former is just `return reflect.DeepEqual(thing1, thing2)`, is not modified by this PR, and would still report the objects not equal as such. The latter copies the objects first and then nulls out their IDs and/or created and updated timestamps based on the options provided before performing a comparison. This PR does modify `EqualWithOpts()` to ignore tag order, though it doesn't introduce a new option: IDs and timestamp differences do actually matter for objects, but tag order never does, so it doesn't seem like it makes sense to add an option.

I'm curious about the history behind this, since as far as I know deck never cares about timestamps (there's no CLI options to toggle that option, and dumps don't include timestamp data, but this doesn't mean that deck repeatedly updates objects because the `nil` timestamps in dumps do not match the not-`nil` timestamps) and only sort of cares about IDs (`dump` has an option to include them or omit them, but `sync` doesn't have an option to ignore them).

- Do we use `Equal()` in practice, and if so, how/why? Do we need to modify it to also create copies and sort their tags?
- Ditto for `EqualWithOpts()`: do we ever use that without ignoring IDs and timestamps?

Unrelated to that, types_test.go does not currently include tags on any of its test objects. We can cover that pretty easily by adding differently-ordered Tags to objects, e.g. after https://github.com/Kong/deck/blob/v1.2.3/state/types_test.go#L51 and confirming that `EqualWithOpts()` is still true, but I wanted to get a pass on the proposed implementation here before writing those out for every object (Golang generics, you cannot arrive soon enough).