### PR TITLE
fix(build) update brew formula for 3.0.8

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,4 +36,4 @@ brews:
   description: Declarative configuration for Kong
   skip_upload: true
   test: |
-      system "#{bin}/deck version"
+      system "#{bin}/deck", "version"


### PR DESCRIPTION
Homebrew 3.0.8 enforces a new restriction on formula commands. They must
be separated into their components to avoid errors like the following:

```
Separate `system` commands into `"#{bin}/deck", "version"`
```
See https://travis-ci.com/github/Kong/homebrew-deck/builds/220979410 for an example failed build.

https://github.com/Homebrew/brew/pull/10873 is the related upstream change.