### PR TITLE
Strip patch version from ping output

### DIFF
--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -26,7 +27,7 @@ can connect to Kong's Admin API or not.`,
 			return errors.Wrap(err, "reading Kong version")
 		}
 		fmt.Println("Successfully connected to Kong!")
-		fmt.Println("Kong version: ", version)
+		fmt.Fprintf(os.Stdout, "Kong version: %v.%v\n", version.Major, version.Minor)
 		return nil
 	},
 }


### PR DESCRIPTION
Strip the patch version from ping output. We already strip it when generating a semver `Version` in `CleanKongVersion`, so it's always 0 if we print the full version.

Fix #361