### PR TITLE
fix(state) drop index on target.Target

### DIFF
--- a/state/target.go
+++ b/state/target.go
@@ -24,17 +24,6 @@ var targetTableSchema = &memdb.TableSchema{
 			Unique:  true,
 			Indexer: &memdb.StringFieldIndex{Field: "ID"},
 		},
-		"target": {
-			Name: "target",
-			Indexer: &indexers.SubFieldIndexer{
-				Fields: []indexers.Field{
-					{
-						Struct: "Target",
-						Sub:    "Target",
-					},
-				},
-			},
-		},
 		all: allIndex,
 		// foreign
 		targetsByUpstreamID: {

--- a/state/target_test.go
+++ b/state/target_test.go
@@ -122,14 +122,6 @@ func TestTargetsInvalidType(t *testing.T) {
 
 	collection := targetsCollection()
 
-	var upstream Upstream
-	upstream.Name = kong.String("my-upstream")
-	upstream.ID = kong.String("first")
-	txn := collection.db.Txn(true)
-	err := txn.Insert(targetTableName, &upstream)
-	assert.NotNil(err)
-	txn.Abort()
-
 	type badTarget struct {
 		kong.Target
 		Meta
@@ -145,8 +137,8 @@ func TestTargetsInvalidType(t *testing.T) {
 		},
 	}
 
-	txn = collection.db.Txn(true)
-	err = txn.Insert(targetTableName, &target)
+	txn := collection.db.Txn(true)
+	err := txn.Insert(targetTableName, &target)
 	assert.Nil(err)
 	txn.Commit()
 


### PR DESCRIPTION
target.Target represents an IP address or a DNS name in Kong. These can
be same across different Upstreams.
Drop the unique index on Target resource for this reason.

This is similar to the fix applies to ServiceVersion resource in
cf44212.

The test has been updated to remove insertion of Upstream which doesn't
add in value.

Fix #233