### PR TITLE
fix(dump) add workaround for free mode mtls-auths

### DIFF
--- a/dump/dump.go
+++ b/dump/dump.go
@@ -674,6 +674,17 @@ func GetAllMTLSAuths(ctx context.Context,
 		if kong.IsNotFoundErr(err) {
 			return mtlsAuths, nil
 		}
+		// TODO figure out a better way to handle unauthorized endpoints
+		// per https://github.com/Kong/deck/issues/274 we can't dump these resources
+		// from an Enterprise instance running in free mode, and the 403 results in a
+		// fatal error when running "deck dump". We don't want to just treat 403s the
+		// same as 404s because Kong also uses them to indicate missing RBAC permissions,
+		// but this is currently necessary for compatibility. We need a better approach
+		// before adding other Enterprise resources that decK handles by default (versus,
+		// for example, RBAC roles, which require the --rbac-resources-only flag).
+		if err.(*kong.APIError).Code() == 403 {
+			return mtlsAuths, nil
+		}
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Treat a 403 on the mtls-auth endpoint the same as a 404. This handles the endpoint's behavior in Enterprise free mode gracefully, whereas previously the dump would fail entirely.

We eventually want a way to properly determine if an instance is in Enterprise free mode and avoid unavailable API calls entirely rather than relying on the return code.

Fix #274