### PR TITLE
feat(file) implement env var substitution for state files

### DIFF
--- a/file/testdata/bad-env-var/file.yaml
+++ b/file/testdata/bad-env-var/file.yaml
@@ -1,11 +1,9 @@
 services:
 - name: svc2
-  host: ${{ env "DECK_SVC2_HOST" }}
+  host: ${{ env "SVC2_HOST" }}
   routes:
   - name: r2
     paths:
     - /r2
-  tags:
-    - '<'
 plugins:
 - name: prometheus

--- a/file/testdata/file.yaml
+++ b/file/testdata/file.yaml
@@ -6,6 +6,6 @@ services:
     paths:
     - /r2
   tags:
-    - '<'
+    - '<' # verifies that the templating engine does not perform character escaping
 plugins:
 - name: prometheus


### PR DESCRIPTION
Introducing support for envirment variable substitution in state files.
This is primarily intended for injecting sensitive data at runtime.

Fix #191