### PR TITLE
fix: set description to null to reset description

### DIFF
--- a/konnect/types.go
+++ b/konnect/types.go
@@ -14,7 +14,7 @@ func BaseURL() string {
 type ServicePackage struct {
 	ID          *string `json:"id,omitempty"`
 	Name        *string `json:"name,omitempty"`
-	Description *string `json:"description,omitempty"`
+	Description *string `json:"description"`
 
 	Versions []ServiceVersion `json:"versions,omitempty"`
 }


### PR DESCRIPTION
Konnect API's behavior seems to be that if one sends a PATCH request without
an explicit `null`, that property is not reset to empty.
After removal of `omitempty`, deleting `description` field from the
state file correctly updates the description in Konnect.