### PR TITLE
Address missing functionality in Enterprise RBAC PR

### DIFF
--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -135,4 +135,6 @@ func init() {
 		"select-tag", []string{},
 		"only entities matching tags specified via this flag are deleted.\n"+
 			"Multiple tags are ANDed together.")
+	resetCmd.Flags().BoolVar(&dumpConfig.RBACResourcesOnly, "rbac-resources-only",
+		false, "sync only the RBAC resources (Kong Enterprise only)")
 }

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -136,5 +136,5 @@ func init() {
 		"only entities matching tags specified via this flag are deleted.\n"+
 			"Multiple tags are ANDed together.")
 	resetCmd.Flags().BoolVar(&dumpConfig.RBACResourcesOnly, "rbac-resources-only",
-		false, "sync only the RBAC resources (Kong Enterprise only)")
+		false, "reset only the RBAC resources (Kong Enterprise only)")
 }

--- a/file/codegen/main.go
+++ b/file/codegen/main.go
@@ -98,6 +98,10 @@ func main() {
 		"client_id", "redirect_uris", "client_secret"}
 	schema.Definitions["MTLSAuth"].Required = []string{"id", "subject_name"}
 
+	// RBAC resources
+	schema.Definitions["FRBACRole"].Required = []string{"name"}
+	schema.Definitions["FRBACEndpointPermission"].Required = []string{"workspace", "endpoint"}
+
 	// Foreign references
 	stringType := &jsonschema.Type{Type: "string"}
 	schema.Definitions["FPlugin"].Properties["consumer"] = stringType

