### PR TITLE
fix: default value miss in route & upstream resource

### DIFF
--- a/utils/constants.go
+++ b/utils/constants.go
@@ -23,6 +23,7 @@ var (
 		RegexPriority: kong.Int(0),
 		StripPath:     kong.Bool(false),
 		Protocols:     kong.StringSlice("http", "https"),
+		PathHandling:	 kong.String("v1"),
 	}
 	targetDefaults = kong.Target{
 		Weight: kong.Int(defaultWeight),
@@ -47,6 +48,7 @@ var (
 					Interval:     kong.Int(0),
 					HTTPStatuses: []int{429, 404, 500, 501, 502, 503, 504, 505},
 				},
+				HTTPSVerifyCertificate:	kong.Bool(true),
 			},
 			Passive: &kong.PassiveHealthcheck{
 				Healthy: &kong.Healthy{


### PR DESCRIPTION
add default value for PathHandling in route and HTTPSVerifyCertificate in upstream. 
to fix https://github.com/Kong/kubernetes-ingress-controller/issues/1212