### PR TITLE
feat: add support for Kong Enterprise RBAC resources

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -54,6 +54,8 @@ func init() {
 		"select-tag", []string{},
 		"only entities matching tags specified via this flag are diffed.\n"+
 			"Multiple tags are ANDed together.")
+	diffCmd.Flags().BoolVar(&dumpConfig.RBACResourcesOnly, "rbac-resources-only",
+		false, "sync only the RBAC resources (Kong Enterprise only)")
 	diffCmd.Flags().BoolVar(&diffCmdNonZeroExitCode, "non-zero-exit-code",
 		false, "return exit code 2 if there is a diff present,\n"+
 			"exit code 0 if no diff is found,\n"+

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -168,5 +168,6 @@ func init() {
 		"select-tag", []string{},
 		"only entities matching tags specified via this flag are exported.\n"+
 			"Multiple tags are ANDed together.")
-
+	dumpCmd.Flags().BoolVar(&dumpConfig.RBACResourcesOnly, "rbac-resources-only",
+		false, "export only the RBAC resources (Kong Enterprise only)")
 }

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -135,4 +135,6 @@ func init() {
 		"select-tag", []string{},
 		"only entities matching tags specified via this flag are deleted.\n"+
 			"Multiple tags are ANDed together.")
+	resetCmd.Flags().BoolVar(&dumpConfig.RBACResourcesOnly, "rbac-resources-only",
+		false, "reset only the RBAC resources (Kong Enterprise only)")
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -51,6 +51,8 @@ func init() {
 		"select-tag", []string{},
 		"only entities matching tags specified via this flag are synced.\n"+
 			"Multiple tags are ANDed together.")
