### PR TITLE
fix(file) disable deepcopy-gen for invalid types

### DIFF
--- a/file/types.go
+++ b/file/types.go
@@ -47,7 +47,6 @@ func (s FService) id() string {
 	return ""
 }
 
-// +k8s:deepcopy-gen=true
 type service struct {
 	ClientCertificate *string    `json:"client_certificate,omitempty" yaml:"client_certificate,omitempty"`
 	ConnectTimeout    *int       `json:"connect_timeout,omitempty" yaml:"connect_timeout,omitempty"`
@@ -311,7 +310,6 @@ type FPlugin struct {
 
 // foo is a shadow type of Plugin.
 // It is used for custom marshalling of plugin.
-// +k8s:deepcopy-gen=true
 type foo struct {
 	CreatedAt *int               `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 	ID        *string            `json:"id,omitempty" yaml:"id,omitempty"`


### PR DESCRIPTION
Disable deepcopy-gen on the file.foo and file.service types.

Requesting deepcopy-gen on these types _sometimes_ led to CI failures, e.g. https://github.com/Kong/deck/pull/343/checks?check_run_id=2421543562

Typically, deepcopy-gen simply ignores these types. Although unexported types [are not supported](https://github.com/kubernetes/gengo/blob/de9496dff47bef4ff8f45a56096bf50798cba2a5/examples/deepcopy-gen/generators/deepcopy.go#L405-L407), it just [logs that it cannot generate code for them and skips over them](https://github.com/kubernetes/gengo/blob/de9496dff47bef4ff8f45a56096bf50798cba2a5/examples/deepcopy-gen/generators/deepcopy.go#L270-L273). However, there is an initial check to see if anything in a package needs code generation, and this check [throws a fatal error if it encounters a type that requests but does not support deepcopy](https://github.com/kubernetes/gengo/blob/de9496dff47bef4ff8f45a56096bf50798cba2a5/examples/deepcopy-gen/generators/deepcopy.go#L177-L186). This check effectively picks a type at random (because the range order is not deterministic), so it will only fail sometimes.