--- a/file/schema.go
+++ b/file/schema.go
@@ -478,6 +478,10 @@ const contentSchema = `{
       "type": "object"
     },
     "FRBACEndpointPermission": {
+      "required": [
+        "workspace",
+        "endpoint"
+      ],
       "properties": {
         "actions": {
           "items": {
@@ -509,6 +513,9 @@ const contentSchema = `{
       "type": "object"
     },
     "FRBACRole": {
+      "required": [
+        "name"
+      ],
       "properties": {
         "comment": {
           "type": "string"

--- a/reset/reset.go
+++ b/reset/reset.go
@@ -96,6 +96,14 @@ func Reset(state *utils.KongRawState, client *kong.Client) error {
 		}
 	}
 
+	// Deleting RBAC roles also deletes their associated permissions
+	for _, r := range state.RBACRoles {
+		err := client.RBACRoles.Delete(nil, r.ID)
+		if err != nil {
+			return err
+		}
+	}
+
 	// TODO handle custom entities
 	return nil
 }

--- a/solver/rbac_endpoint_permission.go
+++ b/solver/rbac_endpoint_permission.go
@@ -12,7 +12,7 @@ type rbacEndpointPermissionCRUD struct {
 	client *kong.Client
 }
 
-func rbacEndpointPermissionFromStuct(arg diff.Event) *state.RBACEndpointPermission {
+func rbacEndpointPermissionFromStruct(arg diff.Event) *state.RBACEndpointPermission {
 	ep, ok := arg.Obj.(*state.RBACEndpointPermission)
 	if !ok {
 		panic("unexpected type, expected *state.RBACEndpointPermission")
@@ -27,7 +27,7 @@ func rbacEndpointPermissionFromStuct(arg diff.Event) *state.RBACEndpointPermissi
 // It returns a the created *state.RBACEndpointPermission.
 func (s *rbacEndpointPermissionCRUD) Create(arg ...crud.Arg) (crud.Arg, error) {
 	event := eventFromArg(arg[0])
-	ep := rbacEndpointPermissionFromStuct(event)
+	ep := rbacEndpointPermissionFromStruct(event)
 	createdRBACEndpointPermission, err := s.client.RBACEndpointPermissions.Create(nil, &ep.RBACEndpointPermission)
 	if err != nil {
 		return nil, err
@@ -41,7 +41,7 @@ func (s *rbacEndpointPermissionCRUD) Create(arg ...crud.Arg) (crud.Arg, error) {
 // It returns a the deleted *state.RBACEndpointPermission.
 func (s *rbacEndpointPermissionCRUD) Delete(arg ...crud.Arg) (crud.Arg, error) {
 	event := eventFromArg(arg[0])
-	ep := rbacEndpointPermissionFromStuct(event)
+	ep := rbacEndpointPermissionFromStruct(event)
 	err := s.client.RBACEndpointPermissions.Delete(nil, ep.Role.ID, ep.Workspace, ep.Endpoint)
 	if err != nil {
 		return nil, err
@@ -55,7 +55,7 @@ func (s *rbacEndpointPermissionCRUD) Delete(arg ...crud.Arg) (crud.Arg, error) {
 // It returns a the updated *state.RBACEndpointPermission.
 func (s *rbacEndpointPermissionCRUD) Update(arg ...crud.Arg) (crud.Arg, error) {
 	event := eventFromArg(arg[0])
-	ep := rbacEndpointPermissionFromStuct(event)
+	ep := rbacEndpointPermissionFromStruct(event)
 
 	updatedRBACEndpointPermission, err := s.client.RBACEndpointPermissions.Update(nil, &ep.RBACEndpointPermission)
 	if err != nil {

--- a/state/rbac_endpoint_permission.go
+++ b/state/rbac_endpoint_permission.go
@@ -15,8 +15,6 @@ const (
 )
 
 var errInvalidRole = errors.New("role.ID is required in rbacEndpointPermission")
-var errEndpointRequired = errors.New("endpoint is required in rbacEndpointPermission")
-var errWorkspaceRequired = errors.New("workspace is required in rbacEndpointPermission")
 var rbacEndpointPermissionTableSchema = &memdb.TableSchema{
 	Name: rbacEndpointPermissionTableName,
 	Indexes: map[string]*memdb.IndexSchema{
@@ -56,15 +54,6 @@ type RBACEndpointPermissionsCollection collection
 // Add adds a rbacEndpointPermission into RBACEndpointPermissionsCollection
 // rbacEndpointPermission.Endpoint should not be nil else an error is thrown.
 func (k *RBACEndpointPermissionsCollection) Add(rbacEndpointPermission RBACEndpointPermission) error {
-	// TODO abstract this check in the go-memdb library itself
-	if utils.Empty(rbacEndpointPermission.Endpoint) {
-		return errEndpointRequired
-	}
-
-	if utils.Empty(rbacEndpointPermission.Workspace) {
-		return errWorkspaceRequired
-	}
-
 	if err := validateRoleForRBACEndpointPermission(&rbacEndpointPermission); err != nil {
 		return err
 	}
@@ -126,12 +115,6 @@ func (k *RBACEndpointPermissionsCollection) Get(nameOrID string) (*RBACEndpointP
 
 // Update updates a rbacEndpointPermission
 func (k *RBACEndpointPermissionsCollection) Update(rbacEndpointPermission RBACEndpointPermission) error {
-	if utils.Empty(rbacEndpointPermission.Endpoint) {
-		return errEndpointRequired
-	}
-	if utils.Empty(rbacEndpointPermission.Workspace) {
-		return errWorkspaceRequired
-	}
 	txn := k.db.Txn(true)
 	defer txn.Abort()
 

--- a/state/rbac_endpoint_permission.go
+++ b/state/rbac_endpoint_permission.go
@@ -16,6 +16,7 @@ const (
 
 var errInvalidRole = errors.New("role.ID is required in rbacEndpointPermission")
 var errEndpointRequired = errors.New("endpoint is required in rbacEndpointPermission")
+var errWorkspaceRequired = errors.New("workspace is required in rbacEndpointPermission")
 var rbacEndpointPermissionTableSchema = &memdb.TableSchema{
 	Name: rbacEndpointPermissionTableName,
 	Indexes: map[string]*memdb.IndexSchema{
@@ -58,6 +59,10 @@ func (k *RBACEndpointPermissionsCollection) Add(rbacEndpointPermission RBACEndpo
 	// TODO abstract this check in the go-memdb library itself
 	if utils.Empty(rbacEndpointPermission.Endpoint) {
 		return errEndpointRequired
+	}
+
+	if utils.Empty(rbacEndpointPermission.Workspace) {
+		return errWorkspaceRequired
 	}
 
 	if err := validateRoleForRBACEndpointPermission(&rbacEndpointPermission); err != nil {
@@ -123,6 +128,9 @@ func (k *RBACEndpointPermissionsCollection) Get(nameOrID string) (*RBACEndpointP
 func (k *RBACEndpointPermissionsCollection) Update(rbacEndpointPermission RBACEndpointPermission) error {
 	if utils.Empty(rbacEndpointPermission.Endpoint) {
 		return errEndpointRequired
+	}
+	if utils.Empty(rbacEndpointPermission.Workspace) {
+		return errWorkspaceRequired
 	}
 	txn := k.db.Txn(true)
 	defer txn.Abort()

--- a/state/rbac_endpoint_permission_test.go
+++ b/state/rbac_endpoint_permission_test.go
@@ -22,19 +22,6 @@ func TestRBACEndpointPermissionsCollection_Add(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "errors when endpoint is nil",
-			args: args{
-				rbacEndpointPermission: RBACEndpointPermission{
-					RBACEndpointPermission: kong.RBACEndpointPermission{
-						Workspace: kong.String("*"),
-						Actions:   kong.StringSlice("read"),
-						Role:      &kong.RBACRole{ID: kong.String("1234")},
-					},
-				},
-			},
-			wantErr: true,
-		},
-		{
 			name: "errors when role is nil",
 			args: args{
 				rbacEndpointPermission: RBACEndpointPermission{
@@ -42,18 +29,6 @@ func TestRBACEndpointPermissionsCollection_Add(t *testing.T) {
 						Workspace: kong.String("*"),
 						Actions:   kong.StringSlice("read"),
 						Endpoint:  kong.String("/foo"),
-					},
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "errors when workspace is nil",
-			args: args{
-				rbacEndpointPermission: RBACEndpointPermission{
-					RBACEndpointPermission: kong.RBACEndpointPermission{
-						Actions:  kong.StringSlice("read"),
-						Endpoint: kong.String("/foo"),
 					},
 				},
 			},
@@ -208,19 +183,6 @@ func TestRBACEndpointPermissionsCollection_Update(t *testing.T) {
 		wantErr                       bool
 		updatedRBACEndpointPermission *RBACEndpointPermission
 	}{
-		{
-			name: "update errors if rbacEndpointPermission.Endpoint is nil",
-			args: args{
-				rbacEndpointPermission: RBACEndpointPermission{
-					RBACEndpointPermission: kong.RBACEndpointPermission{
-						Workspace: kong.String("*"),
-						Actions:   kong.StringSlice("read"),
-						Role:      &kong.RBACRole{ID: kong.String("1234")},
-					},
-				},
-			},
-			wantErr: true,
-		},
 		{
 			name: "update errors if rbacEndpointPermission does not exist",
 			args: args{

--- a/state/rbac_endpoint_permission_test.go
+++ b/state/rbac_endpoint_permission_test.go
@@ -48,6 +48,18 @@ func TestRBACEndpointPermissionsCollection_Add(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "errors when workspace is nil",
+			args: args{
+				rbacEndpointPermission: RBACEndpointPermission{
+					RBACEndpointPermission: kong.RBACEndpointPermission{
+						Actions:  kong.StringSlice("read"),
+						Endpoint: kong.String("/foo"),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "inserts without a workspace, endpoint, and role",
 			args: args{
 				rbacEndpointPermission: RBACEndpointPermission{


### PR DESCRIPTION
Addresses two issues found during testing for #276:

- Adds `--rbac-resources-only` support to `deck reset`.
- Rejects endpoint permissions with no workspace.