### PR TITLE
fix(cmd) use separate variables for Konnect flags

### DIFF
--- a/cmd/konnect_diff.go
+++ b/cmd/konnect_diff.go
@@ -4,6 +4,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	konnectDiffCmdKongStateFile   []string
+	konnectDiffCmdParallelism     int
+	konnectDiffCmdNonZeroExitCode bool
+)
+
 // konnectDiffCmd represents the 'deck konnect diff' command.
 var konnectDiffCmd = &cobra.Command{
 	Use:   "diff",
@@ -15,23 +21,23 @@ the entities present in files locally. This allows you to see the entities
 that will be created or updated or deleted.` + konnectAlphaState,
 	Args: validateNoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return syncKonnect(cmd.Context(), diffCmdKongStateFile, true,
-			diffCmdParallelism)
+		return syncKonnect(cmd.Context(), konnectDiffCmdKongStateFile, true,
+			konnectDiffCmdParallelism)
 	},
 }
 
 func init() {
 	konnectCmd.AddCommand(konnectDiffCmd)
-	konnectDiffCmd.Flags().StringSliceVarP(&diffCmdKongStateFile,
+	konnectDiffCmd.Flags().StringSliceVarP(&konnectDiffCmdKongStateFile,
 		"state", "s", []string{"konnect.yaml"}, "file(s) containing Konnect's configuration.\n"+
 			"This flag can be specified multiple times for multiple files.\n"+
 			"Use '-' to read from stdin.")
 	konnectDiffCmd.Flags().BoolVar(&konnectDumpIncludeConsumers, "include-consumers",
 		false, "export consumers, associated credentials and any plugins associated "+
 			"with consumers")
-	konnectDiffCmd.Flags().IntVar(&diffCmdParallelism, "parallelism",
+	konnectDiffCmd.Flags().IntVar(&konnectDiffCmdParallelism, "parallelism",
 		100, "Maximum number of concurrent operations")
-	konnectDiffCmd.Flags().BoolVar(&diffCmdNonZeroExitCode, "non-zero-exit-code",
+	konnectDiffCmd.Flags().BoolVar(&konnectDiffCmdNonZeroExitCode, "non-zero-exit-code",
 		false, "return exit code 2 if there is a diff present,\n"+
 			"exit code 0 if no diff is found,\n"+
 			"and exit code 1 if an error occurs.")

--- a/cmd/konnect_dump.go
+++ b/cmd/konnect_dump.go
@@ -15,6 +15,9 @@ import (
 
 var (
 	konnectDumpIncludeConsumers bool
+	konnectDumpCmdKongStateFile string
+	konnectDumpCmdStateFormat   string
+	konnectDumpWithID           bool
 )
 
 // konnectDumpCmd represents the dump2 command
@@ -65,8 +68,8 @@ configure Konnect.` + konnectAlphaState,
 		}
 
 		if err := file.KonnectStateToFile(ks, file.WriteConfig{
-			Filename:   dumpCmdKongStateFile,
-			FileFormat: file.Format(strings.ToUpper(dumpCmdStateFormat)),
+			Filename:   konnectDumpCmdKongStateFile,
+			FileFormat: file.Format(strings.ToUpper(konnectDumpCmdStateFormat)),
 			WithID:     dumpWithID,
 		}); err != nil {
 			return err
@@ -77,12 +80,12 @@ configure Konnect.` + konnectAlphaState,
 
 func init() {
 	konnectCmd.AddCommand(konnectDumpCmd)
-	konnectDumpCmd.Flags().StringVarP(&dumpCmdKongStateFile, "output-file", "o",
+	konnectDumpCmd.Flags().StringVarP(&konnectDumpCmdKongStateFile, "output-file", "o",
 		"konnect", "file to which to write Kong's configuration."+
 			"Use '-' to write to stdout.")
-	konnectDumpCmd.Flags().StringVar(&dumpCmdStateFormat, "format",
+	konnectDumpCmd.Flags().StringVar(&konnectDumpCmdStateFormat, "format",
 		"yaml", "output file format: json or yaml")
-	konnectDumpCmd.Flags().BoolVar(&dumpWithID, "with-id",
+	konnectDumpCmd.Flags().BoolVar(&konnectDumpWithID, "with-id",
 		false, "write ID of all entities in the output")
 	konnectDumpCmd.Flags().BoolVar(&konnectDumpIncludeConsumers, "include-consumers",
 		false, "export consumers, associated credentials and any plugins associated "+

--- a/cmd/konnect_sync.go
+++ b/cmd/konnect_sync.go
@@ -13,20 +13,20 @@ var konnectSyncCmd = &cobra.Command{
 to get Konnect's state in sync with the input state.` + konnectAlphaState,
 	Args: validateNoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return syncKonnect(cmd.Context(), diffCmdKongStateFile, false,
-			diffCmdParallelism)
+		return syncKonnect(cmd.Context(), konnectDiffCmdKongStateFile, false,
+			konnectDiffCmdParallelism)
 	},
 }
 
 func init() {
 	konnectCmd.AddCommand(konnectSyncCmd)
-	konnectSyncCmd.Flags().StringSliceVarP(&diffCmdKongStateFile,
+	konnectSyncCmd.Flags().StringSliceVarP(&konnectDiffCmdKongStateFile,
 		"state", "s", []string{"konnect.yaml"}, "file(s) containing Konnect's configuration.\n"+
 			"This flag can be specified multiple times for multiple files.\n"+
 			"Use '-' to read from stdin.")
 	konnectSyncCmd.Flags().BoolVar(&konnectDumpIncludeConsumers, "include-consumers",
 		false, "export consumers, associated credentials and any plugins associated "+
 			"with consumers")
-	konnectSyncCmd.Flags().IntVar(&diffCmdParallelism, "parallelism",
+	konnectSyncCmd.Flags().IntVar(&konnectDiffCmdParallelism, "parallelism",
 		100, "Maximum number of concurrent operations")
 }


### PR DESCRIPTION
Use separate variables to store Konnect command flag values where Konnect commands share flags with non-Konnect commands.

Cobra will otherwise update the variable contents with whichever flags it processes last, effectively overriding the non-Konnect defaults with the Konnect defaults.

I don't think anything wants a different default value currently other than the state file, but I think we should define new variables for everything that's not actually being inherited from a parent command for consistency and safety in the event of future changes to one command set's defaults.

Fix #288