### PR TITLE
feat(state) handle consumers with custom_id only

### DIFF
--- a/file/builder.go
+++ b/file/builder.go
@@ -162,7 +162,13 @@ func (b *stateBuilder) consumers() {
 	for _, c := range b.targetContent.Consumers {
 		c := c
 		if utils.Empty(c.ID) {
-			consumer, err := b.currentState.Consumers.Get(*c.Username)
+			var consumer *state.Consumer
+			var err error
+			if !utils.Empty(c.Username) {
+				consumer, err = b.currentState.Consumers.Get(*c.Username)
+			} else if !utils.Empty(c.CustomID) {
+				consumer, err = b.currentState.Consumers.GetByCustomID(*c.CustomID)
+			}
 			if err == state.ErrNotFound {
 				c.ID = uuid()
 			} else if err != nil {

--- a/file/codegen/main.go
+++ b/file/codegen/main.go
@@ -33,12 +33,15 @@ var (
 		},
 	}
 
-	anyOfUsernameOrID = []*jsonschema.Type{
+	anyOfUsernameOrIDOrCustomID = []*jsonschema.Type{
 		{
 			Required: []string{"username"},
 		},
 		{
 			Required: []string{"id"},
+		},
+		{
+			Required: []string{"custom_id"},
 		},
 	}
 )
@@ -64,8 +67,8 @@ func main() {
 	schema.Definitions["Route"].AnyOf = anyOfNameOrID
 	schema.Definitions["FRoute"].AnyOf = anyOfNameOrID
 
-	schema.Definitions["Consumer"].AnyOf = anyOfUsernameOrID
-	schema.Definitions["FConsumer"].AnyOf = anyOfUsernameOrID
+	schema.Definitions["Consumer"].AnyOf = anyOfUsernameOrIDOrCustomID
+	schema.Definitions["FConsumer"].AnyOf = anyOfUsernameOrIDOrCustomID
 
 	schema.Definitions["Upstream"].Required = []string{"name"}
 	schema.Definitions["FUpstream"].Required = []string{"name"}

--- a/file/schema.go
+++ b/file/schema.go
@@ -260,6 +260,11 @@ const contentSchema = `{
           "required": [
             "id"
           ]
+        },
+        {
+          "required": [
+            "custom_id"
+          ]
         }
       ]
     },
@@ -414,6 +419,11 @@ const contentSchema = `{
         {
           "required": [
             "id"
+          ]
+        },
+        {
+          "required": [
+            "custom_id"
           ]
         }
       ]


### PR DESCRIPTION
This draft adds `custom_id` as one of the schema-allowed fields for consumers along with new lookup and de-duplication code to support them. This allows syncing files like:

```
_format_version: "1.1"
consumers:
- custom_id: foo
```

More in-depth background:

deck dumps and KIC usage of deck's libraries can omit IDs, but still allow syncing/diffing based on unique fields. At present, these fields are predetermined, and all entities have a single unique field only.

Consumers are (possibly) unique in that both their username and custom_id fiends are unique, and only one or the other is required. deck wants to look up consumers via username, however, so we impose a de facto requirement that you always populate the username, normally enforced by schema validity checks. KIC bypasses this check, however, so it can pass consumers without usernames, resulting in [a nil reference crash](https://github.com/Kong/kubernetes-ingress-controller/issues/550) when [attempting to retrieve a consumer by a non-existent username](https://github.com/Kong/deck/blob/v1.2.3/file/builder.go#L165).

The [exposed Consumer getter](https://github.com/Kong/deck/blob/v1.2.3/state/consumer.go#L84-L93) accepts some arbitrary string, and then attempts a lookup [against either the `id` or `Username` indices](https://github.com/Kong/deck/blob/v1.2.3/state/consumer.go#L67-L68). We effectively rely on a soft assumption that nobody attempts to create a problematic consumer set like:

```
{{"id":"32d32db5-e7a0-4d3f-a15d-1734fa0af347","username":"foo"},
{"id":"126d965b-6c59-474a-8858-c51c811f8a1e","username":"32d32db5-e7a0-4d3f-a15d-1734fa0af347"}}
```

That could theoretically trip up the [current getter](https://github.com/Kong/deck/blob/v1.2.3/state/consumer.go#L65-L93), which tries to [search all fields indices](https://github.com/Kong/deck/blob/v1.2.3/state/utils.go#L36-L55) without regards for for their contents. We could expand this to search to include the new CustomID index, which would allow collisions between these consumers:

```
{{"id":"32d32db5-e7a0-4d3f-a15d-1734fa0af347","username":"foo"},
{"id":"126d965b-6c59-474a-8858-c51c811f8a1e","custom_id":"foo"}}
```
We could avoid this by refactoring across the board to search only a single index, i.e. here we'd lookup by ID, Username, and CustomID each separately, and for services by ID and name separately, and so on, or keep that general pattern with an additional CustomID-only search in the event that the initial Username+ID search fails. This takes the consumer-specific approach.