### PR TITLE
refactor: plumb a single context throughout the code

### DIFF
--- a/cmd/common_konnect.go
+++ b/cmd/common_konnect.go
@@ -79,7 +79,7 @@ func syncKonnect(ctx context.Context,
 	}
 
 	s, _ := diff.NewSyncer(currentState, targetState)
-	stats, errs := solver.Solve(stopChannel, s, kongClient, konnectClient, parallelism, dry)
+	stats, errs := solver.Solve(ctx, s, kongClient, konnectClient, parallelism, dry)
 	printFn := color.New(color.FgGreen, color.Bold).PrintfFunc()
 	printFn("Summary:\n")
 	printFn("  Created: %v\n", stats.CreateOps)
@@ -142,7 +142,7 @@ func getKonnectState(ctx context.Context,
 	group.Go(func() error {
 		var err error
 		// get export of Kong resources
-		kongState, err = dump.Get(kongClient, dump.Config{
+		kongState, err = dump.Get(ctx, kongClient, dump.Config{
 			SkipConsumers: skipConsumers,
 		})
 		if err != nil {

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -24,7 +24,8 @@ that will be created or updated or deleted.
 `,
 	Args: validateNoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return syncMain(diffCmdKongStateFile, true, diffCmdParallelism, 0, diffWorkspace)
+		return syncMain(cmd.Context(), diffCmdKongStateFile, true,
+			diffCmdParallelism, 0, diffWorkspace)
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if len(diffCmdKongStateFile) == 0 {

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -45,6 +45,7 @@ The file can then be read using the Sync o Diff command to again
 configure Kong.`,
 	Args: validateNoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
 
 		wsClient, err := utils.GetKongClient(rootConfig)
 		if err != nil {
@@ -61,7 +62,7 @@ configure Kong.`,
 			if dumpCmdKongStateFile != "kong" {
 				return errors.New("output-file cannot be specified with --all-workspace flag")
 			}
-			workspaces, err := listWorkspaces(cmd.Context(), wsClient)
+			workspaces, err := listWorkspaces(ctx, wsClient)
 			if err != nil {
 				return err
 			}
@@ -72,7 +73,7 @@ configure Kong.`,
 					return err
 				}
 
-				rawState, err := dump.Get(wsClient, dumpConfig)
+				rawState, err := dump.Get(ctx, wsClient, dumpConfig)
 				if err != nil {
 					return errors.Wrap(err, "reading configuration from Kong")
 				}
@@ -105,7 +106,7 @@ configure Kong.`,
 		if dumpWorkspace != "" {
 			wsConfig := rootConfig.ForWorkspace(dumpWorkspace)
 
-			exists, err := workspaceExists(wsConfig)
+			exists, err := workspaceExists(ctx, wsConfig)
 			if err != nil {
 				return err
 			}
@@ -119,7 +120,7 @@ configure Kong.`,
 			}
 		}
 
-		rawState, err := dump.Get(wsClient, dumpConfig)
+		rawState, err := dump.Get(ctx, wsClient, dumpConfig)
 		if err != nil {
 			return errors.Wrap(err, "reading configuration from Kong")
 		}

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -19,9 +19,10 @@ var pingCmd = &cobra.Command{
 can connect to Kong's Admin API or not.`,
 	Args: validateNoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
 
 		wsConfig := rootConfig.ForWorkspace(pingWorkspace)
-		version, err := kongVersion(wsConfig)
+		version, err := kongVersion(ctx, wsConfig)
 		if err != nil {
 			return errors.Wrap(err, "reading Kong version")
 		}

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -26,6 +26,8 @@ Use this command with extreme care as it is equivalent to running
 By default, this command will ask for a confirmation prompt.`,
 	Args: validateNoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
 		if !resetCmdForce {
 			ok, err := utils.Confirm("This will delete all configuration from Kong's database." +
 				"\n> Are you sure? ")
@@ -43,11 +45,11 @@ By default, this command will ask for a confirmation prompt.`,
 		}
 		// Kong OSS or default workspace
 		if !resetAllWorkspaces && resetWorkspace == "" {
-			state, err := dump.Get(rootClient, dumpConfig)
+			state, err := dump.Get(ctx, rootClient, dumpConfig)
 			if err != nil {
 				return err
 			}
-			err = reset.Reset(state, rootClient)
+			err = reset.Reset(ctx, state, rootClient)
 			if err != nil {
 				return err
 			}
@@ -61,13 +63,13 @@ By default, this command will ask for a confirmation prompt.`,
 		// Kong Enterprise
 		var workspaces []string
 		if resetAllWorkspaces {
-			workspaces, err = listWorkspaces(cmd.Context(), rootClient)
+			workspaces, err = listWorkspaces(ctx, rootClient)
 			if err != nil {
 				return err
 			}
 		}
 		if resetWorkspace != "" {
-			exists, err := workspaceExists(rootConfig.ForWorkspace(resetWorkspace))
+			exists, err := workspaceExists(ctx, rootConfig.ForWorkspace(resetWorkspace))
 			if err != nil {
 				return err
 			}
@@ -83,11 +85,11 @@ By default, this command will ask for a confirmation prompt.`,
 			if err != nil {
 				return err
 			}
-			state, err := dump.Get(wsClient, dumpConfig)
+			state, err := dump.Get(ctx, wsClient, dumpConfig)
 			if err != nil {
 				return err
 			}
-			err = reset.Reset(state, wsClient)
+			err = reset.Reset(ctx, state, wsClient)
 			if err != nil {
 				return err
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/url"
@@ -39,10 +40,10 @@ It can be used to export, import or sync entities to Kong.`,
 }
 
 // Execute adds all child commands to the root command and sets
-// sflags appropriately.
+// flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	err := rootCmd.Execute()
+func Execute(ctx context.Context) {
+	err := rootCmd.ExecuteContext(ctx)
 	if err != nil {
 		// do not print error because cobra already prints it
 		os.Exit(1)

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -21,7 +21,8 @@ var syncCmd = &cobra.Command{
 to get Kong's state in sync with the input state.`,
 	Args: validateNoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return syncMain(syncCmdKongStateFile, false, syncCmdParallelism, syncCmdDBUpdateDelay, syncWorkspace)
+		return syncMain(cmd.Context(), syncCmdKongStateFile, false,
+			syncCmdParallelism, syncCmdDBUpdateDelay, syncWorkspace)
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if len(syncCmdKongStateFile) == 0 {

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -1,6 +1,7 @@
 package diff
 
 import (
+	"context"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -366,7 +367,7 @@ func (sc *Syncer) wait() {
 }
 
 // Run starts a diff and invokes d for every diff.
-func (sc *Syncer) Run(done <-chan struct{}, parallelism int, d Do) []error {
+func (sc *Syncer) Run(ctx context.Context, parallelism int, d Do) []error {
 	if parallelism < 1 {
 		return append([]error{}, errors.New("parallelism can not be negative"))
 	}
@@ -410,7 +411,7 @@ func (sc *Syncer) Run(done <-chan struct{}, parallelism int, d Do) []error {
 
 	var errs []error
 	select {
-	case <-done:
+	case <-ctx.Done():
 	case err, ok := <-sc.errChan:
 		if ok && err != nil {
 			if err != errEnqueueFailed {

--- a/dump/dump.go
+++ b/dump/dump.go
@@ -232,7 +232,7 @@ func getEnterpriseRBACConfiguration(ctx context.Context, group *errgroup.Group,
 
 // Get queries all the entities using client and returns
 // all the entities in KongRawState.
-func Get(client *kong.Client, config Config) (*utils.KongRawState, error) {
+func Get(ctx context.Context, client *kong.Client, config Config) (*utils.KongRawState, error) {
 
 	var state utils.KongRawState
 
@@ -240,7 +240,7 @@ func Get(client *kong.Client, config Config) (*utils.KongRawState, error) {
 		return nil, err
 	}
 
-	group, ctx := errgroup.WithContext(context.Background())
+	group, ctx := errgroup.WithContext(ctx)
 
 	// dump only rbac resources
 	if config.RBACResourcesOnly {

--- a/dump/dump_konnect.go
+++ b/dump/dump_konnect.go
@@ -22,7 +22,7 @@ func GetFromKonnect(ctx context.Context, konnectClient *konnect.Client,
 	var servicePackages []*konnect.ServicePackage
 	var relations []*konnect.ControlPlaneServiceRelation
 
-	group, ctx := errgroup.WithContext(context.Background())
+	group, ctx := errgroup.WithContext(ctx)
 	// group1 fetches service packages and their versions
 	group.Go(func() error {
 		var err error

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"os"
@@ -11,22 +12,22 @@ import (
 	"github.com/kong/deck/cmd"
 )
 
-func registerSignalHandler() {
+func registerSignalHandler() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
 	sigs := make(chan os.Signal, 1)
-	done := make(chan struct{})
-	cmd.SetStopCh(done)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
 		sig := <-sigs
 		fmt.Println("received", sig, ", terminating...")
-		close(done)
+		cancel()
 	}()
+	return ctx
 }
 
 func main() {
-	registerSignalHandler()
-	cmd.Execute()
+	ctx := registerSignalHandler()
+	cmd.Execute(ctx)
 }
 
 func init() {

--- a/reset/reset.go
+++ b/reset/reset.go
@@ -10,12 +10,12 @@ import (
 )
 
 // Reset deletes all entities in Kong.
-func Reset(state *utils.KongRawState, client *kong.Client) error {
+func Reset(ctx context.Context, state *utils.KongRawState, client *kong.Client) error {
 	if state == nil {
 		return errors.New("state cannot be empty")
 	}
 
-	group, ctx := errgroup.WithContext(context.Background())
+	group, ctx := errgroup.WithContext(ctx)
 
 	group.Go(func() error {
 		// Delete routes before services

--- a/solver/solver.go
+++ b/solver/solver.go
@@ -1,6 +1,8 @@
 package solver
 
 import (
+	"context"
+
 	"github.com/kong/deck/crud"
 	"github.com/kong/deck/diff"
 	"github.com/kong/deck/konnect"
@@ -18,7 +20,7 @@ type Stats struct {
 }
 
 // Solve generates a diff and walks the graph.
-func Solve(doneCh chan struct{}, syncer *diff.Syncer,
+func Solve(ctx context.Context, syncer *diff.Syncer,
 	client *kong.Client, konnectClient *konnect.Client,
 	parallelism int, dry bool) (Stats, []error) {
 
@@ -36,7 +38,7 @@ func Solve(doneCh chan struct{}, syncer *diff.Syncer,
 		}
 	}
 
-	errs := syncer.Run(doneCh, parallelism, func(e diff.Event) (crud.Arg, error) {
+	errs := syncer.Run(ctx, parallelism, func(e diff.Event) (crud.Arg, error) {
 		var err error
 		var result crud.Arg
 


### PR DESCRIPTION
This patch is an effort to improve the context propagation in decK, down
to every single operation.
In order to do that, a single root context is now being created in the
main function, and all contexts should be derived from it.