### PR TITLE
fix(dump) address free mode workaround regression

### DIFF
--- a/dump/dump.go
+++ b/dump/dump.go
@@ -660,18 +660,18 @@ func GetAllMTLSAuths(ctx context.Context,
 		if kong.IsNotFoundErr(err) {
 			return mtlsAuths, nil
 		}
-		// TODO figure out a better way to handle unauthorized endpoints
-		// per https://github.com/Kong/deck/issues/274 we can't dump these resources
-		// from an Enterprise instance running in free mode, and the 403 results in a
-		// fatal error when running "deck dump". We don't want to just treat 403s the
-		// same as 404s because Kong also uses them to indicate missing RBAC permissions,
-		// but this is currently necessary for compatibility. We need a better approach
-		// before adding other Enterprise resources that decK handles by default (versus,
-		// for example, RBAC roles, which require the --rbac-resources-only flag).
-		if err.(*kong.APIError).Code() == 403 {
-			return mtlsAuths, nil
-		}
 		if err != nil {
+			// TODO figure out a better way to handle unauthorized endpoints
+			// per https://github.com/Kong/deck/issues/274 we can't dump these resources
+			// from an Enterprise instance running in free mode, and the 403 results in a
+			// fatal error when running "deck dump". We don't want to just treat 403s the
+			// same as 404s because Kong also uses them to indicate missing RBAC permissions,
+			// but this is currently necessary for compatibility. We need a better approach
+			// before adding other Enterprise resources that decK handles by default (versus,
+			// for example, RBAC roles, which require the --rbac-resources-only flag).
+			if err.(*kong.APIError).Code() == 403 {
+				return mtlsAuths, nil
+			}
 			return nil, err
 		}
 		if err := ctx.Err(); err != nil {

--- a/dump/dump.go
+++ b/dump/dump.go
@@ -669,8 +669,10 @@ func GetAllMTLSAuths(ctx context.Context,
 			// but this is currently necessary for compatibility. We need a better approach
 			// before adding other Enterprise resources that decK handles by default (versus,
 			// for example, RBAC roles, which require the --rbac-resources-only flag).
-			if err.(*kong.APIError).Code() == 403 {
-				return mtlsAuths, nil
+			if kongErr, ok := err.(*kong.APIError); ok {
+				if kongErr.Code() == 403 {
+					return mtlsAuths, nil
+				}
 			}
 			return nil, err
 		}


### PR DESCRIPTION
I goofed checking 8254879 and only confirmed the negative case :facepalm: 

We don't want this to happen if the mTLS auth credentials endpoint _is_ available:

```
$ /tmp/main-deck dump -o main.yaml
panic: interface conversion: error is nil, not *kong.APIError

goroutine 36 [running]:
github.com/kong/deck/dump.GetAllMTLSAuths(0xc80cb8, 0xc000139240, 0xc000172400, 0xf592b0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/traines/src/deck/dump/dump.go:671 +0x5b5
github.com/kong/deck/dump.getConsumerConfiguration.func8(0x0, 0x0)
	/home/traines/src/deck/dump/dump.go:128 +0xef
golang.org/x/sync/errgroup.(*Group).Go.func1(0xc0001dd2c0, 0xc000142f50)
	/home/traines/go/pkg/mod/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9/errgroup/errgroup.go:57 +0x85
created by golang.org/x/sync/errgroup.(*Group).Go
	/home/traines/go/pkg/mod/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9/errgroup/errgroup.go:54 +0x6b
10:16:08-0700 yagody $ /tmp/329-deck dump -o 329.yaml
panic: interface conversion: error is nil, not *kong.APIError
```