### PR TITLE
Fix --verbose

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -155,6 +155,8 @@ func initConfig() {
 		}
 	}
 
+	verbose = viper.GetInt("verbose")
+
 	rootConfig.Address = viper.GetString("kong-addr")
 	rootConfig.TLSServerName = viper.GetString("tls-server-name")
 	rootConfig.TLSSkipVerify = viper.GetBool("tls-skip-verify")
@@ -163,6 +165,5 @@ func initConfig() {
 	rootConfig.SkipWorkspaceCrud = viper.GetBool("skip-workspace-crud")
 	rootConfig.Debug = verbose >= 1
 
-	verbose = viper.GetInt("verbose")
 	noColor = viper.GetBool("no-color")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,8 +18,6 @@ import (
 var (
 	cfgFile    string
 	rootConfig utils.KongClientConfig
-	verbose    int
-	noColor    bool
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -34,9 +32,6 @@ It can be used to export, import or sync entities to Kong.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if _, err := url.ParseRequestURI(rootConfig.Address); err != nil {
 			return errors.WithStack(errors.Wrap(err, "invalid URL"))
-		}
-		if noColor {
-			color.NoColor = true
 		}
 		return nil
 	},
@@ -155,15 +150,13 @@ func initConfig() {
 		}
 	}
 
-	verbose = viper.GetInt("verbose")
-
 	rootConfig.Address = viper.GetString("kong-addr")
 	rootConfig.TLSServerName = viper.GetString("tls-server-name")
 	rootConfig.TLSSkipVerify = viper.GetBool("tls-skip-verify")
 	rootConfig.TLSCACert = viper.GetString("ca-cert")
 	rootConfig.Headers = viper.GetStringSlice("headers")
 	rootConfig.SkipWorkspaceCrud = viper.GetBool("skip-workspace-crud")
-	rootConfig.Debug = verbose >= 1
+	rootConfig.Debug = (viper.GetInt("verbose") >= 1)
 
-	noColor = viper.GetBool("no-color")
+	color.NoColor = (color.NoColor || viper.GetBool("no-color"))
 }


### PR DESCRIPTION
We originally set the verbosity config after loading it from the `--verbose flag`. #225's changes to fix workspace issues [grouped that config set with other config settings, before loading the `--verbose` flag value](https://github.com/Kong/deck/compare/v1.2.2...v1.2.3#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL157-L166). As a result, deck always uses the default verbosity.

This change moves the `--verbose` flag load above those settings, restoring the ability to control verbosity.

Originally reported internally in FTI-2144. FWIW, no-color is still after everything in that block, but that doesn’t appear to matter/it’s still applied correctly in 1.2.3. Didn’t dig into how that works, but it doesn’t appear that needs a similar fix, so left it alone.