### PR TITLE
fix: send analytics on a best effort basis

### DIFF
--- a/cmd/analytics.go
+++ b/cmd/analytics.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"net/http"
 	"os"
-	"time"
 )
 
-func sendAnalytics() {
+func sendAnalytics(ctx context.Context) {
 	const (
-		minOSArgs        = 2
-		analyticsTimeout = 3 * time.Second
+		minOSArgs = 2
 	)
 
 	if os.Getenv("DECK_ANALYTICS") == "off" {
@@ -31,9 +29,6 @@ func sendAnalytics() {
 	// HTTP to avoid latency due to handshake
 	URL := "http://d.yolo42.com/" + cmd
 
-	ctx, cancel := context.WithDeadline(context.Background(),
-		time.Now().Add(analyticsTimeout))
-	defer cancel()
 	req, _ := http.NewRequestWithContext(ctx, "GET", URL, nil)
 	req.Header["deck-version"] = []string{VERSION}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -46,13 +47,16 @@ func Execute() {
 	const threads = 2
 	wg.Add(threads)
 
+	ctx, cancel := context.WithCancel(context.Background())
+
 	go func() {
-		sendAnalytics()
+		sendAnalytics(ctx)
 		wg.Done()
 	}()
 
 	go func() {
 		err = rootCmd.Execute()
+		cancel()
 		wg.Done()
 	}()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,14 +50,14 @@ func Execute() {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	go func() {
+		defer wg.Done()
 		sendAnalytics(ctx)
-		wg.Done()
 	}()
 
 	go func() {
+		defer wg.Done()
+		defer cancel()
 		err = rootCmd.Execute()
-		cancel()
-		wg.Done()
 	}()
 
 	wg.Wait()


### PR DESCRIPTION
With this patch, analytics is sent only on a best-effort basis.
Failure to send analytics doesn't result in any slowdown for the end
user.

Fix #253