+	syncCmd.Flags().BoolVar(&dumpConfig.RBACResourcesOnly, "rbac-resources-only",
+		false, "diff only the RBAC resources (Kong Enterprise only)")
 	syncCmd.Flags().IntVar(&syncCmdDBUpdateDelay, "db-update-propagation-delay",
 		0, "aritificial delay in seconds that is injected between insert operations \n"+
 			"for related entities (usually for cassandra deployments).\n"+

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -8,7 +8,8 @@ import (
 )
 
 var (
-	validateCmdKongStateFile []string
+	validateCmdKongStateFile     []string
+	validateCmdRBACResourcesOnly bool
 )
 
 // validateCmd represents the diff command
@@ -43,6 +44,9 @@ this command.
 		if err != nil {
 			return err
 		}
+		if err := checkForRBACResources(*rawState, validateCmdRBACResourcesOnly); err != nil {
+			return err
+		}
 		// this catches foreign relation errors
 		_, err = state.Get(rawState)
 		if err != nil {
@@ -62,6 +66,8 @@ this command.
 
 func init() {
 	rootCmd.AddCommand(validateCmd)
+	validateCmd.Flags().BoolVar(&validateCmdRBACResourcesOnly, "rbac-resources-only",
+		false, "indicate that the state file(s) contain RBAC resources only (Kong Enterprise only)")
 	validateCmd.Flags().StringSliceVarP(&validateCmdKongStateFile,
 		"state", "s", []string{"kong.yaml"}, "file(s) containing Kong's configuration.\n"+
 			"This flag can be specified multiple times for multiple files.\n"+

--- a/crud/registry.go
+++ b/crud/registry.go
@@ -1,6 +1,8 @@
 package crud
 
-import "github.com/pkg/errors"
+import (
+	"github.com/pkg/errors"
+)
 
 // Kind represents Kind of an entity or object.
 type Kind string

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -71,6 +71,8 @@ func NewSyncer(current, target *state.KongState) (*Syncer, error) {
 	s.postProcess.MustRegister("acl-group", &aclGroupPostAction{current})
 	s.postProcess.MustRegister("oauth2-cred", &oauth2CredPostAction{current})
 	s.postProcess.MustRegister("mtls-auth", &mtlsAuthPostAction{current})
+	s.postProcess.MustRegister("rbac-role", &rbacRolePostAction{current})
+	s.postProcess.MustRegister("rbac-endpointpermission", &rbacEndpointPermissionPostAction{current})
 	return s, nil
 }
 
@@ -179,6 +181,16 @@ func (sc *Syncer) delete() error {
 		return err
 	}
 
+	err = sc.deleteRBACEndpointPermissions()
+	if err != nil {
+		return err
+	}
+
+	err = sc.deleteRBACRoles()
+	if err != nil {
+		return err
+	}
+
 	// finish delete before returning
 	sc.wait()
 
@@ -268,6 +280,16 @@ func (sc *Syncer) createUpdate() error {
 	sc.wait()
 
 	err = sc.createUpdatePlugins()
+	if err != nil {
+		return err
+	}
+
+	err = sc.createUpdateRBACRoles()
+	if err != nil {
+		return err
+	}
+
+	err = sc.createUpdateRBACEndpointPermissions()
 	if err != nil {
 		return err
 	}

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -186,6 +186,10 @@ func (sc *Syncer) delete() error {
 		return err
 	}
 
+	// barrier for foreign relations
+	// RBAC endpoint permissions must be deleted before RBAC roles
+	sc.wait()
+
 	err = sc.deleteRBACRoles()
 	if err != nil {
 		return err
@@ -288,6 +292,10 @@ func (sc *Syncer) createUpdate() error {
 	if err != nil {
 		return err
 	}
+
+	// barrier for foreign relations
+	// RBAC roles must be created before endpoint permissions
+	sc.wait()
 
 	err = sc.createUpdateRBACEndpointPermissions()
 	if err != nil {

--- a/diff/postProcess.go
+++ b/diff/postProcess.go
@@ -262,3 +262,35 @@ func (crud *mtlsAuthPostAction) Delete(args ...crud.Arg) (crud.Arg, error) {
 func (crud *mtlsAuthPostAction) Update(args ...crud.Arg) (crud.Arg, error) {
 	return nil, crud.currentState.MTLSAuths.Update(*args[0].(*state.MTLSAuth))
 }
+
+type rbacRolePostAction struct {
+	currentState *state.KongState
+}
+
+func (crud *rbacRolePostAction) Create(args ...crud.Arg) (crud.Arg, error) {
+	return nil, crud.currentState.RBACRoles.Add(*args[0].(*state.RBACRole))
+}
+
+func (crud *rbacRolePostAction) Delete(args ...crud.Arg) (crud.Arg, error) {
+	return nil, crud.currentState.RBACRoles.Delete(*((args[0].(*state.RBACRole)).ID))
+}
+
+func (crud *rbacRolePostAction) Update(args ...crud.Arg) (crud.Arg, error) {
+	return nil, crud.currentState.RBACRoles.Update(*args[0].(*state.RBACRole))
+}
+
+type rbacEndpointPermissionPostAction struct {
+	currentState *state.KongState
+}
+
+func (crud *rbacEndpointPermissionPostAction) Create(args ...crud.Arg) (crud.Arg, error) {
+	return nil, crud.currentState.RBACEndpointPermissions.Add(*args[0].(*state.RBACEndpointPermission))
+}
+
+func (crud *rbacEndpointPermissionPostAction) Delete(args ...crud.Arg) (crud.Arg, error) {
+	return nil, crud.currentState.RBACEndpointPermissions.Delete(args[0].(*state.RBACEndpointPermission).Identifier())
+}
+
+func (crud *rbacEndpointPermissionPostAction) Update(args ...crud.Arg) (crud.Arg, error) {
+	return nil, crud.currentState.RBACEndpointPermissions.Update(*args[0].(*state.RBACEndpointPermission))
+}

--- a/diff/rbac_endpoint_permission.go
+++ b/diff/rbac_endpoint_permission.go
@@ -1,0 +1,94 @@
+package diff
+
+import (
+	"github.com/kong/deck/crud"
+	"github.com/kong/deck/state"
+	"github.com/pkg/errors"
+)
+
+func (sc *Syncer) deleteRBACEndpointPermissions() error {
+	currentRBACEndpointPermissions, err := sc.currentState.RBACEndpointPermissions.GetAll()
+	if err != nil {
+		return errors.Wrap(err, "error fetching eps from state")
+	}
+
+	for _, ep := range currentRBACEndpointPermissions {
+		n, err := sc.deleteRBACEndpointPermission(ep)
+		if err != nil {
+			return err
+		}
+		if n != nil {
+			err = sc.queueEvent(*n)
+			if err != nil {
+				return err
+			}
+		}
+
+	}
+	return nil
+}
+
+func (sc *Syncer) deleteRBACEndpointPermission(ep *state.RBACEndpointPermission) (*Event, error) {
+	_, err := sc.targetState.RBACEndpointPermissions.Get(ep.Identifier())
+	if err == state.ErrNotFound {
+		return &Event{
+			Op:   crud.Delete,
+			Kind: "rbac-endpointpermission",
+			Obj:  ep,
+		}, nil
+	}
+	if err != nil {
+		return nil, errors.Wrapf(err, "looking up rbac ep '%v'",
+			ep.ID)
+	}
+	return nil, nil
+}
+
+func (sc *Syncer) createUpdateRBACEndpointPermissions() error {
+	targetRBACEndpointPermissions, err := sc.targetState.RBACEndpointPermissions.GetAll()
+	if err != nil {
+		return errors.Wrap(err, "error fetching rbac eps from state")
+	}
+
+	for _, ep := range targetRBACEndpointPermissions {
+		n, err := sc.createUpdateRBACEndpointPermission(ep)
+		if err != nil {
+			return err
+		}
+		if n != nil {
+			err = sc.queueEvent(*n)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (sc *Syncer) createUpdateRBACEndpointPermission(ep *state.RBACEndpointPermission) (*Event, error) {
+	epCopy := &state.RBACEndpointPermission{RBACEndpointPermission: *ep.DeepCopy()}
+	currentEp, err := sc.currentState.RBACEndpointPermissions.Get(ep.Identifier())
+
+	if err == state.ErrNotFound {
+		return &Event{
+			Op:   crud.Create,
+			Kind: "rbac-endpointpermission",
+			Obj:  epCopy,
+		}, nil
+	}
+	if err != nil {
+		return nil, errors.Wrapf(err, "error looking up rbac endpoint permission %v",
+			ep.Identifier())
+	}
+
+	// found, check if update needed
+	if !currentEp.EqualWithOpts(epCopy, false, true, false) {
+		return &Event{
+			Op:     crud.Update,
+			Kind:   "rbac-endpointpermission",
+			Obj:    epCopy,
+			OldObj: currentEp,
+		}, nil
+	}
+	return nil, nil
+}

--- a/diff/rbac_role.go
+++ b/diff/rbac_role.go
@@ -1,0 +1,94 @@
+package diff
+
+import (
+	"github.com/kong/deck/crud"
+	"github.com/kong/deck/state"
+	"github.com/pkg/errors"
+)
+
+func (sc *Syncer) deleteRBACRoles() error {
+	currentRBACRoles, err := sc.currentState.RBACRoles.GetAll()
+	if err != nil {
+		return errors.Wrap(err, "error fetching roles from state")
+	}
+
+	for _, role := range currentRBACRoles {
+		n, err := sc.deleteRBACRole(role)
+		if err != nil {
+			return err
+		}
+		if n != nil {
+			err = sc.queueEvent(*n)
+			if err != nil {
+				return err
+			}
+		}
+
+	}
+	return nil
+}
+
+func (sc *Syncer) deleteRBACRole(role *state.RBACRole) (*Event, error) {
+	_, err := sc.targetState.RBACRoles.Get(*role.Name)
+	if err == state.ErrNotFound {
+		return &Event{
+			Op:   crud.Delete,
+			Kind: "rbac-role",
+			Obj:  role,
+		}, nil
+	}
+	if err != nil {
+		return nil, errors.Wrapf(err, "looking up rbac role '%v'",
+			role.ID)
+	}
+	return nil, nil
+}
+
+func (sc *Syncer) createUpdateRBACRoles() error {
+	targetRBACRoles, err := sc.targetState.RBACRoles.GetAll()
+	if err != nil {
+		return errors.Wrap(err, "error fetching rbac roles from state")
+	}
+
+	for _, role := range targetRBACRoles {
+		n, err := sc.createUpdateRBACRole(role)
+		if err != nil {
+			return err
+		}
+		if n != nil {
+			err = sc.queueEvent(*n)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (sc *Syncer) createUpdateRBACRole(role *state.RBACRole) (*Event, error) {
+	roleCopy := &state.RBACRole{RBACRole: *role.DeepCopy()}
+	currentRole, err := sc.currentState.RBACRoles.Get(*role.Name)
+
+	if err == state.ErrNotFound {
+		return &Event{
+			Op:   crud.Create,
+			Kind: "rbac-role",
+			Obj:  roleCopy,
+		}, nil
+	}
+	if err != nil {
+		return nil, errors.Wrapf(err, "error looking up rbac role %v",
+			*role.ID)
+	}
+
+	// found, check if update needed
+	if !currentRole.EqualWithOpts(roleCopy, false, true, false) {
+		return &Event{
+			Op:     crud.Update,
+			Kind:   "rbac-role",
+			Obj:    roleCopy,
+			OldObj: currentRole,
+		}, nil
+	}
+	return nil, nil
+}

--- a/diff/rbac_role.go
+++ b/diff/rbac_role.go
@@ -9,7 +9,7 @@ import (
 func (sc *Syncer) deleteRBACRoles() error {
 	currentRBACRoles, err := sc.currentState.RBACRoles.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching roles from state")
+		return errors.Wrap(err, "error fetching rbac roles from state")
 	}
 
 	for _, role := range currentRBACRoles {
@@ -39,7 +39,7 @@ func (sc *Syncer) deleteRBACRole(role *state.RBACRole) (*Event, error) {
 	}
 	if err != nil {
 		return nil, errors.Wrapf(err, "looking up rbac role '%v'",
-			role.ID)
+			role.Identifier())
 	}
 	return nil, nil
 }
@@ -78,7 +78,7 @@ func (sc *Syncer) createUpdateRBACRole(role *state.RBACRole) (*Event, error) {
 	}
 	if err != nil {
 		return nil, errors.Wrapf(err, "error looking up rbac role %v",
-			*role.ID)
+			role.Identifier())
 	}
 
 	// found, check if update needed

--- a/dump/dump_test.go
+++ b/dump/dump_test.go
@@ -1,0 +1,61 @@
+package dump
+
+import "testing"
+
+func Test_validateConfig(t *testing.T) {
+	type args struct {
+		config Config
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "valid config for RBAC resources",
+			args: args{
+				config: Config{
+					RBACResourcesOnly: true,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid config for proxy resources",
+			args: args{
+				config: Config{
+					SkipConsumers: true,
+					SelectorTags:  []string{"foo", "bar"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid config mixing RBAC and selector tags",
+			args: args{
+				config: Config{
+					SelectorTags:      []string{"foo", "bar"},
+					RBACResourcesOnly: true,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid config mixing RBAC and SkipConsumers",
+			args: args{
+				config: Config{
+					SkipConsumers:     true,
+					RBACResourcesOnly: true,
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateConfig(tt.args.config); (err != nil) != tt.wantErr {
+				t.Errorf("validateConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/file/builder.go
+++ b/file/builder.go
@@ -53,7 +53,7 @@ func (b *stateBuilder) build() (*utils.KongRawState, error) {
 	b.upstreams()
 	b.consumers()
 	b.plugins()
-	b.rbacRoles()
+	b.enterprise()
 
 	// result
 	if b.err != nil {
@@ -469,6 +469,10 @@ func (b *stateBuilder) routes() {
 			return
 		}
 	}
+}
+
+func (b *stateBuilder) enterprise() {
+	b.rbacRoles()
 }
 
 func (b *stateBuilder) rbacRoles() {

--- a/file/codegen/main.go
+++ b/file/codegen/main.go
@@ -98,6 +98,10 @@ func main() {
 		"client_id", "redirect_uris", "client_secret"}
 	schema.Definitions["MTLSAuth"].Required = []string{"id", "subject_name"}
 
+	// RBAC resources
+	schema.Definitions["FRBACRole"].Required = []string{"name"}
+	schema.Definitions["FRBACEndpointPermission"].Required = []string{"workspace", "endpoint"}
+
 	// Foreign references
 	stringType := &jsonschema.Type{Type: "string"}
 	schema.Definitions["FPlugin"].Properties["consumer"] = stringType

--- a/file/schema.go
+++ b/file/schema.go
@@ -478,6 +478,10 @@ const contentSchema = `{
       "type": "object"
     },
     "FRBACEndpointPermission": {
+      "required": [
+        "workspace",
+        "endpoint"
+      ],
       "properties": {
         "actions": {
           "items": {
@@ -509,6 +513,9 @@ const contentSchema = `{
       "type": "object"
     },
     "FRBACRole": {
+      "required": [
+        "name"
+      ],
       "properties": {
         "comment": {
           "type": "string"

--- a/file/schema.go
+++ b/file/schema.go
@@ -50,6 +50,13 @@ const contentSchema = `{
       },
       "type": "array"
     },
+    "rbac_roles": {
+      "items": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "$ref": "#/definitions/FRBACRole"
+      },
+      "type": "array"
+    },
     "routes": {
       "items": {
         "$ref": "#/definitions/FRoute"
@@ -465,6 +472,65 @@ const contentSchema = `{
             "type": "string"
           },
           "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "FRBACEndpointPermission": {
+      "properties": {
+        "actions": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "comment": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "integer"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "negative": {
+          "type": "boolean"
+        },
+        "role": {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/RBACRole"
+        },
+        "workspace": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "FRBACRole": {
+      "properties": {
+        "comment": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "integer"
+        },
+        "endpoint_permissions": {
+          "items": {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$ref": "#/definitions/FRBACEndpointPermission"
+          },
+          "type": "array"
+        },
+        "id": {
+          "type": "string"
+        },
+        "is_default": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
         }
       },
       "additionalProperties": false,
@@ -1009,6 +1075,27 @@ const contentSchema = `{
         },
         "unhealthy": {
           "$ref": "#/definitions/Unhealthy"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "RBACRole": {
+      "properties": {
+        "comment": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "integer"
+        },
+        "id": {
+          "type": "string"
+        },
+        "is_default": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/file/types.go
+++ b/file/types.go
@@ -479,6 +479,16 @@ func (c FConsumer) id() string {
 	return ""
 }
 
+// FRBACRole represents an RBACRole in Kong
+type FRBACRole struct {
+	kong.RBACRole       `yaml:",inline,omitempty"`
+	EndpointPermissions []*FRBACEndpointPermission `json:"endpoint_permissions,omitempty" yaml:"endpoint_permissions,omitempty"` //nolint
+}
+
+type FRBACEndpointPermission struct {
+	kong.RBACEndpointPermission `yaml:",inline,omitempty"`
+}
+
 // Info contains meta-data of the file.
 type Info struct {
 	SelectorTags []string `json:"select_tags,omitempty" yaml:"select_tags,omitempty"`
@@ -499,6 +509,8 @@ type Content struct {
 	Upstreams      []FUpstream      `json:"upstreams,omitempty" yaml:",omitempty"`
 	Certificates   []FCertificate   `json:"certificates,omitempty" yaml:",omitempty"`
 	CACertificates []FCACertificate `json:"ca_certificates,omitempty" yaml:"ca_certificates,omitempty"`
+
+	RBACRoles []FRBACRole `json:"rbac_roles,omitempty" yaml:"rbac_roles,omitempty"`
 
 	PluginConfigs map[string]kong.Configuration `json:"_plugin_configs,omitempty" yaml:"_plugin_configs,omitempty"`
 }

--- a/file/types_test.go
+++ b/file/types_test.go
@@ -2,7 +2,6 @@ package file
 
 import (
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -223,7 +222,6 @@ func Test_unwrapURL(t *testing.T) {
 			if err := unwrapURL(tt.args.urlString, &in); (err != nil) != tt.wantErr {
 				t.Errorf("unwrapURL() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			fmt.Printf("\n\n%+v", in)
 			if !reflect.DeepEqual(tt.args.fService, &in) {
 				t.Errorf("unwrapURL() got = %v, want = %v", &in, tt.args.fService)
 			}

--- a/file/writer.go
+++ b/file/writer.go
@@ -388,6 +388,7 @@ func KongStateToFile(kongState *state.KongState, config WriteConfig) error {
 			r.EndpointPermissions = append(
 				r.EndpointPermissions, &FRBACEndpointPermission{RBACEndpointPermission: ep.RBACEndpointPermission})
 		}
+		zeroOutID(&r, r.Name, config.WithID)
 		zeroOutTimestamps(&r)
 		file.RBACRoles = append(file.RBACRoles, r)
 	}

--- a/go.sum
+++ b/go.sum
@@ -4,7 +4,9 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/jsonschema v0.0.0-20191017121752-4bb6e3fae4f2 h1:swGeCLPiUQ647AIRnFxnAHdzlg6IPpmU6QdkOPZINt8=
 github.com/alecthomas/jsonschema v0.0.0-20191017121752-4bb6e3fae4f2/go.mod h1:Juc2PrI3wtNfUwptSvAIeNx+HrETwHQs6nf+TkOJlOA=
+github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -135,6 +137,7 @@ github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDf
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
+github.com/prometheus/common v0.4.0 h1:7etb9YClo3a6HjLzfl6rIQaU+FDfi0VSX39io3aQ+DM=
 github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
@@ -146,6 +149,7 @@ github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdh
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
@@ -206,6 +210,7 @@ go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
@@ -250,6 +255,7 @@ google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9Ywl
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/reset/reset.go
+++ b/reset/reset.go
@@ -96,6 +96,14 @@ func Reset(state *utils.KongRawState, client *kong.Client) error {
 		}
 	}
 
+	// Deleting RBAC roles also deletes their associated permissions
+	for _, r := range state.RBACRoles {
+		err := client.RBACRoles.Delete(nil, r.ID)
+		if err != nil {
+			return err
+		}
+	}
+
 	// TODO handle custom entities
 	return nil
 }

--- a/solver/rbac_endpoint_permission.go
+++ b/solver/rbac_endpoint_permission.go
@@ -1,0 +1,65 @@
+package solver
+
+import (
+	"github.com/kong/deck/crud"
+	"github.com/kong/deck/diff"
+	"github.com/kong/deck/state"
+	"github.com/kong/go-kong/kong"
+)
+
+// rbacEndpointPermissionCRUD implements crud.Actions interface.
+type rbacEndpointPermissionCRUD struct {
+	client *kong.Client
+}
+
+func rbacEndpointPermissionFromStuct(arg diff.Event) *state.RBACEndpointPermission {
+	ep, ok := arg.Obj.(*state.RBACEndpointPermission)
+	if !ok {
+		panic("unexpected type, expected *state.RBACEndpointPermission")
+	}
+
+	return ep
+}
+
+// Create creates a RBACEndpointPermission in Kong.
+// The arg should be of type diff.Event, containing the ep to be created,
+// else the function will panic.
+// It returns a the created *state.RBACEndpointPermission.
+func (s *rbacEndpointPermissionCRUD) Create(arg ...crud.Arg) (crud.Arg, error) {
+	event := eventFromArg(arg[0])
+	ep := rbacEndpointPermissionFromStuct(event)
+	createdRBACEndpointPermission, err := s.client.RBACEndpointPermissions.Create(nil, &ep.RBACEndpointPermission)
+	if err != nil {
+		return nil, err
+	}
+	return &state.RBACEndpointPermission{RBACEndpointPermission: *createdRBACEndpointPermission}, nil
+}
+
+// Delete deletes a RBACEndpointPermission in Kong.
+// The arg should be of type diff.Event, containing the ep to be deleted,
+// else the function will panic.
+// It returns a the deleted *state.RBACEndpointPermission.
+func (s *rbacEndpointPermissionCRUD) Delete(arg ...crud.Arg) (crud.Arg, error) {
+	event := eventFromArg(arg[0])
+	ep := rbacEndpointPermissionFromStuct(event)
+	err := s.client.RBACEndpointPermissions.Delete(nil, ep.Role.ID, ep.Workspace, ep.Endpoint)
+	if err != nil {
+		return nil, err
+	}
+	return ep, nil
+}
+
+// Update updates a RBACEndpointPermission in Kong.
+// The arg should be of type diff.Event, containing the ep to be updated,
+// else the function will panic.
+// It returns a the updated *state.RBACEndpointPermission.
+func (s *rbacEndpointPermissionCRUD) Update(arg ...crud.Arg) (crud.Arg, error) {
+	event := eventFromArg(arg[0])
+	ep := rbacEndpointPermissionFromStuct(event)
+
+	updatedRBACEndpointPermission, err := s.client.RBACEndpointPermissions.Create(nil, &ep.RBACEndpointPermission)
+	if err != nil {
+		return nil, err
+	}
+	return &state.RBACEndpointPermission{RBACEndpointPermission: *updatedRBACEndpointPermission}, nil
+}

--- a/solver/rbac_endpoint_permission.go
+++ b/solver/rbac_endpoint_permission.go
@@ -57,7 +57,7 @@ func (s *rbacEndpointPermissionCRUD) Update(arg ...crud.Arg) (crud.Arg, error) {
 	event := eventFromArg(arg[0])
 	ep := rbacEndpointPermissionFromStuct(event)
 
-	updatedRBACEndpointPermission, err := s.client.RBACEndpointPermissions.Create(nil, &ep.RBACEndpointPermission)
+	updatedRBACEndpointPermission, err := s.client.RBACEndpointPermissions.Update(nil, &ep.RBACEndpointPermission)
 	if err != nil {
 		return nil, err
 	}

--- a/solver/rbac_endpoint_permission.go
+++ b/solver/rbac_endpoint_permission.go
@@ -12,7 +12,7 @@ type rbacEndpointPermissionCRUD struct {
 	client *kong.Client
 }
 
-func rbacEndpointPermissionFromStuct(arg diff.Event) *state.RBACEndpointPermission {
+func rbacEndpointPermissionFromStruct(arg diff.Event) *state.RBACEndpointPermission {
 	ep, ok := arg.Obj.(*state.RBACEndpointPermission)
 	if !ok {
 		panic("unexpected type, expected *state.RBACEndpointPermission")
@@ -27,7 +27,7 @@ func rbacEndpointPermissionFromStuct(arg diff.Event) *state.RBACEndpointPermissi
 // It returns a the created *state.RBACEndpointPermission.
 func (s *rbacEndpointPermissionCRUD) Create(arg ...crud.Arg) (crud.Arg, error) {
 	event := eventFromArg(arg[0])
-	ep := rbacEndpointPermissionFromStuct(event)
+	ep := rbacEndpointPermissionFromStruct(event)
 	createdRBACEndpointPermission, err := s.client.RBACEndpointPermissions.Create(nil, &ep.RBACEndpointPermission)
 	if err != nil {
 		return nil, err
@@ -41,7 +41,7 @@ func (s *rbacEndpointPermissionCRUD) Create(arg ...crud.Arg) (crud.Arg, error) {
 // It returns a the deleted *state.RBACEndpointPermission.
 func (s *rbacEndpointPermissionCRUD) Delete(arg ...crud.Arg) (crud.Arg, error) {
 	event := eventFromArg(arg[0])
-	ep := rbacEndpointPermissionFromStuct(event)
+	ep := rbacEndpointPermissionFromStruct(event)
 	err := s.client.RBACEndpointPermissions.Delete(nil, ep.Role.ID, ep.Workspace, ep.Endpoint)
 	if err != nil {
 		return nil, err
@@ -55,7 +55,7 @@ func (s *rbacEndpointPermissionCRUD) Delete(arg ...crud.Arg) (crud.Arg, error) {
 // It returns a the updated *state.RBACEndpointPermission.
 func (s *rbacEndpointPermissionCRUD) Update(arg ...crud.Arg) (crud.Arg, error) {
 	event := eventFromArg(arg[0])
-	ep := rbacEndpointPermissionFromStuct(event)
+	ep := rbacEndpointPermissionFromStruct(event)
 
 	updatedRBACEndpointPermission, err := s.client.RBACEndpointPermissions.Update(nil, &ep.RBACEndpointPermission)
 	if err != nil {

--- a/solver/rbac_role.go
+++ b/solver/rbac_role.go
@@ -1,0 +1,65 @@
+package solver
+
+import (
+	"github.com/kong/deck/crud"
+	"github.com/kong/deck/diff"
+	"github.com/kong/deck/state"
+	"github.com/kong/go-kong/kong"
+)
+
+// rbacRoleCRUD implements crud.Actions interface.
+type rbacRoleCRUD struct {
+	client *kong.Client
+}
+
+func rbacRoleFromStuct(arg diff.Event) *state.RBACRole {
+	role, ok := arg.Obj.(*state.RBACRole)
+	if !ok {
+		panic("unexpected type, expected *state.RBACRole")
+	}
+
+	return role
+}
+
+// Create creates a RBACRole in Kong.
+// The arg should be of type diff.Event, containing the role to be created,
+// else the function will panic.
+// It returns a the created *state.RBACRole.
+func (s *rbacRoleCRUD) Create(arg ...crud.Arg) (crud.Arg, error) {
+	event := eventFromArg(arg[0])
+	role := rbacRoleFromStuct(event)
+	createdRBACRole, err := s.client.RBACRoles.Create(nil, &role.RBACRole)
+	if err != nil {
+		return nil, err
+	}
+	return &state.RBACRole{RBACRole: *createdRBACRole}, nil
+}
+
+// Delete deletes a RBACRole in Kong.
+// The arg should be of type diff.Event, containing the role to be deleted,
+// else the function will panic.
+// It returns a the deleted *state.RBACRole.
+func (s *rbacRoleCRUD) Delete(arg ...crud.Arg) (crud.Arg, error) {
+	event := eventFromArg(arg[0])
+	role := rbacRoleFromStuct(event)
+	err := s.client.RBACRoles.Delete(nil, role.ID)
+	if err != nil {
+		return nil, err
+	}
+	return role, nil
+}
+
+// Update updates a RBACRole in Kong.
+// The arg should be of type diff.Event, containing the role to be updated,
+// else the function will panic.
+// It returns a the updated *state.RBACRole.
+func (s *rbacRoleCRUD) Update(arg ...crud.Arg) (crud.Arg, error) {
+	event := eventFromArg(arg[0])
+	role := rbacRoleFromStuct(event)
+
+	updatedRBACRole, err := s.client.RBACRoles.Create(nil, &role.RBACRole)
+	if err != nil {
+		return nil, err
+	}
+	return &state.RBACRole{RBACRole: *updatedRBACRole}, nil
+}

--- a/solver/solver.go
+++ b/solver/solver.go
@@ -92,5 +92,7 @@ func buildRegistry(client *kong.Client) *crud.Registry {
 	r.MustRegister("acl-group", &aclGroupCRUD{client: client})
 	r.MustRegister("oauth2-cred", &oauth2CredCRUD{client: client})
 	r.MustRegister("mtls-auth", &mtlsAuthCRUD{client: client})
+	r.MustRegister("rbac-role", &rbacRoleCRUD{client: client})
+	r.MustRegister("rbac-endpointpermission", &rbacEndpointPermissionCRUD{client: client})
 	return &r
 }

--- a/state/builder.go
+++ b/state/builder.go
@@ -174,5 +174,17 @@ func Get(raw *utils.KongRawState) (*KongState, error) {
 			return nil, errors.Wrap(err, "inserting plugins into state")
 		}
 	}
+	for _, r := range raw.RBACRoles {
+		err := kongState.RBACRoles.Add(RBACRole{RBACRole: *r})
+		if err != nil {
+			return nil, errors.Wrap(err, "inserting rbac roles into state")
+		}
+	}
+	for _, r := range raw.RBACEndpointPermissions {
+		err := kongState.RBACEndpointPermissions.Add(RBACEndpointPermission{RBACEndpointPermission: *r})
+		if err != nil {
+			return nil, errors.Wrap(err, "inserting rbac endpoint permissions into state")
+		}
+	}
 	return kongState, nil
 }

--- a/state/rbac_endpoint_permission.go
+++ b/state/rbac_endpoint_permission.go
@@ -89,7 +89,6 @@ func getRBACEndpointPermission(txn *memdb.Txn, IDs ...string) (*RBACEndpointPerm
 	for _, id := range IDs {
 		res, err := multiIndexLookupUsingTxn(txn, rbacEndpointPermissionTableName,
 			[]string{"id"}, id)
-		fmt.Println(res)
 		if err == ErrNotFound {
 			continue
 		}

--- a/state/rbac_endpoint_permission.go
+++ b/state/rbac_endpoint_permission.go
@@ -15,7 +15,6 @@ const (
 )
 
 var errInvalidRole = errors.New("role.ID is required in rbacEndpointPermission")
-var errEndpointRequired = errors.New("endpoint is required in rbacEndpointPermission")
 var rbacEndpointPermissionTableSchema = &memdb.TableSchema{
 	Name: rbacEndpointPermissionTableName,
 	Indexes: map[string]*memdb.IndexSchema{
@@ -55,11 +54,6 @@ type RBACEndpointPermissionsCollection collection
 // Add adds a rbacEndpointPermission into RBACEndpointPermissionsCollection
 // rbacEndpointPermission.Endpoint should not be nil else an error is thrown.
 func (k *RBACEndpointPermissionsCollection) Add(rbacEndpointPermission RBACEndpointPermission) error {
-	// TODO abstract this check in the go-memdb library itself
-	if utils.Empty(rbacEndpointPermission.Endpoint) {
-		return errEndpointRequired
-	}
-
 	if err := validateRoleForRBACEndpointPermission(&rbacEndpointPermission); err != nil {
 		return err
 	}
@@ -121,9 +115,6 @@ func (k *RBACEndpointPermissionsCollection) Get(nameOrID string) (*RBACEndpointP
 
 // Update updates a rbacEndpointPermission
 func (k *RBACEndpointPermissionsCollection) Update(rbacEndpointPermission RBACEndpointPermission) error {
-	if utils.Empty(rbacEndpointPermission.Endpoint) {
-		return errEndpointRequired
-	}
 	txn := k.db.Txn(true)
 	defer txn.Abort()
 

--- a/state/rbac_endpoint_permission.go
+++ b/state/rbac_endpoint_permission.go
@@ -1,0 +1,217 @@
+package state
+
+import (
+	"fmt"
+
+	memdb "github.com/hashicorp/go-memdb"
+	"github.com/kong/deck/state/indexers"
+	"github.com/kong/deck/utils"
+	"github.com/pkg/errors"
+)
+
+const (
+	rbacEndpointPermissionTableName = "rbac-endpointpermission"
+	rbacEndpointPermissionsByRoleID = "rbacEndpointPermissionsByRoleID"
+)
+
+var errInvalidRole = errors.New("role.ID is required in rbacEndpointPermission")
+var errEndpointRequired = errors.New("endpoint is required in rbacEndpointPermission")
+var rbacEndpointPermissionTableSchema = &memdb.TableSchema{
+	Name: rbacEndpointPermissionTableName,
+	Indexes: map[string]*memdb.IndexSchema{
+		// ID in the case of an RBACEndpointPermission is a composite key of role ID, workspace, and endpoint
+		"id": {
+			Name:    "id",
+			Unique:  true,
+			Indexer: &memdb.StringFieldIndex{Field: "ID"},
+		},
+		all: allIndex,
+		// foreign
+		rbacEndpointPermissionsByRoleID: {
+			Name: rbacEndpointPermissionsByRoleID,
+			Indexer: &indexers.SubFieldIndexer{
+				Fields: []indexers.Field{
+					{
+						Struct: "Role",
+						Sub:    "ID",
+					},
+				},
+			},
+		},
+	},
+}
+
+func validateRoleForRBACEndpointPermission(rbacEndpointPermission *RBACEndpointPermission) error {
+	if rbacEndpointPermission.Role == nil ||
+		utils.Empty(rbacEndpointPermission.Role.ID) {
+		return errInvalidRole
+	}
+	return nil
+}
+
+// RBACEndpointPermissionsCollection stores and indexes Kong RBACEndpointPermissions.
+type RBACEndpointPermissionsCollection collection
+
+// Add adds a rbacEndpointPermission into RBACEndpointPermissionsCollection
+// rbacEndpointPermission.Endpoint should not be nil else an error is thrown.
+func (k *RBACEndpointPermissionsCollection) Add(rbacEndpointPermission RBACEndpointPermission) error {
+	// TODO abstract this check in the go-memdb library itself
+	if utils.Empty(rbacEndpointPermission.Endpoint) {
+		return errEndpointRequired
+	}
+
+	if err := validateRoleForRBACEndpointPermission(&rbacEndpointPermission); err != nil {
+		return err
+	}
+
+	txn := k.db.Txn(true)
+	defer txn.Abort()
+
+	var searchBy []string
+	searchBy = append(searchBy, rbacEndpointPermission.Identifier())
+
+	_, err := getRBACEndpointPermission(txn, searchBy...)
+	if err == nil {
+		return fmt.Errorf("inserting rbacEndpointPermission %v: %w", rbacEndpointPermission.Console(), ErrAlreadyExists)
+	} else if err != ErrNotFound {
+		return err
+	}
+	rbacEndpointPermission.ID = rbacEndpointPermission.Identifier()
+	err = txn.Insert(rbacEndpointPermissionTableName, &rbacEndpointPermission)
+	if err != nil {
+		return err
+	}
+	txn.Commit()
+	return nil
+}
+
+func getRBACEndpointPermission(txn *memdb.Txn, IDs ...string) (*RBACEndpointPermission, error) {
+	for _, id := range IDs {
+		res, err := multiIndexLookupUsingTxn(txn, rbacEndpointPermissionTableName,
+			[]string{"id"}, id)
+		fmt.Println(res)
+		if err == ErrNotFound {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		rbacEndpointPermission, ok := res.(*RBACEndpointPermission)
+		if !ok {
+			panic(unexpectedType)
+		}
+		return &RBACEndpointPermission{RBACEndpointPermission: *rbacEndpointPermission.DeepCopy()}, nil
+	}
+	return nil, ErrNotFound
+}
+
+// Get gets a rbacEndpointPermission by name or ID.
+func (k *RBACEndpointPermissionsCollection) Get(nameOrID string) (*RBACEndpointPermission, error) {
+	if nameOrID == "" {
+		return nil, errIDRequired
+	}
+
+	txn := k.db.Txn(false)
+	defer txn.Abort()
+	rbacEndpointPermission, err := getRBACEndpointPermission(txn, nameOrID)
+	if err != nil {
+		return nil, err
+	}
+	return rbacEndpointPermission, nil
+}
+
+// Update updates a rbacEndpointPermission
+func (k *RBACEndpointPermissionsCollection) Update(rbacEndpointPermission RBACEndpointPermission) error {
+	if utils.Empty(rbacEndpointPermission.Endpoint) {
+		return errEndpointRequired
+	}
+	txn := k.db.Txn(true)
+	defer txn.Abort()
+
+	err := deleteRBACEndpointPermission(txn, rbacEndpointPermission.Identifier())
+	if err != nil {
+		return err
+	}
+
+	rbacEndpointPermission.ID = rbacEndpointPermission.Identifier()
+	err = txn.Insert(rbacEndpointPermissionTableName, &rbacEndpointPermission)
+	if err != nil {
+		return err
+	}
+
+	txn.Commit()
+	return nil
+}
+
+func deleteRBACEndpointPermission(txn *memdb.Txn, nameOrID string) error {
+	rbacEndpointPermission, err := getRBACEndpointPermission(txn, nameOrID)
+	if err != nil {
+		return err
+	}
+	rbacEndpointPermission.ID = rbacEndpointPermission.Identifier()
+	err = txn.Delete(rbacEndpointPermissionTableName, rbacEndpointPermission)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Delete deletes a rbacEndpointPermission by name or ID.
+func (k *RBACEndpointPermissionsCollection) Delete(endpointIdentifier string) error {
+	if endpointIdentifier == "" {
+		return errIDRequired
+	}
+
+	txn := k.db.Txn(true)
+	defer txn.Abort()
+
+	err := deleteRBACEndpointPermission(txn, endpointIdentifier)
+	if err != nil {
+		return err
+	}
+
+	txn.Commit()
+	return nil
+}
+
+// GetAll gets a rbacEndpointPermission by name or ID.
+func (k *RBACEndpointPermissionsCollection) GetAll() ([]*RBACEndpointPermission, error) {
+	txn := k.db.Txn(false)
+	defer txn.Abort()
+
+	iter, err := txn.Get(rbacEndpointPermissionTableName, all, true)
+	if err != nil {
+		return nil, err
+	}
+
+	var res []*RBACEndpointPermission
+	for el := iter.Next(); el != nil; el = iter.Next() {
+		r, ok := el.(*RBACEndpointPermission)
+		if !ok {
+			panic(unexpectedType)
+		}
+		res = append(res, &RBACEndpointPermission{RBACEndpointPermission: *r.DeepCopy()})
+	}
+	txn.Commit()
+	return res, nil
+}
+
+// GetAllByRoleID returns all endpoint permissions by referencing a role
+// by its id.
+func (k *RBACEndpointPermissionsCollection) GetAllByRoleID(id string) ([]*RBACEndpointPermission,
+	error) {
+	txn := k.db.Txn(false)
+	iter, err := txn.Get(rbacEndpointPermissionTableName, rbacEndpointPermissionsByRoleID, id)
+	if err != nil {
+		return nil, err
+	}
+	var res []*RBACEndpointPermission
+	for el := iter.Next(); el != nil; el = iter.Next() {
+		r, ok := el.(*RBACEndpointPermission)
+		if !ok {
+			panic(unexpectedType)
+		}
+		res = append(res, &RBACEndpointPermission{RBACEndpointPermission: *r.DeepCopy()})
+	}
+	return res, nil
+}

--- a/state/rbac_endpoint_permission_test.go
+++ b/state/rbac_endpoint_permission_test.go
@@ -22,19 +22,6 @@ func TestRBACEndpointPermissionsCollection_Add(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "errors when endpoint is nil",
-			args: args{
-				rbacEndpointPermission: RBACEndpointPermission{
-					RBACEndpointPermission: kong.RBACEndpointPermission{
-						Workspace: kong.String("*"),
-						Actions:   kong.StringSlice("read"),
-						Role:      &kong.RBACRole{ID: kong.String("1234")},
-					},
-				},
-			},
-			wantErr: true,
-		},
-		{
 			name: "errors when role is nil",
 			args: args{
 				rbacEndpointPermission: RBACEndpointPermission{
@@ -196,19 +183,6 @@ func TestRBACEndpointPermissionsCollection_Update(t *testing.T) {
 		wantErr                       bool
 		updatedRBACEndpointPermission *RBACEndpointPermission
 	}{
-		{
-			name: "update errors if rbacEndpointPermission.Endpoint is nil",
-			args: args{
-				rbacEndpointPermission: RBACEndpointPermission{
-					RBACEndpointPermission: kong.RBACEndpointPermission{
-						Workspace: kong.String("*"),
-						Actions:   kong.StringSlice("read"),
-						Role:      &kong.RBACRole{ID: kong.String("1234")},
-					},
-				},
-			},
-			wantErr: true,
-		},
 		{
 			name: "update errors if rbacEndpointPermission does not exist",
 			args: args{

--- a/state/rbac_endpoint_permission_test.go
+++ b/state/rbac_endpoint_permission_test.go
@@ -1,0 +1,359 @@
+package state
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kong/go-kong/kong"
+	"github.com/stretchr/testify/assert"
+)
+
+func rbacEndpointPermissionsCollection() *RBACEndpointPermissionsCollection {
+	return state().RBACEndpointPermissions
+}
+
+func TestRBACEndpointPermissionsCollection_Add(t *testing.T) {
+	type args struct {
+		rbacEndpointPermission RBACEndpointPermission
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "errors when endpoint is nil",
+			args: args{
+				rbacEndpointPermission: RBACEndpointPermission{
+					RBACEndpointPermission: kong.RBACEndpointPermission{
+						Workspace: kong.String("*"),
+						Actions:   kong.StringSlice("read"),
+						Role:      &kong.RBACRole{ID: kong.String("1234")},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "errors when role is nil",
+			args: args{
+				rbacEndpointPermission: RBACEndpointPermission{
+					RBACEndpointPermission: kong.RBACEndpointPermission{
+						Workspace: kong.String("*"),
+						Actions:   kong.StringSlice("read"),
+						Endpoint:  kong.String("/foo"),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "inserts without a workspace, endpoint, and role",
+			args: args{
+				rbacEndpointPermission: RBACEndpointPermission{
+					RBACEndpointPermission: kong.RBACEndpointPermission{
+						Workspace: kong.String("*"),
+						Endpoint:  kong.String("/foo"),
+						Actions:   kong.StringSlice("read"),
+						Role:      &kong.RBACRole{ID: kong.String("1234")},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	k := rbacEndpointPermissionsCollection()
+	rbacEndpointPermission1 := RBACEndpointPermission{
+		RBACEndpointPermission: kong.RBACEndpointPermission{
+			Workspace: kong.String("*"),
+			Endpoint:  kong.String("*"),
+			Actions:   kong.StringSlice("read"),
+			Role:      &kong.RBACRole{ID: kong.String("1234")},
+		},
+	}
+	k.Add(rbacEndpointPermission1)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if err := k.Add(tt.args.rbacEndpointPermission); (err != nil) != tt.wantErr {
+				t.Errorf("RBACEndpointPermissionsCollection.Add() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRBACEndpointPermissionsCollection_Get(t *testing.T) {
+	type args struct {
+		nameOrID string
+	}
+	rbacEndpointPermission1 := RBACEndpointPermission{
+		RBACEndpointPermission: kong.RBACEndpointPermission{
+			Workspace: kong.String("*"),
+			Endpoint:  kong.String("/foo"),
+			Actions:   kong.StringSlice("read"),
+			Role:      &kong.RBACRole{ID: kong.String("1234")},
+		},
+	}
+	rbacEndpointPermission2 := RBACEndpointPermission{
+		RBACEndpointPermission: kong.RBACEndpointPermission{
+			Workspace: kong.String("*"),
+			Endpoint:  kong.String("/bar"),
+			Actions:   kong.StringSlice("read"),
+			Role:      &kong.RBACRole{ID: kong.String("1234")},
+		},
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *RBACEndpointPermission
+		wantErr bool
+	}{
+
+		{
+			name: "gets a rbacEndpointPermission by ID",
+			args: args{
+				nameOrID: rbacEndpointPermission1.Identifier(),
+			},
+			want:    &rbacEndpointPermission1,
+			wantErr: false,
+		},
+		{
+			name: "gets a rbacEndpointPermission by Name",
+			args: args{
+				nameOrID: rbacEndpointPermission2.Identifier(),
+			},
+			want:    &rbacEndpointPermission2,
+			wantErr: false,
+		},
+		{
+			name: "returns an ErrNotFound when no rbacEndpointPermission found",
+			args: args{
+				nameOrID: "baz-id",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "returns an error when ID is empty",
+			args: args{
+				nameOrID: "",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	k := rbacEndpointPermissionsCollection()
+	k.Add(rbacEndpointPermission1)
+	k.Add(rbacEndpointPermission2)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := k.Get(tt.args.nameOrID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RBACEndpointPermissionsCollection.Get() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("RBACEndpointPermissionsCollection.Get() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRBACEndpointPermissionsCollection_Update(t *testing.T) {
+	rbacEndpointPermission1 := RBACEndpointPermission{
+		RBACEndpointPermission: kong.RBACEndpointPermission{
+			Workspace: kong.String("*"),
+			Endpoint:  kong.String("/foo"),
+			Actions:   kong.StringSlice("read"),
+			Role:      &kong.RBACRole{ID: kong.String("1234")},
+		},
+	}
+	rbacEndpointPermission2 := RBACEndpointPermission{
+		RBACEndpointPermission: kong.RBACEndpointPermission{
+			Workspace: kong.String("*"),
+			Endpoint:  kong.String("/bar"),
+			Actions:   kong.StringSlice("read"),
+			Role:      &kong.RBACRole{ID: kong.String("1234")},
+		},
+	}
+	rbacEndpointPermission3 := RBACEndpointPermission{
+		RBACEndpointPermission: kong.RBACEndpointPermission{
+			Workspace: kong.String("*"),
+			Endpoint:  kong.String("/foo"),
+			Actions:   kong.StringSlice("read"),
+			Role:      &kong.RBACRole{ID: kong.String("1234")},
+			Comment:   kong.String("updated!"),
+		},
+	}
+	type args struct {
+		rbacEndpointPermission RBACEndpointPermission
+	}
+	tests := []struct {
+		name                          string
+		args                          args
+		wantErr                       bool
+		updatedRBACEndpointPermission *RBACEndpointPermission
+	}{
+		{
+			name: "update errors if rbacEndpointPermission.Endpoint is nil",
+			args: args{
+				rbacEndpointPermission: RBACEndpointPermission{
+					RBACEndpointPermission: kong.RBACEndpointPermission{
+						Workspace: kong.String("*"),
+						Actions:   kong.StringSlice("read"),
+						Role:      &kong.RBACRole{ID: kong.String("1234")},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "update errors if rbacEndpointPermission does not exist",
+			args: args{
+				rbacEndpointPermission: RBACEndpointPermission{
+					RBACEndpointPermission: kong.RBACEndpointPermission{
+						Workspace: kong.String("foo"),
+						Endpoint:  kong.String("bad"),
+						Actions:   kong.StringSlice("read"),
+						Role:      &kong.RBACRole{ID: kong.String("1234")},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "update succeeds when ID is supplied",
+			args: args{
+				rbacEndpointPermission: rbacEndpointPermission3,
+			},
+			wantErr:                       false,
+			updatedRBACEndpointPermission: &rbacEndpointPermission3,
+		},
+	}
+	k := rbacEndpointPermissionsCollection()
+	k.Add(rbacEndpointPermission1)
+	k.Add(rbacEndpointPermission2)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			//t.Parallel()
+			if err := k.Update(tt.args.rbacEndpointPermission); (err != nil) != tt.wantErr {
+				t.Errorf("RBACEndpointPermissionsCollection.Update() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr {
+				got, _ := k.Get(tt.updatedRBACEndpointPermission.Identifier())
+
+				if !reflect.DeepEqual(got, tt.updatedRBACEndpointPermission) {
+					t.Errorf("update rbacEndpointPermission, got = %#v, want %#v", got, tt.updatedRBACEndpointPermission)
+				}
+			}
+		})
+	}
+}
+
+func TestRBACEndpointPermissionDelete(t *testing.T) {
+	assert := assert.New(t)
+	collection := rbacEndpointPermissionsCollection()
+
+	rbacEndpointPermission := RBACEndpointPermission{RBACEndpointPermission: kong.RBACEndpointPermission{
+		Workspace: kong.String("*"),
+		Endpoint:  kong.String("/foo"),
+		Actions:   kong.StringSlice("read"),
+		Role:      &kong.RBACRole{ID: kong.String("1234")},
+	}}
+
+	err := collection.Add(rbacEndpointPermission)
+	assert.Nil(err)
+
+	re, err := collection.Get(rbacEndpointPermission.Identifier())
+	assert.Nil(err)
+	assert.NotNil(re)
+
+	err = collection.Delete(re.Identifier())
+	assert.Nil(err)
+
+	err = collection.Delete(re.Identifier())
+	assert.NotNil(err)
+}
+
+func TestRBACEndpointPermissionGetAll(t *testing.T) {
+	assert := assert.New(t)
+	collection := rbacEndpointPermissionsCollection()
+
+	rbacEndpointPermission := RBACEndpointPermission{RBACEndpointPermission: kong.RBACEndpointPermission{
+		Workspace: kong.String("*"),
+		Endpoint:  kong.String("/first"),
+		Actions:   kong.StringSlice("read"),
+		Role:      &kong.RBACRole{ID: kong.String("1234")},
+	}}
+
+	err := collection.Add(rbacEndpointPermission)
+	assert.Nil(err)
+
+	rbacEndpointPermission2 := RBACEndpointPermission{RBACEndpointPermission: kong.RBACEndpointPermission{
+		Workspace: kong.String("*"),
+		Endpoint:  kong.String("/second"),
+		Actions:   kong.StringSlice("read"),
+		Role:      &kong.RBACRole{ID: kong.String("1234")},
+	}}
+
+	err = collection.Add(rbacEndpointPermission2)
+	assert.Nil(err)
+
+	rbacEndpointPermissions, err := collection.GetAll()
+
+	assert.Nil(err)
+	assert.Equal(2, len(rbacEndpointPermissions))
+}
+
+func TestRBACEndpointPermissionGetAllByServiceID(t *testing.T) {
+	assert := assert.New(t)
+	collection := rbacEndpointPermissionsCollection()
+
+	rbacEndpointPermissions := []*RBACEndpointPermission{
+		{RBACEndpointPermission: kong.RBACEndpointPermission{
+			Workspace: kong.String("*"),
+			Endpoint:  kong.String("/first"),
+			Actions:   kong.StringSlice("read"),
+			Role:      &kong.RBACRole{ID: kong.String("1234")},
+		}},
+		{RBACEndpointPermission: kong.RBACEndpointPermission{
+			Workspace: kong.String("*"),
+			Endpoint:  kong.String("/second"),
+			Actions:   kong.StringSlice("read"),
+			Role:      &kong.RBACRole{ID: kong.String("1234")},
+		}},
+		{RBACEndpointPermission: kong.RBACEndpointPermission{
+			Workspace: kong.String("*"),
+			Endpoint:  kong.String("/third"),
+			Actions:   kong.StringSlice("read"),
+			Role:      &kong.RBACRole{ID: kong.String("1234")},
+		}},
+		{RBACEndpointPermission: kong.RBACEndpointPermission{
+			Workspace: kong.String("*"),
+			Endpoint:  kong.String("/fourth"),
+			Actions:   kong.StringSlice("read"),
+			Role:      &kong.RBACRole{ID: kong.String("4321")},
+		}},
+		{RBACEndpointPermission: kong.RBACEndpointPermission{
+			Workspace: kong.String("*"),
+			Endpoint:  kong.String("/fifth"),
+			Actions:   kong.StringSlice("read"),
+			Role:      &kong.RBACRole{ID: kong.String("4321")},
+		}},
+	}
+
+	for _, rbacEndpointPermission := range rbacEndpointPermissions {
+		err := collection.Add(*rbacEndpointPermission)
+		assert.Nil(err)
+	}
+
+	rbacEndpointPermissions, err := collection.GetAllByRoleID("1234")
+	assert.Nil(err)
+	assert.Equal(3, len(rbacEndpointPermissions))
+
+	rbacEndpointPermissions, err = collection.GetAllByRoleID("4321")
+	assert.Nil(err)
+	assert.Equal(2, len(rbacEndpointPermissions))
+}

--- a/state/rbac_role.go
+++ b/state/rbac_role.go
@@ -20,10 +20,9 @@ var rbacRoleTableSchema = &memdb.TableSchema{
 			Indexer: &memdb.StringFieldIndex{Field: "ID"},
 		},
 		"name": {
-			Name:         "name",
-			Unique:       true,
-			Indexer:      &memdb.StringFieldIndex{Field: "Name"},
-			AllowMissing: true,
+			Name:    "name",
+			Unique:  true,
+			Indexer: &memdb.StringFieldIndex{Field: "Name"},
 		},
 		all: allIndex,
 	},

--- a/state/rbac_role.go
+++ b/state/rbac_role.go
@@ -1,0 +1,176 @@
+package state
+
+import (
+	"fmt"
+
+	memdb "github.com/hashicorp/go-memdb"
+	"github.com/kong/deck/utils"
+)
+
+const (
+	rbacRoleTableName = "rbac-role"
+)
+
+var rbacRoleTableSchema = &memdb.TableSchema{
+	Name: rbacRoleTableName,
+	Indexes: map[string]*memdb.IndexSchema{
+		"id": {
+			Name:    "id",
+			Unique:  true,
+			Indexer: &memdb.StringFieldIndex{Field: "ID"},
+		},
+		"name": {
+			Name:         "name",
+			Unique:       true,
+			Indexer:      &memdb.StringFieldIndex{Field: "Name"},
+			AllowMissing: true,
+		},
+		all: allIndex,
+	},
+}
+
+// RBACRolesCollection stores and indexes Kong RBACRoles.
+type RBACRolesCollection collection
+
+// Add adds a rbacRole into RBACRolesCollection
+// rbacRole.ID should not be nil else an error is thrown.
+func (k *RBACRolesCollection) Add(rbacRole RBACRole) error {
+	// TODO abstract this check in the go-memdb library itself
+	if utils.Empty(rbacRole.ID) {
+		return errIDRequired
+	}
+
+	txn := k.db.Txn(true)
+	defer txn.Abort()
+
+	var searchBy []string
+	searchBy = append(searchBy, *rbacRole.ID)
+	if !utils.Empty(rbacRole.Name) {
+		searchBy = append(searchBy, *rbacRole.Name)
+	}
+	_, err := getRBACRole(txn, searchBy...)
+	if err == nil {
+		return fmt.Errorf("inserting rbacRole %v: %w", rbacRole.Console(), ErrAlreadyExists)
+	} else if err != ErrNotFound {
+		return err
+	}
+
+	err = txn.Insert(rbacRoleTableName, &rbacRole)
+	if err != nil {
+		return err
+	}
+	txn.Commit()
+	return nil
+}
+
+func getRBACRole(txn *memdb.Txn, IDs ...string) (*RBACRole, error) {
+	for _, id := range IDs {
+		res, err := multiIndexLookupUsingTxn(txn, rbacRoleTableName,
+			[]string{"name", "id"}, id)
+		if err == ErrNotFound {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		rbacRole, ok := res.(*RBACRole)
+		if !ok {
+			panic(unexpectedType)
+		}
+		return &RBACRole{RBACRole: *rbacRole.DeepCopy()}, nil
+	}
+	return nil, ErrNotFound
+}
+
+// Get gets a rbacRole by name or ID.
+func (k *RBACRolesCollection) Get(nameOrID string) (*RBACRole, error) {
+	if nameOrID == "" {
+		return nil, errIDRequired
+	}
+
+	txn := k.db.Txn(false)
+	defer txn.Abort()
+	rbacRole, err := getRBACRole(txn, nameOrID)
+	if err != nil {
+		return nil, err
+	}
+	return rbacRole, nil
+}
+
+// Update updates a rbacRole
+func (k *RBACRolesCollection) Update(rbacRole RBACRole) error {
+	// TODO abstract this check in the go-memdb library itself
+	if utils.Empty(rbacRole.ID) {
+		return errIDRequired
+	}
+
+	txn := k.db.Txn(true)
+	defer txn.Abort()
+
+	err := deleteRBACRole(txn, *rbacRole.ID)
+	if err != nil {
+		return err
+	}
+
+	err = txn.Insert(rbacRoleTableName, &rbacRole)
+	if err != nil {
+		return err
+	}
+
+	txn.Commit()
+	return nil
+}
+
+func deleteRBACRole(txn *memdb.Txn, nameOrID string) error {
+	rbacRole, err := getRBACRole(txn, nameOrID)
+	if err != nil {
+		return err
+	}
+
+	err = txn.Delete(rbacRoleTableName, rbacRole)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Delete deletes a rbacRole by name or ID.
+func (k *RBACRolesCollection) Delete(nameOrID string) error {
+	if nameOrID == "" {
+		return errIDRequired
+	}
+
+	txn := k.db.Txn(true)
+	defer txn.Abort()
+
+	err := deleteRBACRole(txn, nameOrID)
+	if err != nil {
+		return err
+	}
+
+	txn.Commit()
+	return nil
+}
+
+// GetAll gets a rbacRole by name or ID.
+func (k *RBACRolesCollection) GetAll() ([]*RBACRole, error) {
+	txn := k.db.Txn(false)
+	defer txn.Abort()
+
+	iter, err := txn.Get(rbacRoleTableName, all, true)
+	if err != nil {
+		return nil, err
+	}
+
+	var res []*RBACRole
+	for el := iter.Next(); el != nil; el = iter.Next() {
+		r, ok := el.(*RBACRole)
+		if !ok {
+			panic(unexpectedType)
+		}
+		res = append(res, &RBACRole{RBACRole: *r.DeepCopy()})
+	}
+	txn.Commit()
+	return res, nil
+}

--- a/state/rbac_role_test.go
+++ b/state/rbac_role_test.go
@@ -33,7 +33,7 @@ func TestRBACRolesCollection_Add(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "inserts without a name",
+			name: "errors without a name",
 			args: args{
 				rbacRole: RBACRole{
 					RBACRole: kong.RBACRole{
@@ -41,7 +41,7 @@ func TestRBACRolesCollection_Add(t *testing.T) {
 					},
 				},
 			},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "inserts with a name and ID",
@@ -175,7 +175,8 @@ func TestRBACRolesCollection_Get(t *testing.T) {
 func TestRBACRolesCollection_Update(t *testing.T) {
 	rbacRole1 := RBACRole{
 		RBACRole: kong.RBACRole{
-			ID: kong.String("foo-id"),
+			ID:   kong.String("foo-id"),
+			Name: kong.String("foo-name"),
 		},
 	}
 	rbacRole2 := RBACRole{
@@ -187,7 +188,7 @@ func TestRBACRolesCollection_Update(t *testing.T) {
 	rbacRole3 := RBACRole{
 		RBACRole: kong.RBACRole{
 			ID:   kong.String("foo-id"),
-			Name: kong.String("name"),
+			Name: kong.String("foo-new-name"),
 		},
 	}
 	type args struct {

--- a/state/rbac_role_test.go
+++ b/state/rbac_role_test.go
@@ -1,0 +1,297 @@
+package state
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kong/go-kong/kong"
+	"github.com/stretchr/testify/assert"
+)
+
+func rbacRolesCollection() *RBACRolesCollection {
+	return state().RBACRoles
+}
+
+func TestRBACRolesCollection_Add(t *testing.T) {
+	type args struct {
+		rbacRole RBACRole
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "errors when ID is nil",
+			args: args{
+				rbacRole: RBACRole{
+					RBACRole: kong.RBACRole{
+						Name: kong.String("foo"),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "inserts without a name",
+			args: args{
+				rbacRole: RBACRole{
+					RBACRole: kong.RBACRole{
+						ID: kong.String("id1"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "inserts with a name and ID",
+			args: args{
+				rbacRole: RBACRole{
+					RBACRole: kong.RBACRole{
+						ID:   kong.String("id2"),
+						Name: kong.String("bar-name"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "errors on re-insert when name is present",
+			args: args{
+				rbacRole: RBACRole{
+					RBACRole: kong.RBACRole{
+						ID:   kong.String("id4"),
+						Name: kong.String("foo-name"),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "errors on re-insert when id is present",
+			args: args{
+				rbacRole: RBACRole{
+					RBACRole: kong.RBACRole{
+						ID:   kong.String("id3"),
+						Name: kong.String("foobar-name"),
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	k := rbacRolesCollection()
+	rbacRole1 := RBACRole{
+		RBACRole: kong.RBACRole{
+			ID:   kong.String("id3"),
+			Name: kong.String("foo-name"),
+		},
+	}
+	k.Add(rbacRole1)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if err := k.Add(tt.args.rbacRole); (err != nil) != tt.wantErr {
+				t.Errorf("RBACRolesCollection.Add() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRBACRolesCollection_Get(t *testing.T) {
+	type args struct {
+		nameOrID string
+	}
+	rbacRole1 := RBACRole{
+		RBACRole: kong.RBACRole{
+			ID: kong.String("foo-id"),
+		},
+	}
+	rbacRole2 := RBACRole{
+		RBACRole: kong.RBACRole{
+			ID:   kong.String("bar-id"),
+			Name: kong.String("bar-name"),
+		},
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *RBACRole
+		wantErr bool
+	}{
+
+		{
+			name: "gets a rbacRole by ID",
+			args: args{
+				nameOrID: "foo-id",
+			},
+			want:    &rbacRole1,
+			wantErr: false,
+		},
+		{
+			name: "gets a rbacRole by Name",
+			args: args{
+				nameOrID: "bar-name",
+			},
+			want:    &rbacRole2,
+			wantErr: false,
+		},
+		{
+			name: "returns an ErrNotFound when no rbacRole found",
+			args: args{
+				nameOrID: "baz-id",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "returns an error when ID is empty",
+			args: args{
+				nameOrID: "",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	k := rbacRolesCollection()
+	k.Add(rbacRole1)
+	k.Add(rbacRole2)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := k.Get(tt.args.nameOrID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RBACRolesCollection.Get() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("RBACRolesCollection.Get() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRBACRolesCollection_Update(t *testing.T) {
+	rbacRole1 := RBACRole{
+		RBACRole: kong.RBACRole{
+			ID: kong.String("foo-id"),
+		},
+	}
+	rbacRole2 := RBACRole{
+		RBACRole: kong.RBACRole{
+			ID:   kong.String("bar-id"),
+			Name: kong.String("bar-name"),
+		},
+	}
+	rbacRole3 := RBACRole{
+		RBACRole: kong.RBACRole{
+			ID:   kong.String("foo-id"),
+			Name: kong.String("name"),
+		},
+	}
+	type args struct {
+		rbacRole RBACRole
+	}
+	tests := []struct {
+		name            string
+		args            args
+		wantErr         bool
+		updatedRBACRole *RBACRole
+	}{
+		{
+			name: "update errors if rbacRole.ID is nil",
+			args: args{
+				rbacRole: RBACRole{
+					RBACRole: kong.RBACRole{
+						Name: kong.String("name"),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "update errors if rbacRole does not exist",
+			args: args{
+				rbacRole: RBACRole{
+					RBACRole: kong.RBACRole{
+						ID: kong.String("does-not-exist"),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "update succeeds when ID is supplied",
+			args: args{
+				rbacRole: rbacRole3,
+			},
+			wantErr:         false,
+			updatedRBACRole: &rbacRole3,
+		},
+	}
+	k := rbacRolesCollection()
+	k.Add(rbacRole1)
+	k.Add(rbacRole2)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			//t.Parallel()
+			if err := k.Update(tt.args.rbacRole); (err != nil) != tt.wantErr {
+				t.Errorf("RBACRolesCollection.Update() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr {
+				got, _ := k.Get(*tt.updatedRBACRole.ID)
+
+				if !reflect.DeepEqual(got, tt.updatedRBACRole) {
+					t.Errorf("update rbacRole, got = %#v, want %#v", got, tt.updatedRBACRole)
+				}
+			}
+		})
+	}
+}
+
+func TestRBACRoleDelete(t *testing.T) {
+	assert := assert.New(t)
+	collection := rbacRolesCollection()
+
+	var rbacRole RBACRole
+	rbacRole.Name = kong.String("my-rbacRole")
+	rbacRole.ID = kong.String("first")
+
+	err := collection.Add(rbacRole)
+	assert.Nil(err)
+
+	re, err := collection.Get("my-rbacRole")
+	assert.Nil(err)
+	assert.NotNil(re)
+
+	err = collection.Delete(*re.ID)
+	assert.Nil(err)
+
+	err = collection.Delete(*re.ID)
+	assert.NotNil(err)
+}
+
+func TestRBACRoleGetAll(t *testing.T) {
+	assert := assert.New(t)
+	collection := rbacRolesCollection()
+
+	var rbacRole RBACRole
+	rbacRole.Name = kong.String("my-rbacRole1")
+	rbacRole.ID = kong.String("first")
+
+	err := collection.Add(rbacRole)
+	assert.Nil(err)
+
+	var rbacRole2 RBACRole
+	rbacRole2.Name = kong.String("my-rbacRole2")
+	rbacRole2.ID = kong.String("second")
+
+	err = collection.Add(rbacRole2)
+	assert.Nil(err)
+
+	rbacRoles, err := collection.GetAll()
+
+	assert.Nil(err)
+	assert.Equal(2, len(rbacRoles))
+}

--- a/state/state.go
+++ b/state/state.go
@@ -23,13 +23,15 @@ type KongState struct {
 	Plugins        *PluginsCollection
 	Consumers      *ConsumersCollection
 
-	KeyAuths    *KeyAuthsCollection
-	HMACAuths   *HMACAuthsCollection
-	JWTAuths    *JWTAuthsCollection
-	BasicAuths  *BasicAuthsCollection
-	ACLGroups   *ACLGroupsCollection
-	Oauth2Creds *Oauth2CredsCollection
-	MTLSAuths   *MTLSAuthsCollection
+	KeyAuths                *KeyAuthsCollection
+	HMACAuths               *HMACAuthsCollection
+	JWTAuths                *JWTAuthsCollection
+	BasicAuths              *BasicAuthsCollection
+	ACLGroups               *ACLGroupsCollection
+	Oauth2Creds             *Oauth2CredsCollection
+	MTLSAuths               *MTLSAuthsCollection
+	RBACRoles               *RBACRolesCollection
+	RBACEndpointPermissions *RBACEndpointPermissionsCollection
 }
 
 // NewKongState creates a new in-memory KongState.
@@ -45,15 +47,17 @@ func NewKongState() (*KongState, error) {
 
 	var schema = &memdb.DBSchema{
 		Tables: map[string]*memdb.TableSchema{
-			serviceTableName:     serviceTableSchema,
-			routeTableName:       routeTableSchema,
-			upstreamTableName:    upstreamTableSchema,
-			targetTableName:      targetTableSchema,
-			certificateTableName: certificateTableSchema,
-			sniTableName:         sniTableSchema,
-			caCertTableName:      caCertTableSchema,
-			pluginTableName:      pluginTableSchema,
-			consumerTableName:    consumerTableSchema,
+			serviceTableName:                serviceTableSchema,
+			routeTableName:                  routeTableSchema,
+			upstreamTableName:               upstreamTableSchema,
+			targetTableName:                 targetTableSchema,
+			certificateTableName:            certificateTableSchema,
+			sniTableName:                    sniTableSchema,
+			caCertTableName:                 caCertTableSchema,
+			pluginTableName:                 pluginTableSchema,
+			consumerTableName:               consumerTableSchema,
+			rbacRoleTableName:               rbacRoleTableSchema,
+			rbacEndpointPermissionTableName: rbacEndpointPermissionTableSchema,
 
 			keyAuthTemp.TableName():     keyAuthTemp.Schema(),
 			hmacAuthTemp.TableName():    hmacAuthTemp.Schema(),
@@ -84,6 +88,8 @@ func NewKongState() (*KongState, error) {
 	state.CACertificates = (*CACertificatesCollection)(&state.common)
 	state.Plugins = (*PluginsCollection)(&state.common)
 	state.Consumers = (*ConsumersCollection)(&state.common)
+	state.RBACRoles = (*RBACRolesCollection)(&state.common)
+	state.RBACEndpointPermissions = (*RBACEndpointPermissionsCollection)(&state.common)
 
 	state.KeyAuths = newKeyAuthsCollection(state.common)
 	state.HMACAuths = newHMACAuthsCollection(state.common)

--- a/state/types.go
+++ b/state/types.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"fmt"
 	"reflect"
 	"sort"
 
@@ -1028,6 +1029,101 @@ func (b1 *MTLSAuth) EqualWithOpts(b2 *MTLSAuth, ignoreID,
 		b2Copy.Consumer = nil
 	}
 	return reflect.DeepEqual(b1Copy, b2Copy)
+}
+
+// RBACRole represents an RBAC Role in Kong.
+// It adds some helper methods along with Meta to the original RBACRole object.
+type RBACRole struct {
+	kong.RBACRole `yaml:",inline"`
+	Meta
+}
+
+// Identifier returns the endpoint key name or ID.
+func (r1 *RBACRole) Identifier() string {
+	if r1.Name != nil {
+		return *r1.Name
+	}
+	return *r1.ID
+}
+
+// Console returns an entity's identity in a human
+// readable string.
+func (r1 *RBACRole) Console() string {
+	return r1.Identifier()
+}
+
+// Equal returns true if r1 and r2 are equal.
+// TODO add compare array without position
+func (r1 *RBACRole) Equal(r2 *RBACRole) bool {
+	return r1.EqualWithOpts(r2, false, false, false)
+}
+
+// EqualWithOpts returns true if r1 and r2 are equal.
+// If ignoreID is set to true, IDs will be ignored while comparison.
+// If ignoreTS is set to true, timestamp fields will be ignored.
+func (r1 *RBACRole) EqualWithOpts(r2 *RBACRole, ignoreID,
+	ignoreTS, ignoreForeign bool) bool {
+	r1Copy := r1.RBACRole.DeepCopy()
+	r2Copy := r2.RBACRole.DeepCopy()
+
+	if ignoreID {
+		r1Copy.ID = nil
+		r2Copy.ID = nil
+	}
+	if ignoreTS {
+		r1Copy.CreatedAt = nil
+		r2Copy.CreatedAt = nil
+	}
+
+	return reflect.DeepEqual(r1Copy, r2Copy)
+}
+
+// RBACEndpointPermission represents an RBAC Role in Kong.
+// It adds some helper methods along with Meta to the original RBACEndpointPermission object.
+type RBACEndpointPermission struct {
+	ID                          string
+	kong.RBACEndpointPermission `yaml:",inline"`
+	Meta
+}
+
+// Identifier returns a composite ID base on Role ID, workspace, and endpoint
+func (r1 *RBACEndpointPermission) Identifier() string {
+	if r1.Endpoint != nil {
+		return fmt.Sprintf("%s-%s-%s", *r1.Role.ID, *r1.Workspace, *r1.Endpoint)
+	}
+	return *r1.Endpoint
+}
+
+// Console returns an entity's identity in a human
+// readable string.
+func (r1 *RBACEndpointPermission) Console() string {
+	return r1.Identifier()
+}
+
+// Equal returns true if r1 and r2 are equal.
+// TODO add compare array without position
+func (r1 *RBACEndpointPermission) Equal(r2 *RBACEndpointPermission) bool {
+	return r1.EqualWithOpts(r2, false, false, false)
+}
+
+// EqualWithOpts returns true if r1 and r2 are equal.
+// If ignoreID is set to true, IDs will be ignored while comparison.
+// If ignoreTS is set to true, timestamp fields will be ignored.
+func (r1 *RBACEndpointPermission) EqualWithOpts(r2 *RBACEndpointPermission, ignoreID,
+	ignoreTS, ignoreForeign bool) bool {
+	r1Copy := r1.RBACEndpointPermission.DeepCopy()
+	r2Copy := r2.RBACEndpointPermission.DeepCopy()
+
+	if ignoreID {
+		r1Copy.Endpoint = nil
+		r2Copy.Endpoint = nil
+	}
+	if ignoreTS {
+		r1Copy.CreatedAt = nil
+		r2Copy.CreatedAt = nil
+	}
+
+	return reflect.DeepEqual(r1Copy, r2Copy)
 }
 
 // GetID returns ID.

--- a/utils/types.go
+++ b/utils/types.go
@@ -41,6 +41,9 @@ type KongRawState struct {
 	ACLGroups   []*kong.ACLGroup
 	Oauth2Creds []*kong.Oauth2Credential
 	MTLSAuths   []*kong.MTLSAuth
+
+	RBACRoles               []*kong.RBACRole
+	RBACEndpointPermissions []*kong.RBACEndpointPermission
 }
 
 // ErrArray holds an array of errors.


### PR DESCRIPTION
This takes the patch from #271 and adds in some machinery to avoid any potential breakage for existing users.
Please see https://github.com/Kong/deck/pull/271#issuecomment-785917323 for reasoning behind additional commits on top of the initial patch.
Please review commit-by-commit.

Fix #270