### PR TITLE
Fix regression preventing workspace creation

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -129,7 +129,7 @@ func syncMain(filenames []string, dry bool, parallelism, delay int, workspace st
 		}
 
 		if !dry {
-			_, err = rootClient.Workspaces.Create(nil, &kong.Workspace{Name: &rootConfig.Workspace})
+			_, err = rootClient.Workspaces.Create(nil, &kong.Workspace{Name: &wsConfig.Workspace})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
https://github.com/Kong/deck/pull/225/files#diff-2b0546a527b3560f4e7f8501ef7907999b2e1a7f2498a60719630310f7778956R74 attempts to create a workspace with no name, as we only populate it in https://github.com/Kong/deck/pull/225/files#diff-2b0546a527b3560f4e7f8501ef7907999b2e1a7f2498a60719630310f7778956R84-R86

Fix appears to be using `wsConfig` instead; that works when testing manually.

@mflendrich it looks like this was probably unintentional leftovers from an earlier draft before the commit was pushed. Do you recall if there's any reason we would indeed want to use `rootConfig` here? Doesn't look like it based on a brief review of the [wsConfig population code](https://github.com/Kong/deck/blob/main/utils/types.go#L82-L87) and [go-kong workspace `Create()`](https://github.com/Kong/go-kong/blob/v0.13.0/kong/workspace_service.go#L14-L39), but to echo Harry's previous comment:

> A general node: This part of this codebase has become complex and fragile over time and we should test it. This has never been prioritized as there haven't been many quality issues in this area (yet).

Figured it was worth double-checking as such.

Fix #251 