### PR TITLE
fix:default value miss in route & upstream

### DIFF
--- a/file/builder_test.go
+++ b/file/builder_test.go
@@ -395,6 +395,7 @@ func Test_stateBuilder_ingestRoute(t *testing.T) {
 						ID:            kong.String("538c7f96-b164-4f1b-97bb-9f4bb472e89f"),
 						Name:          kong.String("foo"),
 						PreserveHost:  kong.Bool(false),
+						PathHandling:  kong.String("v1"),
 						RegexPriority: kong.Int(0),
 						StripPath:     kong.Bool(false),
 						Protocols:     kong.StringSlice("http", "https"),
@@ -421,6 +422,7 @@ func Test_stateBuilder_ingestRoute(t *testing.T) {
 						ID:            kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						Name:          kong.String("foo"),
 						PreserveHost:  kong.Bool(false),
+						PathHandling:  kong.String("v1"),
 						RegexPriority: kong.Int(0),
 						StripPath:     kong.Bool(false),
 						Protocols:     kong.StringSlice("http", "https"),
@@ -1488,7 +1490,8 @@ func Test_stateBuilder_upstream(t *testing.T) {
 						Slots: kong.Int(42),
 						Healthchecks: &kong.Healthcheck{
 							Active: &kong.ActiveHealthcheck{
-								Concurrency: kong.Int(10),
+								HTTPSVerifyCertificate: kong.Bool(true),
+								Concurrency:            kong.Int(10),
 								Healthy: &kong.Healthy{
 									HTTPStatuses: []int{200, 302},
 									Interval:     kong.Int(0),
@@ -1550,7 +1553,8 @@ func Test_stateBuilder_upstream(t *testing.T) {
 						Slots: kong.Int(10000),
 						Healthchecks: &kong.Healthcheck{
 							Active: &kong.ActiveHealthcheck{
-								Concurrency: kong.Int(10),
+								HTTPSVerifyCertificate: kong.Bool(true),
+								Concurrency:            kong.Int(10),
 								Healthy: &kong.Healthy{
 									HTTPStatuses: []int{200, 302},
 									Interval:     kong.Int(0),
@@ -1616,7 +1620,8 @@ func Test_stateBuilder_upstream(t *testing.T) {
 						Slots: kong.Int(10000),
 						Healthchecks: &kong.Healthcheck{
 							Active: &kong.ActiveHealthcheck{
-								Concurrency: kong.Int(10),
+								HTTPSVerifyCertificate: kong.Bool(true),
+								Concurrency:            kong.Int(10),
 								Healthy: &kong.Healthy{
 									HTTPStatuses: []int{200, 302},
 									Interval:     kong.Int(0),
@@ -1658,7 +1663,8 @@ func Test_stateBuilder_upstream(t *testing.T) {
 						Slots: kong.Int(10000),
 						Healthchecks: &kong.Healthcheck{
 							Active: &kong.ActiveHealthcheck{
-								Concurrency: kong.Int(10),
+								HTTPSVerifyCertificate: kong.Bool(true),
+								Concurrency:            kong.Int(10),
 								Healthy: &kong.Healthy{
 									HTTPStatuses: []int{200, 302},
 									Interval:     kong.Int(0),
@@ -1838,6 +1844,7 @@ func Test_stateBuilder(t *testing.T) {
 						ID:            kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
 						Name:          kong.String("foo-route1"),
 						PreserveHost:  kong.Bool(false),
+						PathHandling:  kong.String("v1"),
 						RegexPriority: kong.Int(0),
 						StripPath:     kong.Bool(false),
 						Protocols:     kong.StringSlice("http", "https"),
@@ -1850,6 +1857,7 @@ func Test_stateBuilder(t *testing.T) {
 						ID:            kong.String("d125e79a-297c-414b-bc00-ad3a87be6c2b"),
 						Name:          kong.String("foo-route2"),
 						PreserveHost:  kong.Bool(false),
+						PathHandling:  kong.String("v1"),
 						RegexPriority: kong.Int(0),
 						StripPath:     kong.Bool(false),
 						Protocols:     kong.StringSlice("http", "https"),
@@ -1862,6 +1870,7 @@ func Test_stateBuilder(t *testing.T) {
 						ID:            kong.String("0cc0d614-4c88-4535-841a-cbe0709b0758"),
 						Name:          kong.String("bar-route1"),
 						PreserveHost:  kong.Bool(false),
+						PathHandling:  kong.String("v1"),
 						RegexPriority: kong.Int(0),
 						StripPath:     kong.Bool(false),
 						Protocols:     kong.StringSlice("http", "https"),
@@ -1874,6 +1883,7 @@ func Test_stateBuilder(t *testing.T) {
 						ID:            kong.String("083f61d3-75bc-42b4-9df4-f91929e18fda"),
 						Name:          kong.String("bar-route2"),
 						PreserveHost:  kong.Bool(false),
+						PathHandling:  kong.String("v1"),
 						RegexPriority: kong.Int(0),
 						StripPath:     kong.Bool(false),
 						Protocols:     kong.StringSlice("http", "https"),
@@ -1886,6 +1896,7 @@ func Test_stateBuilder(t *testing.T) {
 						ID:            kong.String("ba843ee8-d63e-4c4f-be1c-ebea546d8fac"),
 						Name:          kong.String("dont-buffer-these"),
 						PreserveHost:  kong.Bool(false),
+						PathHandling:  kong.String("v1"),
 						RegexPriority: kong.Int(0),
 						StripPath:     kong.Bool(false),
 						Protocols:     kong.StringSlice("http", "https"),
@@ -1900,6 +1911,7 @@ func Test_stateBuilder(t *testing.T) {
 						ID:            kong.String("13dd1aac-04ce-4ea2-877c-5579cfa2c78e"),
 						Name:          kong.String("buffer-these"),
 						PreserveHost:  kong.Bool(false),
+						PathHandling:  kong.String("v1"),
 						RegexPriority: kong.Int(0),
 						StripPath:     kong.Bool(false),
 						Protocols:     kong.StringSlice("http", "https"),
@@ -1918,7 +1930,8 @@ func Test_stateBuilder(t *testing.T) {
 						Slots: kong.Int(42),
 						Healthchecks: &kong.Healthcheck{
 							Active: &kong.ActiveHealthcheck{
-								Concurrency: kong.Int(10),
+								HTTPSVerifyCertificate: kong.Bool(true),
+								Concurrency:            kong.Int(10),
 								Healthy: &kong.Healthy{
 									HTTPStatuses: []int{200, 302},
 									Interval:     kong.Int(0),

--- a/utils/constants.go
+++ b/utils/constants.go
@@ -23,6 +23,7 @@ var (
 		RegexPriority: kong.Int(0),
 		StripPath:     kong.Bool(false),
 		Protocols:     kong.StringSlice("http", "https"),
+		PathHandling:  kong.String("v1"),
 	}
 	targetDefaults = kong.Target{
 		Weight: kong.Int(defaultWeight),
@@ -47,6 +48,7 @@ var (
 					Interval:     kong.Int(0),
 					HTTPStatuses: []int{429, 404, 500, 501, 502, 503, 504, 505},
 				},
+				HTTPSVerifyCertificate: kong.Bool(true),
 			},
 			Passive: &kong.PassiveHealthcheck{
 				Healthy: &kong.Healthy{

--- a/utils/defaulter_test.go
+++ b/utils/defaulter_test.go
@@ -157,9 +157,11 @@ func TestRouteSetTest(t *testing.T) {
 			desc: "preserve host is not overridden",
 			arg: &kong.Route{
 				PreserveHost: kong.Bool(true),
+				PathHandling: kong.String("v1"),
 			},
 			want: &kong.Route{
 				PreserveHost:  kong.Bool(true),
+				PathHandling:  kong.String("v1"),
 				RegexPriority: kong.Int(0),
 				StripPath:     kong.Bool(false),
 				Protocols:     kong.StringSlice("http", "https"),
@@ -172,6 +174,7 @@ func TestRouteSetTest(t *testing.T) {
 			},
 			want: &kong.Route{
 				PreserveHost:  kong.Bool(false),
+				PathHandling:  kong.String("v1"),
 				RegexPriority: kong.Int(0),
 				StripPath:     kong.Bool(false),
 				Protocols:     kong.StringSlice("http", "tls"),
@@ -190,6 +193,7 @@ func TestRouteSetTest(t *testing.T) {
 				Hosts:         kong.StringSlice("1.example.com", "2.example.com"),
 				Methods:       kong.StringSlice("GET", "POST"),
 				PreserveHost:  kong.Bool(false),
+				PathHandling:  kong.String("v1"),
 				RegexPriority: kong.Int(0),
 				StripPath:     kong.Bool(false),
 				Protocols:     kong.StringSlice("http", "https"),
@@ -202,6 +206,7 @@ func TestRouteSetTest(t *testing.T) {
 			},
 			want: &kong.Route{
 				PreserveHost:  kong.Bool(false),
+				PathHandling:  kong.String("v1"),
 				RegexPriority: kong.Int(0),
 				StripPath:     kong.Bool(false),
 				Protocols:     kong.StringSlice("http", "https"),
@@ -214,6 +219,7 @@ func TestRouteSetTest(t *testing.T) {
 			},
 			want: &kong.Route{
 				PreserveHost:  kong.Bool(false),
+				PathHandling:  kong.String("v1"),
 				RegexPriority: kong.Int(0),
 				StripPath:     kong.Bool(true),
 				Protocols:     kong.StringSlice("http", "https"),
@@ -250,6 +256,7 @@ func TestUpstreamSetTest(t *testing.T) {
 			arg: &kong.Upstream{
 				Healthchecks: &kong.Healthcheck{
 					Active: &kong.ActiveHealthcheck{
+						HTTPSVerifyCertificate: kong.Bool(true),
 						Healthy: &kong.Healthy{
 							HTTPStatuses: []int{200},
 						},
@@ -260,7 +267,8 @@ func TestUpstreamSetTest(t *testing.T) {
 				Slots: kong.Int(10000),
 				Healthchecks: &kong.Healthcheck{
 					Active: &kong.ActiveHealthcheck{
-						Concurrency: kong.Int(10),
+						HTTPSVerifyCertificate: kong.Bool(true),
+						Concurrency:            kong.Int(10),
 						Healthy: &kong.Healthy{
 							HTTPStatuses: []int{200},
 							Interval:     kong.Int(0),
@@ -303,6 +311,7 @@ func TestUpstreamSetTest(t *testing.T) {
 				Name: kong.String("foo"),
 				Healthchecks: &kong.Healthcheck{
 					Active: &kong.ActiveHealthcheck{
+						HTTPSVerifyCertificate: kong.Bool(true),
 						Healthy: &kong.Healthy{
 							Interval: kong.Int(1),
 						},
@@ -314,7 +323,8 @@ func TestUpstreamSetTest(t *testing.T) {
 				Slots: kong.Int(10000),
 				Healthchecks: &kong.Healthcheck{
 					Active: &kong.ActiveHealthcheck{
-						Concurrency: kong.Int(10),
+						HTTPSVerifyCertificate: kong.Bool(true),
+						Concurrency:            kong.Int(10),
 						Healthy: &kong.Healthy{
 							HTTPStatuses: []int{200, 302},
 							Interval:     kong.Int(1),
@@ -357,10 +367,10 @@ func TestUpstreamSetTest(t *testing.T) {
 				Name: kong.String("foo"),
 				Healthchecks: &kong.Healthcheck{
 					Active: &kong.ActiveHealthcheck{
+						HTTPSVerifyCertificate: kong.Bool(true),
 						Healthy: &kong.Healthy{
 							Interval: kong.Int(1),
 						},
-						HTTPSVerifyCertificate: kong.Bool(false),
 					},
 				},
 			},
@@ -369,16 +379,16 @@ func TestUpstreamSetTest(t *testing.T) {
 				Slots: kong.Int(10000),
 				Healthchecks: &kong.Healthcheck{
 					Active: &kong.ActiveHealthcheck{
-						Concurrency: kong.Int(10),
+						HTTPSVerifyCertificate: kong.Bool(true),
+						Concurrency:            kong.Int(10),
 						Healthy: &kong.Healthy{
 							HTTPStatuses: []int{200, 302},
 							Interval:     kong.Int(1),
 							Successes:    kong.Int(0),
 						},
-						HTTPPath:               kong.String("/"),
-						HTTPSVerifyCertificate: kong.Bool(false),
-						Type:                   kong.String("http"),
-						Timeout:                kong.Int(1),
+						HTTPPath: kong.String("/"),
+						Type:     kong.String("http"),
+						Timeout:  kong.Int(1),
 						Unhealthy: &kong.Unhealthy{
 							HTTPFailures: kong.Int(0),
 							TCPFailures:  kong.Int(0),
@@ -413,10 +423,10 @@ func TestUpstreamSetTest(t *testing.T) {
 				Name: kong.String("foo"),
 				Healthchecks: &kong.Healthcheck{
 					Active: &kong.ActiveHealthcheck{
+						HTTPSVerifyCertificate: kong.Bool(true),
 						Healthy: &kong.Healthy{
 							Interval: kong.Int(1),
 						},
-						HTTPSVerifyCertificate: kong.Bool(true),
 					},
 				},
 			},
@@ -425,16 +435,16 @@ func TestUpstreamSetTest(t *testing.T) {
 				Slots: kong.Int(10000),
 				Healthchecks: &kong.Healthcheck{
 					Active: &kong.ActiveHealthcheck{
-						Concurrency: kong.Int(10),
+						HTTPSVerifyCertificate: kong.Bool(true),
+						Concurrency:            kong.Int(10),
 						Healthy: &kong.Healthy{
 							HTTPStatuses: []int{200, 302},
 							Interval:     kong.Int(1),
 							Successes:    kong.Int(0),
 						},
-						HTTPPath:               kong.String("/"),
-						HTTPSVerifyCertificate: kong.Bool(true),
-						Type:                   kong.String("http"),
-						Timeout:                kong.Int(1),
+						HTTPPath: kong.String("/"),
+						Type:     kong.String("http"),
+						Timeout:  kong.Int(1),
 						Unhealthy: &kong.Unhealthy{
 							HTTPFailures: kong.Int(0),
 							TCPFailures:  kong.Int(0),


### PR DESCRIPTION
add default value for PathHandling in route & HTTPSVerifyCertificate in upstream
set PathHandling to "v1" according https://docs.konghq.com/gateway-oss/2.3.x/admin-api/#add-route
set HTTPSVerifyCertificate to true according  https://docs.konghq.com/gateway-oss/2.3.x/admin-api/#add-upstream
fix https://github.com/Kong/kubernetes-ingress-controller/issues/1212
It's my first pr, thx review