### PR TITLE
refactor: simplify error creation and wrapping

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -15,7 +15,6 @@ import (
 	"github.com/kong/deck/state"
 	"github.com/kong/deck/utils"
 	"github.com/kong/go-kong/kong"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -52,7 +51,7 @@ func workspaceExists(ctx context.Context, config utils.KongClientConfig) (bool, 
 	case err == nil:
 		return true, nil
 	default:
-		return false, errors.Wrap(err, "checking if workspace exists")
+		return false, fmt.Errorf("checking if workspace exists: %w", err)
 	}
 }
 
@@ -83,11 +82,11 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 	// load Kong version after workspace
 	kongVersion, err := fetchKongVersion(ctx, wsConfig)
 	if err != nil {
-		return errors.Wrap(err, "reading Kong version")
+		return fmt.Errorf("reading Kong version: %w", err)
 	}
 	parsedKongVersion, err := parseKongVersion(kongVersion)
 	if err != nil {
-		return errors.Wrap(err, "parsing Kong version")
+		return fmt.Errorf("parsing Kong version: %w", err)
 	}
 
 	// TODO: instead of guessing the cobra command here, move the sendAnalytics
@@ -220,8 +219,8 @@ func parseKongVersion(version string) (semver.Version, error) {
 
 func validateNoArgs(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
-		return errors.New("positional arguments are not valid for this command, please use flags instead\n" +
-			"Run 'deck --help' for usage.")
+		return fmt.Errorf("positional arguments are not valid for this command, " +
+			"please use flags instead")
 	}
 	return nil
 }

--- a/cmd/common_konnect.go
+++ b/cmd/common_konnect.go
@@ -13,7 +13,6 @@ import (
 	"github.com/kong/deck/state"
 	"github.com/kong/deck/utils"
 	"github.com/kong/go-kong/kong"
-	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -45,7 +44,7 @@ func syncKonnect(ctx context.Context,
 		konnectConfig.Email,
 		konnectConfig.Password)
 	if err != nil {
-		return errors.Wrap(err, "authenticating with Konnect")
+		return fmt.Errorf("authenticating with Konnect: %w", err)
 	}
 
 	// get kong control plane ID
@@ -104,7 +103,7 @@ func fetchKongControlPlaneID(ctx context.Context,
 	client *konnect.Client) (string, error) {
 	controlPlanes, _, err := client.ControlPlanes.List(ctx, nil)
 	if err != nil {
-		return "", errors.Wrap(err, "fetching control planes")
+		return "", fmt.Errorf("fetching control planes: %w", err)
 	}
 
 	return singleOutKongCP(controlPlanes)
@@ -123,11 +122,11 @@ func singleOutKongCP(controlPlanes []konnect.ControlPlane) (string, error) {
 		}
 	}
 	if kongCPCount == 0 {
-		return "", errors.New("found no Kong EE control-planes")
+		return "", fmt.Errorf("found no Kong EE control-planes")
 	}
 	if kongCPCount > 1 {
-		return "", errors.New("found multiple Kong EE control-planes. " +
-			"decK expected a single control-plane.")
+		return "", fmt.Errorf("found multiple Kong EE control-planes, " +
+			"decK expected a single control-plane")
 	}
 	return kongCPID, nil
 }
@@ -150,7 +149,7 @@ func getKonnectState(ctx context.Context,
 			SkipConsumers: skipConsumers,
 		})
 		if err != nil {
-			return errors.Wrap(err, "reading configuration from Kong")
+			return fmt.Errorf("reading configuration from Kong: %w", err)
 		}
 		return nil
 	})
@@ -173,7 +172,7 @@ func getKonnectState(ctx context.Context,
 
 	ks, err := state.GetKonnectState(kongState, konnectState)
 	if err != nil {
-		return nil, errors.Wrap(err, "building state")
+		return nil, fmt.Errorf("building state: %w", err)
 	}
 	return ks, nil
 }

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -1,7 +1,8 @@
 package cmd
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -29,8 +30,8 @@ that will be created or updated or deleted.
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if len(diffCmdKongStateFile) == 0 {
-			return errors.New("A state file with Kong's configuration " +
-				"must be specified using -s/--state flag.")
+			return fmt.Errorf("a state file with Kong's configuration " +
+				"must be specified using -s/--state flag")
 		}
 		return preRunSilenceEventsFlag()
 	},

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/kong/deck/dump"
@@ -9,7 +10,6 @@ import (
 	"github.com/kong/deck/state"
 	"github.com/kong/deck/utils"
 	"github.com/kong/go-kong/kong"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -24,7 +24,7 @@ var (
 func listWorkspaces(ctx context.Context, client *kong.Client) ([]string, error) {
 	workspaces, err := client.Workspaces.ListAll(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "fetching workspaces from Kong")
+		return nil, fmt.Errorf("fetching workspaces from Kong: %w", err)
 	}
 	var res []string
 	for _, workspace := range workspaces {
@@ -56,17 +56,17 @@ configure Kong.`,
 
 		kongVersion, err := fetchKongVersion(ctx, rootConfig.ForWorkspace(dumpWorkspace))
 		if err != nil {
-			return errors.Wrap(err, "reading Kong version")
+			return fmt.Errorf("reading Kong version: %w", err)
 		}
 		_ = sendAnalytics("dump", kongVersion)
 
 		// Kong Enterprise dump all workspace
 		if dumpAllWorkspaces {
 			if dumpWorkspace != "" {
-				return errors.New("workspace cannot be specified with --all-workspace flag")
+				return fmt.Errorf("workspace cannot be specified with --all-workspace flag")
 			}
 			if dumpCmdKongStateFile != "kong" {
-				return errors.New("output-file cannot be specified with --all-workspace flag")
+				return fmt.Errorf("output-file cannot be specified with --all-workspace flag")
 			}
 			workspaces, err := listWorkspaces(ctx, wsClient)
 			if err != nil {
@@ -81,11 +81,11 @@ configure Kong.`,
 
 				rawState, err := dump.Get(ctx, wsClient, dumpConfig)
 				if err != nil {
-					return errors.Wrap(err, "reading configuration from Kong")
+					return fmt.Errorf("reading configuration from Kong: %w", err)
 				}
 				ks, err := state.Get(rawState)
 				if err != nil {
-					return errors.Wrap(err, "building state")
+					return fmt.Errorf("building state: %w", err)
 				}
 
 				if err := file.KongStateToFile(ks, file.WriteConfig{
@@ -117,7 +117,7 @@ configure Kong.`,
 				return err
 			}
 			if !exists {
-				return errors.Errorf("workspace '%v' does not exist in Kong", dumpWorkspace)
+				return fmt.Errorf("workspace '%v' does not exist in Kong", dumpWorkspace)
 			}
 
 			wsClient, err = utils.GetKongClient(wsConfig)
@@ -128,11 +128,11 @@ configure Kong.`,
 
 		rawState, err := dump.Get(ctx, wsClient, dumpConfig)
 		if err != nil {
-			return errors.Wrap(err, "reading configuration from Kong")
+			return fmt.Errorf("reading configuration from Kong: %w", err)
 		}
 		ks, err := state.Get(rawState)
 		if err != nil {
-			return errors.Wrap(err, "building state")
+			return fmt.Errorf("building state: %w", err)
 		}
 		if err := file.KongStateToFile(ks, file.WriteConfig{
 			SelectTags: dumpConfig.SelectorTags,

--- a/cmd/konnect_diff.go
+++ b/cmd/konnect_diff.go
@@ -1,7 +1,8 @@
 package cmd
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -23,7 +24,7 @@ that will be created or updated or deleted.` + konnectAlphaState,
 	Args: validateNoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if konnectDumpCmdKongStateFile == "-" {
-			return errors.New("writing to stdout is not supported in Konnect mode")
+			return fmt.Errorf("writing to stdout is not supported in Konnect mode")
 		}
 		_ = sendAnalytics("konnect-diff", "")
 		return syncKonnect(cmd.Context(), konnectDiffCmdKongStateFile, true,

--- a/cmd/konnect_dump.go
+++ b/cmd/konnect_dump.go
@@ -1,11 +1,11 @@
 package cmd
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/kong/deck/file"
 	"github.com/kong/deck/utils"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +29,7 @@ configure Konnect.` + konnectAlphaState,
 		_ = sendAnalytics("konnect-dump", "")
 
 		if konnectDumpCmdKongStateFile == "-" {
-			return errors.New("writing to stdout is not supported in Konnect mode")
+			return fmt.Errorf("writing to stdout is not supported in Konnect mode")
 		}
 
 		if yes, err := utils.ConfirmFileOverwrite(konnectDumpCmdKongStateFile, dumpCmdStateFormat, assumeYes); err != nil {
@@ -49,7 +49,7 @@ configure Konnect.` + konnectAlphaState,
 			konnectConfig.Email,
 			konnectConfig.Password)
 		if err != nil {
-			return errors.Wrap(err, "authenticating with Konnect")
+			return fmt.Errorf("authenticating with Konnect: %w", err)
 		}
 
 		// get kong control plane ID

--- a/cmd/konnect_ping.go
+++ b/cmd/konnect_ping.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/kong/deck/utils"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -25,7 +24,7 @@ credentials.` + konnectAlphaState,
 		res, err := client.Auth.Login(cmd.Context(), konnectConfig.Email,
 			konnectConfig.Password)
 		if err != nil {
-			return errors.Wrap(err, "authenticating with Konnect")
+			return fmt.Errorf("authenticating with Konnect: %w", err)
 		}
 		fmt.Printf("Successfully Konnected as %s %s (%s)!\n",
 			res.FirstName, res.LastName, res.Organization)

--- a/cmd/konnect_sync.go
+++ b/cmd/konnect_sync.go
@@ -1,7 +1,8 @@
 package cmd
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -15,7 +16,7 @@ to get Konnect's state in sync with the input state.` + konnectAlphaState,
 	Args: validateNoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if konnectDumpCmdKongStateFile == "-" {
-			return errors.New("writing to stdout is not supported in Konnect mode")
+			return fmt.Errorf("writing to stdout is not supported in Konnect mode")
 		}
 		_ = sendAnalytics("konnect-sync", "")
 		return syncKonnect(cmd.Context(), konnectDiffCmdKongStateFile, false,

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +21,7 @@ can connect to Kong's Admin API or not.`,
 		wsConfig := rootConfig.ForWorkspace(pingWorkspace)
 		version, err := fetchKongVersion(ctx, wsConfig)
 		if err != nil {
-			return errors.Wrap(err, "reading Kong version")
+			return fmt.Errorf("reading Kong version: %w", err)
 		}
 		_ = sendAnalytics("ping", version)
 		fmt.Println("Successfully connected to Kong!")

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -1,10 +1,11 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/kong/deck/dump"
 	"github.com/kong/deck/reset"
 	"github.com/kong/deck/utils"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -46,7 +47,7 @@ By default, this command will ask for a confirmation prompt.`,
 
 		kongVersion, err := fetchKongVersion(ctx, rootConfig.ForWorkspace(resetWorkspace))
 		if err != nil {
-			return errors.Wrap(err, "reading Kong version")
+			return fmt.Errorf("reading Kong version: %w", err)
 		}
 		_ = sendAnalytics("reset", kongVersion)
 
@@ -64,7 +65,7 @@ By default, this command will ask for a confirmation prompt.`,
 		}
 
 		if resetAllWorkspaces && resetWorkspace != "" {
-			return errors.New("workspace cannot be specified with --all-workspace flag")
+			return fmt.Errorf("workspace cannot be specified with --all-workspace flag")
 		}
 
 		// Kong Enterprise
@@ -81,7 +82,7 @@ By default, this command will ask for a confirmation prompt.`,
 				return err
 			}
 			if !exists {
-				return errors.Errorf("workspace '%v' does not exist in Kong", resetWorkspace)
+				return fmt.Errorf("workspace '%v' does not exist in Kong", resetWorkspace)
 			}
 
 			workspaces = append(workspaces, resetWorkspace)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,7 +11,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/kong/deck/utils"
 	homedir "github.com/mitchellh/go-homedir"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -35,7 +34,7 @@ It can be used to export, import or sync entities to Kong.`,
 	SilenceUsage: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if _, err := url.ParseRequestURI(rootConfig.Address); err != nil {
-			return errors.WithStack(errors.Wrap(err, "invalid URL"))
+			return fmt.Errorf("invalid URL: %w", err)
 		}
 		return nil
 	},
@@ -195,10 +194,10 @@ func initKonnectConfig() error {
 	if password == "" && passwordFile != "" {
 		fileContent, err := ioutil.ReadFile(passwordFile)
 		if err != nil {
-			return errors.Errorf("read file '%s': %v", passwordFile, err)
+			return fmt.Errorf("read file %q: %w", passwordFile, err)
 		}
 		if len(fileContent) == 0 {
-			return errors.Errorf("file '%s': empty", passwordFile)
+			return fmt.Errorf("file %q: empty", passwordFile)
 		}
 		password = string(fileContent)
 		password = strings.TrimRight(password, "\n")

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -1,7 +1,8 @@
 package cmd
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -26,8 +27,8 @@ to get Kong's state in sync with the input state.`,
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if len(syncCmdKongStateFile) == 0 {
-			return errors.New("A state file with Kong's configuration " +
-				"must be specified using -s/--state flag.")
+			return fmt.Errorf("a state file with Kong's configuration " +
+				"must be specified using -s/--state flag")
 		}
 		return preRunSilenceEventsFlag()
 	},

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -17,9 +17,7 @@ func printStats(stats solver.Stats) {
 	printFn("  Deleted: %v\n", stats.DeleteOps)
 }
 
-var (
-	silenceEvents bool
-)
+var silenceEvents bool
 
 func preRunSilenceEventsFlag() error {
 	printPkg.DisableOutput = true

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/kong/deck/file"
 	"github.com/kong/deck/state"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -58,8 +59,8 @@ this command.
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if len(validateCmdKongStateFile) == 0 {
-			return errors.New("A state file with Kong's configuration " +
-				"must be specified using -s/--state flag.")
+			return fmt.Errorf("a state file with Kong's configuration " +
+				"must be specified using -s/--state flag")
 		}
 		return nil
 	},

--- a/crud/registry.go
+++ b/crud/registry.go
@@ -1,7 +1,7 @@
 package crud
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 )
 
 // Kind represents Kind of an entity or object.
@@ -23,11 +23,11 @@ func (r *Registry) typesMap() map[Kind]Actions {
 // An error will be returned if kind was previously registered.
 func (r *Registry) Register(kind Kind, a Actions) error {
 	if kind == "" {
-		return errors.New("kind cannot be empty")
+		return fmt.Errorf("kind cannot be empty")
 	}
 	m := r.typesMap()
 	if _, ok := m[kind]; ok {
-		return errors.New("kind '" + string(kind) + "' already registered")
+		return fmt.Errorf("kind %q already registered", kind)
 	}
 	m[kind] = a
 	return nil
@@ -45,12 +45,12 @@ func (r *Registry) MustRegister(kind Kind, a Actions) {
 // An error will be returned if kind was never registered.
 func (r *Registry) Get(kind Kind) (Actions, error) {
 	if kind == "" {
-		return nil, errors.New("kind cannot be empty")
+		return nil, fmt.Errorf("kind cannot be empty")
 	}
 	m := r.typesMap()
 	a, ok := m[kind]
 	if !ok {
-		return nil, errors.New("kind '" + string(kind) + "' is not registered")
+		return nil, fmt.Errorf("kind %q is not registered", kind)
 	}
 	return a, nil
 }
@@ -60,12 +60,12 @@ func (r *Registry) Get(kind Kind) (Actions, error) {
 func (r *Registry) Create(kind Kind, args ...Arg) (Arg, error) {
 	a, err := r.Get(kind)
 	if err != nil {
-		return nil, errors.Wrap(err, "create failed")
+		return nil, fmt.Errorf("create failed: %w", err)
 	}
 
 	res, err := a.Create(args...)
 	if err != nil {
-		return nil, errors.Wrap(err, "create failed")
+		return nil, fmt.Errorf("create failed: %w", err)
 	}
 	return res, nil
 }
@@ -75,12 +75,12 @@ func (r *Registry) Create(kind Kind, args ...Arg) (Arg, error) {
 func (r *Registry) Update(kind Kind, args ...Arg) (Arg, error) {
 	a, err := r.Get(kind)
 	if err != nil {
-		return nil, errors.Wrap(err, "update failed")
+		return nil, fmt.Errorf("update failed: %w", err)
 	}
 
 	res, err := a.Update(args...)
 	if err != nil {
-		return nil, errors.Wrap(err, "update failed")
+		return nil, fmt.Errorf("update failed: %w", err)
 	}
 	return res, nil
 }
@@ -90,12 +90,12 @@ func (r *Registry) Update(kind Kind, args ...Arg) (Arg, error) {
 func (r *Registry) Delete(kind Kind, args ...Arg) (Arg, error) {
 	a, err := r.Get(kind)
 	if err != nil {
-		return nil, errors.Wrap(err, "delete failed")
+		return nil, fmt.Errorf("delete failed: %w", err)
 	}
 
 	res, err := a.Delete(args...)
 	if err != nil {
-		return nil, errors.Wrap(err, "delete failed")
+		return nil, fmt.Errorf("delete failed: %w", err)
 	}
 	return res, nil
 }
@@ -104,7 +104,7 @@ func (r *Registry) Delete(kind Kind, args ...Arg) (Arg, error) {
 func (r *Registry) Do(kind Kind, op Op, args ...Arg) (Arg, error) {
 	a, err := r.Get(kind)
 	if err != nil {
-		return nil, errors.Wrapf(err, "%v failed", op)
+		return nil, fmt.Errorf("%v failed: %w", op, err)
 	}
 
 	var res Arg
@@ -117,7 +117,7 @@ func (r *Registry) Do(kind Kind, op Op, args ...Arg) (Arg, error) {
 	case Delete.name:
 		res, err = a.Delete(args...)
 	default:
-		return nil, errors.New("unknown operation: " + op.name)
+		return nil, fmt.Errorf("unknown operation: %s", op.name)
 	}
 
 	if err != nil {

--- a/crud/registry_test.go
+++ b/crud/registry_test.go
@@ -1,9 +1,9 @@
 package crud
 
 import (
+	"fmt"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,7 +21,7 @@ func (t testActionFixture) invoke(op string, inputs ...Arg) (Arg, error) {
 	for _, input := range inputs {
 		iString, ok := input.(string)
 		if !ok {
-			return nil, errors.New("input is not a string")
+			return nil, fmt.Errorf("input is not a string")
 		}
 		res += " " + iString
 	}

--- a/diff/aclGroup.go
+++ b/diff/aclGroup.go
@@ -1,15 +1,16 @@
 package diff
 
 import (
+	"fmt"
+
 	"github.com/kong/deck/crud"
 	"github.com/kong/deck/state"
-	"github.com/pkg/errors"
 )
 
 func (sc *Syncer) deleteACLGroups() error {
 	currentACLGroups, err := sc.currentState.ACLGroups.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching acls from state")
+		return fmt.Errorf("error fetching acls from state: %w", err)
 	}
 
 	for _, aclGroup := range currentACLGroups {
@@ -38,7 +39,7 @@ func (sc *Syncer) deleteACLGroup(aclGroup *state.ACLGroup) (*Event, error) {
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "looking up acl '%v'", *aclGroup.Group)
+		return nil, fmt.Errorf("looking up acl %q: %w", *aclGroup.Group, err)
 	}
 	return nil, nil
 }
@@ -46,7 +47,7 @@ func (sc *Syncer) deleteACLGroup(aclGroup *state.ACLGroup) (*Event, error) {
 func (sc *Syncer) createUpdateACLGroups() error {
 	targetACLGroups, err := sc.targetState.ACLGroups.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching acls from state")
+		return fmt.Errorf("error fetching acls from state: %w", err)
 	}
 
 	for _, aclGroup := range targetACLGroups {
@@ -78,8 +79,8 @@ func (sc *Syncer) createUpdateACLGroup(aclGroup *state.ACLGroup) (*Event, error)
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "error looking up acl %v",
-			*aclGroup.Group)
+		return nil, fmt.Errorf("error looking up acl %q: %w",
+			*aclGroup.Group, err)
 	}
 	// found, check if update needed
 

--- a/diff/basicAuth.go
+++ b/diff/basicAuth.go
@@ -1,10 +1,11 @@
 package diff
 
 import (
+	"fmt"
+
 	"github.com/kong/deck/crud"
 	"github.com/kong/deck/print"
 	"github.com/kong/deck/state"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -24,7 +25,7 @@ func (sc *Syncer) warnBasicAuth() {
 func (sc *Syncer) deleteBasicAuths() error {
 	currentBasicAuths, err := sc.currentState.BasicAuths.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching basic-auths from state")
+		return fmt.Errorf("error fetching basic-auths from state: %w", err)
 	}
 
 	for _, basicAuth := range currentBasicAuths {
@@ -53,8 +54,8 @@ func (sc *Syncer) deleteBasicAuth(basicAuth *state.BasicAuth) (*Event, error) {
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "looking up basic-auth '%v'",
-			*basicAuth.Username)
+		return nil, fmt.Errorf("looking up basic-auth %q: %w",
+			*basicAuth.Username, err)
 	}
 	return nil, nil
 }
@@ -62,7 +63,7 @@ func (sc *Syncer) deleteBasicAuth(basicAuth *state.BasicAuth) (*Event, error) {
 func (sc *Syncer) createUpdateBasicAuths() error {
 	targetBasicAuths, err := sc.targetState.BasicAuths.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching basic-auths from state")
+		return fmt.Errorf("error fetching basic-auths from state: %w", err)
 	}
 
 	for _, basicAuth := range targetBasicAuths {
@@ -94,8 +95,8 @@ func (sc *Syncer) createUpdateBasicAuth(basicAuth *state.BasicAuth) (*Event, err
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "error looking up basic-auth %v",
-			*basicAuth.Username)
+		return nil, fmt.Errorf("error looking up basic-auth %q: %w",
+			*basicAuth.Username, err)
 	}
 	// found, check if update needed
 

--- a/diff/caCert.go
+++ b/diff/caCert.go
@@ -1,15 +1,16 @@
 package diff
 
 import (
+	"fmt"
+
 	"github.com/kong/deck/crud"
 	"github.com/kong/deck/state"
-	"github.com/pkg/errors"
 )
 
 func (sc *Syncer) deleteCACertificates() error {
 	currentCACertificates, err := sc.currentState.CACertificates.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching caCertificates from state")
+		return fmt.Errorf("error fetching caCertificates from state: %w", err)
 	}
 
 	for _, certificate := range currentCACertificates {
@@ -38,8 +39,8 @@ func (sc *Syncer) deleteCACertificate(
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "looking up caCertificate '%v'",
-			caCert.Identifier())
+		return nil, fmt.Errorf("looking up caCertificate %q: %w",
+			caCert.Identifier(), err)
 	}
 	return nil, nil
 }
@@ -47,7 +48,7 @@ func (sc *Syncer) deleteCACertificate(
 func (sc *Syncer) createUpdateCACertificates() error {
 	targetCACertificates, err := sc.targetState.CACertificates.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching caCertificates from state")
+		return fmt.Errorf("error fetching caCertificates from state: %w", err)
 	}
 
 	for _, caCert := range targetCACertificates {
@@ -79,8 +80,8 @@ func (sc *Syncer) createUpdateCACertificate(
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "error looking up caCertificate %v",
-			caCert.Identifier())
+		return nil, fmt.Errorf("error looking up caCertificate %q: %w",
+			caCert.Identifier(), err)
 	}
 
 	// found, check if update needed

--- a/diff/cert.go
+++ b/diff/cert.go
@@ -1,15 +1,16 @@
 package diff
 
 import (
+	"fmt"
+
 	"github.com/kong/deck/crud"
 	"github.com/kong/deck/state"
-	"github.com/pkg/errors"
 )
 
 func (sc *Syncer) deleteCertificates() error {
 	currentCertificates, err := sc.currentState.Certificates.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching certificates from state")
+		return fmt.Errorf("error fetching certificates from state: %w", err)
 	}
 
 	for _, certificate := range currentCertificates {
@@ -38,8 +39,8 @@ func (sc *Syncer) deleteCertificate(
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "looking up certificate '%v'",
-			certificate.Identifier())
+		return nil, fmt.Errorf("looking up certificate %q': %w",
+			certificate.Identifier(), err)
 	}
 	return nil, nil
 }
@@ -47,7 +48,7 @@ func (sc *Syncer) deleteCertificate(
 func (sc *Syncer) createUpdateCertificates() error {
 	targetCertificates, err := sc.targetState.Certificates.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching certificates from state")
+		return fmt.Errorf("error fetching certificates from state: %w", err)
 	}
 
 	for _, certificate := range targetCertificates {
@@ -79,8 +80,8 @@ func (sc *Syncer) createUpdateCertificate(
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "error looking up certificate %v",
-			certificate.Identifier())
+		return nil, fmt.Errorf("error looking up certificate %q: %w",
+			certificate.Identifier(), err)
 	}
 
 	// found, check if update needed
@@ -95,8 +96,8 @@ func (sc *Syncer) createUpdateCertificate(
 		// subsequent actions on the SNI objects will handle those.
 		currentSNIs, err := sc.currentState.SNIs.GetAllByCertID(*currentCertificate.ID)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error looking up current certificate SNIs %v",
-				certificate.Identifier())
+			return nil, fmt.Errorf("error looking up current certificate SNIs %q: %w",
+				certificate.Identifier(), err)
 		}
 		sniNames := make([]*string, 0)
 		for _, s := range currentSNIs {

--- a/diff/consumer.go
+++ b/diff/consumer.go
@@ -1,15 +1,16 @@
 package diff
 
 import (
+	"fmt"
+
 	"github.com/kong/deck/crud"
 	"github.com/kong/deck/state"
-	"github.com/pkg/errors"
 )
 
 func (sc *Syncer) deleteConsumers() error {
 	currentConsumers, err := sc.currentState.Consumers.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching consumers from state")
+		return fmt.Errorf("error fetching consumers from state: %w", err)
 	}
 
 	for _, consumer := range currentConsumers {
@@ -38,8 +39,8 @@ func (sc *Syncer) deleteConsumer(consumer *state.Consumer) (*Event, error) {
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "looking up consumer '%v'",
-			consumer.Identifier())
+		return nil, fmt.Errorf("looking up consumer %q: %w",
+			consumer.Identifier(), err)
 	}
 	return nil, nil
 }
@@ -47,7 +48,7 @@ func (sc *Syncer) deleteConsumer(consumer *state.Consumer) (*Event, error) {
 func (sc *Syncer) createUpdateConsumers() error {
 	targetConsumers, err := sc.targetState.Consumers.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching consumers from state")
+		return fmt.Errorf("error fetching consumers from state: %w", err)
 	}
 
 	for _, consumer := range targetConsumers {
@@ -78,8 +79,8 @@ func (sc *Syncer) createUpdateConsumer(consumer *state.Consumer) (*Event, error)
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "error looking up consumer %v",
-			consumer.Identifier())
+		return nil, fmt.Errorf("error looking up consumer %q: %w",
+			consumer.Identifier(), err)
 	}
 
 	// found, check if update needed

--- a/diff/documents.go
+++ b/diff/documents.go
@@ -1,15 +1,16 @@
 package diff
 
 import (
+	"fmt"
+
 	"github.com/kong/deck/crud"
 	"github.com/kong/deck/state"
-	"github.com/pkg/errors"
 )
 
 func (sc *Syncer) deleteDocuments() error {
 	currentDocuments, err := sc.currentState.Documents.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching documents from state")
+		return fmt.Errorf("error fetching documents from state: %w", err)
 	}
 
 	for _, d := range currentDocuments {
@@ -38,8 +39,8 @@ func (sc *Syncer) deleteDocument(d *state.Document) (*Event, error) {
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "looking up document '%v'",
-			d.Identifier())
+		return nil, fmt.Errorf("looking up document %q: %w",
+			d.Identifier(), err)
 	}
 	return nil, nil
 }
@@ -47,7 +48,7 @@ func (sc *Syncer) deleteDocument(d *state.Document) (*Event, error) {
 func (sc *Syncer) createUpdateDocuments() error {
 	targetDocuments, err := sc.targetState.Documents.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching documents from state")
+		return fmt.Errorf("error fetching documents from state: %w", err)
 	}
 
 	for _, d := range targetDocuments {
@@ -77,8 +78,8 @@ func (sc *Syncer) createUpdateDocument(d *state.Document) (*Event, error) {
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "error looking up document %v",
-			d.Identifier())
+		return nil, fmt.Errorf("error looking up document %q: %w",
+			d.Identifier(), err)
 	}
 
 	// found, check if update needed

--- a/diff/hmacAuth.go
+++ b/diff/hmacAuth.go
@@ -1,15 +1,16 @@
 package diff
 
 import (
+	"fmt"
+
 	"github.com/kong/deck/crud"
 	"github.com/kong/deck/state"
-	"github.com/pkg/errors"
 )
 
 func (sc *Syncer) deleteHMACAuths() error {
 	currentHMACAuths, err := sc.currentState.HMACAuths.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching hmac-auths from state")
+		return fmt.Errorf("error fetching hmac-auths from state: %w", err)
 	}
 
 	for _, hmacAuth := range currentHMACAuths {
@@ -37,8 +38,8 @@ func (sc *Syncer) deleteHMACAuth(hmacAuth *state.HMACAuth) (*Event, error) {
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "looking up hmac-auth '%v'",
-			*hmacAuth.Username)
+		return nil, fmt.Errorf("looking up hmac-auth %q: %w",
+			*hmacAuth.Username, err)
 	}
 	return nil, nil
 }
@@ -46,7 +47,7 @@ func (sc *Syncer) deleteHMACAuth(hmacAuth *state.HMACAuth) (*Event, error) {
 func (sc *Syncer) createUpdateHMACAuths() error {
 	targetHMACAuths, err := sc.targetState.HMACAuths.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching hmac-auths from state")
+		return fmt.Errorf("error fetching hmac-auths from state: %w", err)
 	}
 
 	for _, hmacAuth := range targetHMACAuths {
@@ -77,8 +78,8 @@ func (sc *Syncer) createUpdateHMACAuth(hmacAuth *state.HMACAuth) (*Event, error)
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "error looking up hmac-auth %v",
-			*hmacAuth.Username)
+		return nil, fmt.Errorf("error looking up hmac-auth %q: %w",
+			*hmacAuth.Username, err)
 	}
 	// found, check if update needed
 

--- a/diff/jwtAuth.go
+++ b/diff/jwtAuth.go
@@ -1,15 +1,16 @@
 package diff
 
 import (
+	"fmt"
+
 	"github.com/kong/deck/crud"
 	"github.com/kong/deck/state"
-	"github.com/pkg/errors"
 )
 
 func (sc *Syncer) deleteJWTAuths() error {
 	currentJWTAuths, err := sc.currentState.JWTAuths.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching jwt-auths from state")
+		return fmt.Errorf("error fetching jwt-auths from state: %w", err)
 	}
 
 	for _, jwtAuth := range currentJWTAuths {
@@ -37,7 +38,7 @@ func (sc *Syncer) deleteJWTAuth(jwtAuth *state.JWTAuth) (*Event, error) {
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "looking up jwt-auth '%v'", *jwtAuth.Key)
+		return nil, fmt.Errorf("looking up jwt-auth %q: %w", *jwtAuth.Key, err)
 	}
 	return nil, nil
 }
@@ -45,7 +46,7 @@ func (sc *Syncer) deleteJWTAuth(jwtAuth *state.JWTAuth) (*Event, error) {
 func (sc *Syncer) createUpdateJWTAuths() error {
 	targetJWTAuths, err := sc.targetState.JWTAuths.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching jwt-auths from state")
+		return fmt.Errorf("error fetching jwt-auths from state: %w", err)
 	}
 
 	for _, jwtAuth := range targetJWTAuths {
@@ -76,8 +77,8 @@ func (sc *Syncer) createUpdateJWTAuth(jwtAuth *state.JWTAuth) (*Event, error) {
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "error looking up jwt-auth %v",
-			*jwtAuth.Key)
+		return nil, fmt.Errorf("error looking up jwt-auth %q: %w",
+			*jwtAuth.Key, err)
 	}
 	// found, check if update needed
 

--- a/diff/keyAuth.go
+++ b/diff/keyAuth.go
@@ -1,15 +1,16 @@
 package diff
 
 import (
+	"fmt"
+
 	"github.com/kong/deck/crud"
 	"github.com/kong/deck/state"
-	"github.com/pkg/errors"
 )
 
 func (sc *Syncer) deleteKeyAuths() error {
 	currentKeyAuths, err := sc.currentState.KeyAuths.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching key-auths from state")
+		return fmt.Errorf("error fetching key-auths from state: %w", err)
 	}
 
 	for _, keyAuth := range currentKeyAuths {
@@ -37,7 +38,7 @@ func (sc *Syncer) deleteKeyAuth(keyAuth *state.KeyAuth) (*Event, error) {
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "looking up key-auth '%v'", *keyAuth.ID)
+		return nil, fmt.Errorf("looking up key-auth %q: %w", *keyAuth.ID, err)
 	}
 	return nil, nil
 }
@@ -45,7 +46,7 @@ func (sc *Syncer) deleteKeyAuth(keyAuth *state.KeyAuth) (*Event, error) {
 func (sc *Syncer) createUpdateKeyAuths() error {
 	targetKeyAuths, err := sc.targetState.KeyAuths.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching key-auths from state")
+		return fmt.Errorf("error fetching key-auths from state: %w", err)
 	}
 
 	for _, keyAuth := range targetKeyAuths {
@@ -76,8 +77,8 @@ func (sc *Syncer) createUpdateKeyAuth(keyAuth *state.KeyAuth) (*Event, error) {
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "error looking up key-auth %v",
-			*keyAuth.ID)
+		return nil, fmt.Errorf("error looking up key-auth %q: %w",
+			*keyAuth.ID, err)
 	}
 	// found, check if update needed
 

--- a/diff/mtlsAuth.go
+++ b/diff/mtlsAuth.go
@@ -1,15 +1,16 @@
 package diff
 
 import (
+	"fmt"
+
 	"github.com/kong/deck/crud"
 	"github.com/kong/deck/state"
-	"github.com/pkg/errors"
 )
 
 func (sc *Syncer) deleteMTLSAuths() error {
 	currentMTLSAuths, err := sc.currentState.MTLSAuths.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching mtls-auths from state")
+		return fmt.Errorf("error fetching mtls-auths from state: %w", err)
 	}
 
 	for _, mtlsAuth := range currentMTLSAuths {
@@ -37,7 +38,7 @@ func (sc *Syncer) deleteMTLSAuth(mtlsAuth *state.MTLSAuth) (*Event, error) {
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "looking up mtls-auth '%v'", *mtlsAuth.ID)
+		return nil, fmt.Errorf("looking up mtls-auth %q: %w", *mtlsAuth.ID, err)
 	}
 	return nil, nil
 }
@@ -45,7 +46,7 @@ func (sc *Syncer) deleteMTLSAuth(mtlsAuth *state.MTLSAuth) (*Event, error) {
 func (sc *Syncer) createUpdateMTLSAuths() error {
 	targetMTLSAuths, err := sc.targetState.MTLSAuths.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching mtls-auths from state")
+		return fmt.Errorf("error fetching mtls-auths from state: %w", err)
 	}
 
 	for _, mtlsAuth := range targetMTLSAuths {
@@ -76,8 +77,8 @@ func (sc *Syncer) createUpdateMTLSAuth(mtlsAuth *state.MTLSAuth) (*Event, error)
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "error looking up mtls-auth %v",
-			*mtlsAuth.ID)
+		return nil, fmt.Errorf("error looking up mtls-auth %q: %w",
+			*mtlsAuth.ID, err)
 	}
 	// found, check if update needed
 

--- a/diff/oauth2.go
+++ b/diff/oauth2.go
@@ -1,15 +1,16 @@
 package diff
 
 import (
+	"fmt"
+
 	"github.com/kong/deck/crud"
 	"github.com/kong/deck/state"
-	"github.com/pkg/errors"
 )
 
 func (sc *Syncer) deleteOauth2Creds() error {
 	currentOauth2Creds, err := sc.currentState.Oauth2Creds.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching oauth2-cred from state")
+		return fmt.Errorf("error fetching oauth2-cred from state: %w", err)
 	}
 
 	for _, oauth2Cred := range currentOauth2Creds {
@@ -38,7 +39,7 @@ func (sc *Syncer) deleteOauth2Cred(oauth2Cred *state.Oauth2Credential) (
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "looking up oauth2-cred '%v'", *oauth2Cred.Name)
+		return nil, fmt.Errorf("looking up oauth2-cred %q: %w", *oauth2Cred.Name, err)
 	}
 	return nil, nil
 }
@@ -46,7 +47,7 @@ func (sc *Syncer) deleteOauth2Cred(oauth2Cred *state.Oauth2Credential) (
 func (sc *Syncer) createUpdateOauth2Creds() error {
 	targetOauth2Creds, err := sc.targetState.Oauth2Creds.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching oauth2-creds from state")
+		return fmt.Errorf("error fetching oauth2-creds from state: %w", err)
 	}
 
 	for _, oauth2Cred := range targetOauth2Creds {
@@ -77,8 +78,8 @@ func (sc *Syncer) createUpdateOauth2Cred(oauth2Cred *state.Oauth2Credential) (*E
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "error looking up oauth2-cred %v",
-			*oauth2Cred.Name)
+		return nil, fmt.Errorf("error looking up oauth2-cred %q: %w",
+			*oauth2Cred.Name, err)
 	}
 	currentOauth2Cred = &state.Oauth2Credential{Oauth2Credential: *currentOauth2Cred.DeepCopy()}
 	// found, check if update needed

--- a/diff/plugin.go
+++ b/diff/plugin.go
@@ -1,15 +1,16 @@
 package diff
 
 import (
+	"fmt"
+
 	"github.com/kong/deck/crud"
 	"github.com/kong/deck/state"
-	"github.com/pkg/errors"
 )
 
 func (sc *Syncer) deletePlugins() error {
 	currentPlugins, err := sc.currentState.Plugins.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching plugins from state")
+		return fmt.Errorf("error fetching plugins from state: %w", err)
 	}
 
 	for _, plugin := range currentPlugins {
@@ -41,7 +42,7 @@ func (sc *Syncer) deletePlugin(plugin *state.Plugin) (*Event, error) {
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "looking up plugin '%v'", *plugin.ID)
+		return nil, fmt.Errorf("looking up plugin %q: %w", *plugin.ID, err)
 	}
 	return nil, nil
 }
@@ -49,7 +50,7 @@ func (sc *Syncer) deletePlugin(plugin *state.Plugin) (*Event, error) {
 func (sc *Syncer) createUpdatePlugins() error {
 	targetPlugins, err := sc.targetState.Plugins.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching plugins from state")
+		return fmt.Errorf("error fetching plugins from state: %w", err)
 	}
 
 	for _, plugin := range targetPlugins {
@@ -83,8 +84,8 @@ func (sc *Syncer) createUpdatePlugin(plugin *state.Plugin) (*Event, error) {
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "error looking up plugin %v",
-			*plugin.Name)
+		return nil, fmt.Errorf("error looking up plugin %q: %w",
+			*plugin.Name, err)
 	}
 	currentPlugin = &state.Plugin{Plugin: *currentPlugin.DeepCopy()}
 	// found, check if update needed

--- a/diff/rbac_endpoint_permission.go
+++ b/diff/rbac_endpoint_permission.go
@@ -1,15 +1,16 @@
 package diff
 
 import (
+	"fmt"
+
 	"github.com/kong/deck/crud"
 	"github.com/kong/deck/state"
-	"github.com/pkg/errors"
 )
 
 func (sc *Syncer) deleteRBACEndpointPermissions() error {
 	currentRBACEndpointPermissions, err := sc.currentState.RBACEndpointPermissions.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching eps from state")
+		return fmt.Errorf("error fetching eps from state: %w", err)
 	}
 
 	for _, ep := range currentRBACEndpointPermissions {
@@ -38,8 +39,8 @@ func (sc *Syncer) deleteRBACEndpointPermission(ep *state.RBACEndpointPermission)
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "looking up rbac ep '%v'",
-			ep.ID)
+		return nil, fmt.Errorf("looking up rbac ep %q: %w",
+			ep.ID, err)
 	}
 	return nil, nil
 }
@@ -47,7 +48,7 @@ func (sc *Syncer) deleteRBACEndpointPermission(ep *state.RBACEndpointPermission)
 func (sc *Syncer) createUpdateRBACEndpointPermissions() error {
 	targetRBACEndpointPermissions, err := sc.targetState.RBACEndpointPermissions.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching rbac eps from state")
+		return fmt.Errorf("error fetching rbac eps from state: %w", err)
 	}
 
 	for _, ep := range targetRBACEndpointPermissions {
@@ -77,8 +78,8 @@ func (sc *Syncer) createUpdateRBACEndpointPermission(ep *state.RBACEndpointPermi
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "error looking up rbac endpoint permission %v",
-			ep.Identifier())
+		return nil, fmt.Errorf("error looking up rbac endpoint permission %q: %w",
+			ep.Identifier(), err)
 	}
 
 	// found, check if update needed

--- a/diff/rbac_role.go
+++ b/diff/rbac_role.go
@@ -1,15 +1,16 @@
 package diff
 
 import (
+	"fmt"
+
 	"github.com/kong/deck/crud"
 	"github.com/kong/deck/state"
-	"github.com/pkg/errors"
 )
 
 func (sc *Syncer) deleteRBACRoles() error {
 	currentRBACRoles, err := sc.currentState.RBACRoles.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching rbac roles from state")
+		return fmt.Errorf("error fetching rbac roles from state: %w", err)
 	}
 
 	for _, role := range currentRBACRoles {
@@ -38,8 +39,8 @@ func (sc *Syncer) deleteRBACRole(role *state.RBACRole) (*Event, error) {
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "looking up rbac role '%v'",
-			role.Identifier())
+		return nil, fmt.Errorf("looking up rbac role %q: %w",
+			role.Identifier(), err)
 	}
 	return nil, nil
 }
@@ -47,7 +48,7 @@ func (sc *Syncer) deleteRBACRole(role *state.RBACRole) (*Event, error) {
 func (sc *Syncer) createUpdateRBACRoles() error {
 	targetRBACRoles, err := sc.targetState.RBACRoles.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching rbac roles from state")
+		return fmt.Errorf("error fetching rbac roles from state: %w", err)
 	}
 
 	for _, role := range targetRBACRoles {
@@ -77,8 +78,8 @@ func (sc *Syncer) createUpdateRBACRole(role *state.RBACRole) (*Event, error) {
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "error looking up rbac role %v",
-			role.Identifier())
+		return nil, fmt.Errorf("error looking up rbac role %q: %w",
+			role.Identifier(), err)
 	}
 
 	// found, check if update needed

--- a/diff/route.go
+++ b/diff/route.go
@@ -1,15 +1,16 @@
 package diff
 
 import (
+	"fmt"
+
 	"github.com/kong/deck/crud"
 	"github.com/kong/deck/state"
-	"github.com/pkg/errors"
 )
 
 func (sc *Syncer) deleteRoutes() error {
 	currentRoutes, err := sc.currentState.Routes.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching routes from state")
+		return fmt.Errorf("error fetching routes from state: %w", err)
 	}
 
 	for _, route := range currentRoutes {
@@ -37,8 +38,8 @@ func (sc *Syncer) deleteRoute(route *state.Route) (*Event, error) {
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "looking up route '%v'",
-			route.Identifier())
+		return nil, fmt.Errorf("looking up route %q: %w",
+			route.Identifier(), err)
 	}
 	return nil, nil
 }
@@ -46,7 +47,7 @@ func (sc *Syncer) deleteRoute(route *state.Route) (*Event, error) {
 func (sc *Syncer) createUpdateRoutes() error {
 	targetRoutes, err := sc.targetState.Routes.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching routes from state")
+		return fmt.Errorf("error fetching routes from state: %w", err)
 	}
 
 	for _, route := range targetRoutes {
@@ -77,8 +78,8 @@ func (sc *Syncer) createUpdateRoute(route *state.Route) (*Event, error) {
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "error looking up route %v",
-			route.Identifier())
+		return nil, fmt.Errorf("error looking up route %q: %w",
+			route.Identifier(), err)
 	}
 	// found, check if update needed
 

--- a/diff/service.go
+++ b/diff/service.go
@@ -1,15 +1,16 @@
 package diff
 
 import (
+	"fmt"
+
 	"github.com/kong/deck/crud"
 	"github.com/kong/deck/state"
-	"github.com/pkg/errors"
 )
 
 func (sc *Syncer) deleteServices() error {
 	currentServices, err := sc.currentState.Services.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching services from state")
+		return fmt.Errorf("error fetching services from state: %w", err)
 	}
 
 	for _, service := range currentServices {
@@ -38,8 +39,8 @@ func (sc *Syncer) deleteService(service *state.Service) (*Event, error) {
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "looking up service '%v'",
-			service.Identifier())
+		return nil, fmt.Errorf("looking up service %q: %w",
+			service.Identifier(), err)
 	}
 	return nil, nil
 }
@@ -47,7 +48,7 @@ func (sc *Syncer) deleteService(service *state.Service) (*Event, error) {
 func (sc *Syncer) createUpdateServices() error {
 	targetServices, err := sc.targetState.Services.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching services from state")
+		return fmt.Errorf("error fetching services from state: %w", err)
 	}
 
 	for _, service := range targetServices {
@@ -77,8 +78,8 @@ func (sc *Syncer) createUpdateService(service *state.Service) (*Event, error) {
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "error looking up service %v",
-			*service.Name)
+		return nil, fmt.Errorf("error looking up service %q: %w",
+			*service.Name, err)
 	}
 
 	// found, check if update needed

--- a/diff/service_packages.go
+++ b/diff/service_packages.go
@@ -1,15 +1,16 @@
 package diff
 
 import (
+	"fmt"
+
 	"github.com/kong/deck/crud"
 	"github.com/kong/deck/state"
-	"github.com/pkg/errors"
 )
 
 func (sc *Syncer) deleteServicePackages() error {
 	currentServicePackages, err := sc.currentState.ServicePackages.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching services-packages from state")
+		return fmt.Errorf("error fetching services-packages from state: %w", err)
 	}
 
 	for _, sp := range currentServicePackages {
@@ -38,8 +39,8 @@ func (sc *Syncer) deleteServicePackage(sp *state.ServicePackage) (*Event, error)
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "looking up service-package '%v'",
-			sp.Identifier())
+		return nil, fmt.Errorf("looking up service-package %q: %w",
+			sp.Identifier(), err)
 	}
 	return nil, nil
 }
@@ -47,7 +48,7 @@ func (sc *Syncer) deleteServicePackage(sp *state.ServicePackage) (*Event, error)
 func (sc *Syncer) createUpdateServicePackages() error {
 	targetServicePackages, err := sc.targetState.ServicePackages.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching services-packages from state")
+		return fmt.Errorf("error fetching services-packages from state: %w", err)
 	}
 
 	for _, sp := range targetServicePackages {
@@ -77,8 +78,8 @@ func (sc *Syncer) createUpdateServicePackage(sp *state.ServicePackage) (*Event, 
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "error looking up service-package %v",
-			sp.Identifier())
+		return nil, fmt.Errorf("error looking up service-package %q: %w",
+			sp.Identifier(), err)
 	}
 
 	// found, check if update needed

--- a/diff/service_versions.go
+++ b/diff/service_versions.go
@@ -1,15 +1,16 @@
 package diff
 
 import (
+	"fmt"
+
 	"github.com/kong/deck/crud"
 	"github.com/kong/deck/state"
-	"github.com/pkg/errors"
 )
 
 func (sc *Syncer) deleteServiceVersions() error {
 	currentServiceVersions, err := sc.currentState.ServiceVersions.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching service-versions from state")
+		return fmt.Errorf("error fetching service-versions from state: %w", err)
 	}
 
 	for _, sv := range currentServiceVersions {
@@ -38,8 +39,8 @@ func (sc *Syncer) deleteServiceVersion(sv *state.ServiceVersion) (*Event, error)
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "looking up service-version '%v'",
-			sv.Identifier())
+		return nil, fmt.Errorf("looking up service-version %q': %w",
+			sv.Identifier(), err)
 	}
 	return nil, nil
 }
@@ -47,7 +48,7 @@ func (sc *Syncer) deleteServiceVersion(sv *state.ServiceVersion) (*Event, error)
 func (sc *Syncer) createUpdateServiceVersions() error {
 	targetServiceVersions, err := sc.targetState.ServiceVersions.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching services from state")
+		return fmt.Errorf("error fetching services from state: %w", err)
 	}
 
 	for _, sv := range targetServiceVersions {
@@ -77,8 +78,8 @@ func (sc *Syncer) createUpdateServiceVersion(sv *state.ServiceVersion) (*Event, 
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "error looking up service-version %v",
-			sv.Identifier())
+		return nil, fmt.Errorf("error looking up service-version %q: %w",
+			sv.Identifier(), err)
 	}
 
 	// found, check if update needed

--- a/diff/sni.go
+++ b/diff/sni.go
@@ -1,15 +1,16 @@
 package diff
 
 import (
+	"fmt"
+
 	"github.com/kong/deck/crud"
 	"github.com/kong/deck/state"
-	"github.com/pkg/errors"
 )
 
 func (sc *Syncer) deleteSNIs() error {
 	currentSNIs, err := sc.currentState.SNIs.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching snis from state")
+		return fmt.Errorf("error fetching snis from state: %w", err)
 	}
 
 	for _, sni := range currentSNIs {
@@ -37,7 +38,7 @@ func (sc *Syncer) deleteSNI(sni *state.SNI) (*Event, error) {
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "looking up sni '%v'", *sni.Name)
+		return nil, fmt.Errorf("looking up sni %q: %w", *sni.Name, err)
 	}
 	return nil, nil
 }
@@ -45,7 +46,7 @@ func (sc *Syncer) deleteSNI(sni *state.SNI) (*Event, error) {
 func (sc *Syncer) createUpdateSNIs() error {
 	sniSNIs, err := sc.targetState.SNIs.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching snis from state")
+		return fmt.Errorf("error fetching snis from state: %w", err)
 	}
 
 	for _, sni := range sniSNIs {
@@ -76,7 +77,7 @@ func (sc *Syncer) createUpdateSNI(sni *state.SNI) (*Event, error) {
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "error looking up sni %v", *sni.Name)
+		return nil, fmt.Errorf("error looking up sni %q: %w", *sni.Name, err)
 	}
 	// found, check if update needed
 

--- a/diff/target.go
+++ b/diff/target.go
@@ -1,15 +1,16 @@
 package diff
 
 import (
+	"fmt"
+
 	"github.com/kong/deck/crud"
 	"github.com/kong/deck/state"
-	"github.com/pkg/errors"
 )
 
 func (sc *Syncer) deleteTargets() error {
 	currentTargets, err := sc.currentState.Targets.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching targets from state")
+		return fmt.Errorf("error fetching targets from state: %w", err)
 	}
 
 	for _, target := range currentTargets {
@@ -38,8 +39,8 @@ func (sc *Syncer) deleteTarget(target *state.Target) (*Event, error) {
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "looking up target '%v'",
-			*target.Target.Target)
+		return nil, fmt.Errorf("looking up target %q: %w",
+			*target.Target.Target, err)
 	}
 	return nil, nil
 }
@@ -47,7 +48,7 @@ func (sc *Syncer) deleteTarget(target *state.Target) (*Event, error) {
 func (sc *Syncer) createUpdateTargets() error {
 	targetTargets, err := sc.targetState.Targets.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching targets from state")
+		return fmt.Errorf("error fetching targets from state: %w", err)
 	}
 
 	for _, target := range targetTargets {
@@ -79,8 +80,8 @@ func (sc *Syncer) createUpdateTarget(target *state.Target) (*Event, error) {
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "error looking up target %v",
-			*target.Target.Target)
+		return nil, fmt.Errorf("error looking up target %q: %w",
+			*target.Target.Target, err)
 	}
 	// found, check if update needed
 

--- a/diff/upstream.go
+++ b/diff/upstream.go
@@ -1,15 +1,16 @@
 package diff
 
 import (
+	"fmt"
+
 	"github.com/kong/deck/crud"
 	"github.com/kong/deck/state"
-	"github.com/pkg/errors"
 )
 
 func (sc *Syncer) deleteUpstreams() error {
 	currentUpstreams, err := sc.currentState.Upstreams.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching upstreams from state")
+		return fmt.Errorf("error fetching upstreams from state: %w", err)
 	}
 
 	for _, upstream := range currentUpstreams {
@@ -38,8 +39,8 @@ func (sc *Syncer) deleteUpstream(upstream *state.Upstream) (*Event, error) {
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "looking up upstream '%v'",
-			*upstream.Name)
+		return nil, fmt.Errorf("looking up upstream %q: %w",
+			*upstream.Name, err)
 	}
 	return nil, nil
 }
@@ -47,7 +48,7 @@ func (sc *Syncer) deleteUpstream(upstream *state.Upstream) (*Event, error) {
 func (sc *Syncer) createUpdateUpstreams() error {
 	targetUpstreams, err := sc.targetState.Upstreams.GetAll()
 	if err != nil {
-		return errors.Wrap(err, "error fetching upstreams from state")
+		return fmt.Errorf("error fetching upstreams from state: %w", err)
 	}
 
 	for _, upstream := range targetUpstreams {
@@ -78,8 +79,8 @@ func (sc *Syncer) createUpdateUpstream(upstream *state.Upstream) (*Event,
 		}, nil
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "error looking up upstream %v",
-			*upstream.Name)
+		return nil, fmt.Errorf("error looking up upstream %v: %w",
+			*upstream.Name, err)
 	}
 
 	// found, check if update needed

--- a/dump/dump.go
+++ b/dump/dump.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/kong/deck/utils"
 	"github.com/kong/go-kong/kong"
-	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -65,7 +64,7 @@ func getConsumerConfiguration(ctx context.Context, group *errgroup.Group,
 	group.Go(func() error {
 		consumers, err := GetAllConsumers(ctx, client, config.SelectorTags)
 		if err != nil {
-			return errors.Wrap(err, "consumers")
+			return fmt.Errorf("consumers: %w", err)
 		}
 		state.Consumers = consumers
 		return nil
@@ -74,7 +73,7 @@ func getConsumerConfiguration(ctx context.Context, group *errgroup.Group,
 	group.Go(func() error {
 		keyAuths, err := GetAllKeyAuths(ctx, client, config.SelectorTags)
 		if err != nil {
-			return errors.Wrap(err, "key-auths")
+			return fmt.Errorf("key-auths: %w", err)
 		}
 		state.KeyAuths = keyAuths
 		return nil
@@ -83,7 +82,7 @@ func getConsumerConfiguration(ctx context.Context, group *errgroup.Group,
 	group.Go(func() error {
 		hmacAuths, err := GetAllHMACAuths(ctx, client, config.SelectorTags)
 		if err != nil {
-			return errors.Wrap(err, "hmac-auths")
+			return fmt.Errorf("hmac-auths: %w", err)
 		}
 		state.HMACAuths = hmacAuths
 		return nil
@@ -92,7 +91,7 @@ func getConsumerConfiguration(ctx context.Context, group *errgroup.Group,
 	group.Go(func() error {
 		jwtAuths, err := GetAllJWTAuths(ctx, client, config.SelectorTags)
 		if err != nil {
-			return errors.Wrap(err, "jwts")
+			return fmt.Errorf("jwts: %w", err)
 		}
 		state.JWTAuths = jwtAuths
 		return nil
@@ -101,7 +100,7 @@ func getConsumerConfiguration(ctx context.Context, group *errgroup.Group,
 	group.Go(func() error {
 		basicAuths, err := GetAllBasicAuths(ctx, client, config.SelectorTags)
 		if err != nil {
-			return errors.Wrap(err, "basic-auths")
+			return fmt.Errorf("basic-auths: %w", err)
 		}
 		state.BasicAuths = basicAuths
 		return nil
@@ -110,7 +109,7 @@ func getConsumerConfiguration(ctx context.Context, group *errgroup.Group,
 	group.Go(func() error {
 		oauth2Creds, err := GetAllOauth2Creds(ctx, client, config.SelectorTags)
 		if err != nil {
-			return errors.Wrap(err, "oauth2")
+			return fmt.Errorf("oauth2: %w", err)
 		}
 		state.Oauth2Creds = oauth2Creds
 		return nil
@@ -119,7 +118,7 @@ func getConsumerConfiguration(ctx context.Context, group *errgroup.Group,
 	group.Go(func() error {
 		aclGroups, err := GetAllACLGroups(ctx, client, config.SelectorTags)
 		if err != nil {
-			return errors.Wrap(err, "acls")
+			return fmt.Errorf("acls: %w", err)
 		}
 		state.ACLGroups = aclGroups
 		return nil
@@ -128,7 +127,7 @@ func getConsumerConfiguration(ctx context.Context, group *errgroup.Group,
 	group.Go(func() error {
 		mtlsAuths, err := GetAllMTLSAuths(ctx, client, config.SelectorTags)
 		if err != nil {
-			return errors.Wrap(err, "mtls-auths")
+			return fmt.Errorf("mtls-auths: %w", err)
 		}
 		state.MTLSAuths = mtlsAuths
 		return nil
@@ -140,7 +139,7 @@ func getProxyConfiguration(ctx context.Context, group *errgroup.Group,
 	group.Go(func() error {
 		services, err := GetAllServices(ctx, client, config.SelectorTags)
 		if err != nil {
-			return errors.Wrap(err, "services")
+			return fmt.Errorf("services: %w", err)
 		}
 		state.Services = services
 		return nil
@@ -149,7 +148,7 @@ func getProxyConfiguration(ctx context.Context, group *errgroup.Group,
 	group.Go(func() error {
 		routes, err := GetAllRoutes(ctx, client, config.SelectorTags)
 		if err != nil {
-			return errors.Wrap(err, "routes")
+			return fmt.Errorf("routes: %w", err)
 		}
 		state.Routes = routes
 		return nil
@@ -158,7 +157,7 @@ func getProxyConfiguration(ctx context.Context, group *errgroup.Group,
 	group.Go(func() error {
 		plugins, err := GetAllPlugins(ctx, client, config.SelectorTags)
 		if err != nil {
-			return errors.Wrap(err, "plugins")
+			return fmt.Errorf("plugins: %w", err)
 		}
 		if config.SkipConsumers {
 			state.Plugins = excludeConsumersPlugins(plugins)
@@ -171,7 +170,7 @@ func getProxyConfiguration(ctx context.Context, group *errgroup.Group,
 	group.Go(func() error {
 		certificates, err := GetAllCertificates(ctx, client, config.SelectorTags)
 		if err != nil {
-			return errors.Wrap(err, "certificates")
+			return fmt.Errorf("certificates: %w", err)
 		}
 		state.Certificates = certificates
 		return nil
@@ -180,7 +179,7 @@ func getProxyConfiguration(ctx context.Context, group *errgroup.Group,
 	group.Go(func() error {
 		caCerts, err := GetAllCACertificates(ctx, client, config.SelectorTags)
 		if err != nil {
-			return errors.Wrap(err, "ca-certificates")
+			return fmt.Errorf("ca-certificates: %w", err)
 		}
 		state.CACertificates = caCerts
 		return nil
@@ -189,7 +188,7 @@ func getProxyConfiguration(ctx context.Context, group *errgroup.Group,
 	group.Go(func() error {
 		snis, err := GetAllSNIs(ctx, client, config.SelectorTags)
 		if err != nil {
-			return errors.Wrap(err, "snis")
+			return fmt.Errorf("snis: %w", err)
 		}
 		state.SNIs = snis
 		return nil
@@ -198,12 +197,12 @@ func getProxyConfiguration(ctx context.Context, group *errgroup.Group,
 	group.Go(func() error {
 		upstreams, err := GetAllUpstreams(ctx, client, config.SelectorTags)
 		if err != nil {
-			return errors.Wrap(err, "upstreams")
+			return fmt.Errorf("upstreams: %w", err)
 		}
 		state.Upstreams = upstreams
 		targets, err := GetAllTargets(ctx, client, upstreams, config.SelectorTags)
 		if err != nil {
-			return errors.Wrap(err, "targets")
+			return fmt.Errorf("targets: %w", err)
 		}
 		state.Targets = targets
 		return nil
@@ -215,7 +214,7 @@ func getEnterpriseRBACConfiguration(ctx context.Context, group *errgroup.Group,
 	group.Go(func() error {
 		roles, err := GetAllRBACRoles(ctx, client)
 		if err != nil {
-			return errors.Wrap(err, "roles")
+			return fmt.Errorf("roles: %w", err)
 		}
 		state.RBACRoles = roles
 		return nil
@@ -224,7 +223,7 @@ func getEnterpriseRBACConfiguration(ctx context.Context, group *errgroup.Group,
 	group.Go(func() error {
 		eps, err := GetAllRBACREndpointPermissions(ctx, client)
 		if err != nil {
-			return errors.Wrap(err, "eps")
+			return fmt.Errorf("eps: %w", err)
 		}
 		state.RBACEndpointPermissions = eps
 		return nil

--- a/dump/dump_test.go
+++ b/dump/dump_test.go
@@ -1,6 +1,8 @@
 package dump
 
-import "testing"
+import (
+	"testing"
+)
 
 func Test_validateConfig(t *testing.T) {
 	type args struct {

--- a/file/builder.go
+++ b/file/builder.go
@@ -1,12 +1,13 @@
 package file
 
 import (
+	"fmt"
+
 	"github.com/blang/semver/v4"
 	"github.com/kong/deck/konnect"
 	"github.com/kong/deck/state"
 	"github.com/kong/deck/utils"
 	"github.com/kong/go-kong/kong"
-	"github.com/pkg/errors"
 )
 
 type stateBuilder struct {
@@ -690,8 +691,9 @@ func (b *stateBuilder) plugins() {
 		if p.Consumer != nil && !utils.Empty(p.Consumer.ID) {
 			c, err := b.intermediate.Consumers.Get(*p.Consumer.ID)
 			if err == state.ErrNotFound {
-				b.err = errors.Wrapf(err, "consumer %v for plugin %v",
-					*p.Consumer.ID, *p.Name)
+				b.err = fmt.Errorf("consumer %v for plugin %v: %w",
+					*p.Consumer.ID, *p.Name, err)
+
 				return
 			} else if err != nil {
 				b.err = err
@@ -702,8 +704,9 @@ func (b *stateBuilder) plugins() {
 		if p.Service != nil && !utils.Empty(p.Service.ID) {
 			s, err := b.intermediate.Services.Get(*p.Service.ID)
 			if err == state.ErrNotFound {
-				b.err = errors.Wrapf(err, "service %v for plugin %v",
-					*p.Service.ID, *p.Name)
+				b.err = fmt.Errorf("service %v for plugin %v: %w",
+					*p.Service.ID, *p.Name, err)
+
 				return
 			} else if err != nil {
 				b.err = err
@@ -714,8 +717,9 @@ func (b *stateBuilder) plugins() {
 		if p.Route != nil && !utils.Empty(p.Route.ID) {
 			s, err := b.intermediate.Routes.Get(*p.Route.ID)
 			if err == state.ErrNotFound {
-				b.err = errors.Wrapf(err, "route %v for plugin %v",
-					*p.Route.ID, *p.Name)
+				b.err = fmt.Errorf("route %v for plugin %v: %w",
+					*p.Route.ID, *p.Name, err)
+
 				return
 			} else if err != nil {
 				b.err = err
@@ -795,12 +799,12 @@ func (b *stateBuilder) ingestPlugins(plugins []FPlugin) error {
 
 func (b *stateBuilder) fillPluginConfig(plugin *FPlugin) error {
 	if plugin == nil {
-		return errors.New("plugin is nil")
+		return fmt.Errorf("plugin is nil")
 	}
 	if !utils.Empty(plugin.ConfigSource) {
 		conf, ok := b.targetContent.PluginConfigs[*plugin.ConfigSource]
 		if !ok {
-			return errors.Errorf("_plugin_config '%v' not found",
+			return fmt.Errorf("_plugin_config %q not found",
 				*plugin.ConfigSource)
 		}
 		for k, v := range conf {

--- a/file/konnect.go
+++ b/file/konnect.go
@@ -1,12 +1,12 @@
 package file
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/kong/deck/utils"
 	"github.com/kong/go-kong/kong"
-	"github.com/pkg/errors"
 )
 
 // PopulateDocumentContent updates the Documents contained within a Content with the
@@ -15,7 +15,7 @@ import (
 // where <root> is the directory containing the first state file.
 func (c Content) PopulateDocumentContent(filenames []string) error {
 	if len(filenames) == 0 {
-		return errors.New("cannot populate documents without a location")
+		return fmt.Errorf("cannot populate documents without a location")
 	}
 	// TODO decK actually allows you to use _multiple_ state files
 	// We currently choose the first arbitrarily and assume document content is under its directory
@@ -27,7 +27,7 @@ func (c Content) PopulateDocumentContent(filenames []string) error {
 			path := filepath.Join(root, utils.FilenameToName(*sp.Document.Path))
 			content, err := os.ReadFile(path)
 			if err != nil {
-				return errors.Wrap(err, "error reading document file")
+				return fmt.Errorf("error reading document file: %w", err)
 			}
 			sp.Document.Content = kong.String(string(content))
 		}
@@ -36,7 +36,7 @@ func (c Content) PopulateDocumentContent(filenames []string) error {
 				path := filepath.Join(root, utils.FilenameToName(*sv.Document.Path))
 				content, err := os.ReadFile(path)
 				if err != nil {
-					return errors.Wrap(err, "error reading document file")
+					return fmt.Errorf("error reading document file: %w", err)
 				}
 				sv.Document.Content = kong.String(string(content))
 			}

--- a/file/reader.go
+++ b/file/reader.go
@@ -6,7 +6,6 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/kong/deck/state"
 	"github.com/kong/deck/utils"
-	"github.com/pkg/errors"
 )
 
 // RenderConfig contains necessary information to render a correct
@@ -26,7 +25,7 @@ type RenderConfig struct {
 // or if there is any error during processing.
 func GetContentFromFiles(filenames []string) (*Content, error) {
 	if len(filenames) == 0 {
-		return nil, errors.New("filename cannot be empty")
+		return nil, fmt.Errorf("filename cannot be empty")
 	}
 
 	return getContent(filenames)
@@ -41,13 +40,13 @@ func GetForKonnect(fileContent *Content, opt RenderConfig) (*utils.KongRawState,
 
 	d, err := utils.GetKongDefaulter()
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "creating defaulter")
+		return nil, nil, fmt.Errorf("creating defaulter: %w", err)
 	}
 	builder.defaulter = d
 
 	kongState, konnectState, err := builder.build()
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "building state")
+		return nil, nil, fmt.Errorf("building state: %w", err)
 	}
 	return kongState, konnectState, nil
 }
@@ -63,13 +62,13 @@ func Get(fileContent *Content, opt RenderConfig) (*utils.KongRawState, error) {
 
 	d, err := utils.GetKongDefaulter()
 	if err != nil {
-		return nil, errors.Wrap(err, "creating defaulter")
+		return nil, fmt.Errorf("creating defaulter: %w", err)
 	}
 	builder.defaulter = d
 
 	state, _, err := builder.build()
 	if err != nil {
-		return nil, errors.Wrap(err, "building state")
+		return nil, fmt.Errorf("building state: %w", err)
 	}
 	return state, nil
 }

--- a/file/readfile.go
+++ b/file/readfile.go
@@ -13,7 +13,6 @@ import (
 
 	ghodss "github.com/ghodss/yaml"
 	"github.com/imdario/mergo"
-	"github.com/pkg/errors"
 )
 
 // getContent reads all the YAML and JSON files in the directory or the
@@ -32,11 +31,11 @@ func getContent(filenames []string) (*Content, error) {
 	for _, r := range allReaders {
 		content, err := readContent(r)
 		if err != nil {
-			return nil, errors.Wrap(err, "reading file")
+			return nil, fmt.Errorf("reading file: %w", err)
 		}
 		err = mergo.Merge(&res, content, mergo.WithAppendSlice)
 		if err != nil {
-			return nil, errors.Wrap(err, "merging file contents")
+			return nil, fmt.Errorf("merging file contents: %w", err)
 		}
 	}
 	return &res, nil
@@ -55,15 +54,14 @@ func getReaders(fileOrDir string) ([]io.Reader, error) {
 
 	finfo, err := os.Stat(fileOrDir)
 	if err != nil {
-		return nil, errors.Wrap(err, "reading state file")
+		return nil, fmt.Errorf("reading state file: %w", err)
 	}
 
 	var files []string
 	if finfo.IsDir() {
 		files, err = configFilesInDir(fileOrDir)
 		if err != nil {
-			return nil,
-				errors.Wrap(err, "getting files from directory")
+			return nil, fmt.Errorf("getting files from directory: %w", err)
 		}
 	} else {
 		files = append(files, fileOrDir)
@@ -73,7 +71,7 @@ func getReaders(fileOrDir string) ([]io.Reader, error) {
 	for _, file := range files {
 		f, err := os.Open(file)
 		if err != nil {
-			return nil, errors.Wrap(err, "opening file")
+			return nil, fmt.Errorf("opening file: %w", err)
 		}
 		res = append(res, bufio.NewReader(f))
 	}
@@ -95,7 +93,7 @@ func readContent(reader io.Reader) (*Content, error) {
 	renderedContentBytes := []byte(renderedContent)
 	err = validate(renderedContentBytes)
 	if err != nil {
-		return nil, errors.Wrap(err, "validating file content")
+		return nil, fmt.Errorf("validating file content: %w", err)
 	}
 	var result Content
 	err = yamlUnmarshal(renderedContentBytes, &result)
@@ -135,7 +133,7 @@ func configFilesInDir(dir string) ([]string, error) {
 		},
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "reading state directory")
+		return nil, fmt.Errorf("reading state directory: %w", err)
 	}
 	return res, nil
 }

--- a/file/types.go
+++ b/file/types.go
@@ -108,7 +108,7 @@ func copyToService(fService FService) service {
 func unwrapURL(urlString string, fService *FService) error {
 	parsed, err := url.Parse(urlString)
 	if err != nil {
-		return fmt.Errorf("invaid url: " + urlString)
+		return fmt.Errorf("invalid url: " + urlString)
 	}
 	if parsed.Scheme == "" {
 		return fmt.Errorf("invalid url:" + urlString)

--- a/file/types.go
+++ b/file/types.go
@@ -2,13 +2,13 @@ package file
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/url"
 	"strconv"
 	"strings"
 
 	"github.com/kong/deck/utils"
 	"github.com/kong/go-kong/kong"
-	"github.com/pkg/errors"
 )
 
 // Format is a file format for Kong's configuration.
@@ -108,10 +108,10 @@ func copyToService(fService FService) service {
 func unwrapURL(urlString string, fService *FService) error {
 	parsed, err := url.Parse(urlString)
 	if err != nil {
-		return errors.New("invaid url: " + urlString)
+		return fmt.Errorf("invaid url: " + urlString)
 	}
 	if parsed.Scheme == "" {
-		return errors.New("invalid url:" + urlString)
+		return fmt.Errorf("invalid url:" + urlString)
 	}
 
 	fService.Protocol = kong.String(parsed.Scheme)

--- a/file/validate.go
+++ b/file/validate.go
@@ -1,9 +1,10 @@
 package file
 
 import (
+	"fmt"
+
 	ghodss "github.com/ghodss/yaml"
 	"github.com/kong/deck/utils"
-	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonschema"
 )
 
@@ -11,7 +12,7 @@ func validate(content []byte) error {
 	var c map[string]interface{}
 	err := ghodss.Unmarshal(content, &c)
 	if err != nil {
-		return errors.Wrap(err, "unmarshaling file content")
+		return fmt.Errorf("unmarshaling file content: %w", err)
 	}
 	c = ensureJSON(c)
 	schemaLoader := gojsonschema.NewStringLoader(contentSchema)
@@ -25,7 +26,7 @@ func validate(content []byte) error {
 	}
 	var errs utils.ErrArray
 	for _, desc := range result.Errors() {
-		err := errors.New(desc.String())
+		err := fmt.Errorf(desc.String())
 		errs.Errors = append(errs.Errors, err)
 	}
 	return errs

--- a/file/writer.go
+++ b/file/writer.go
@@ -13,7 +13,6 @@ import (
 	"github.com/kong/deck/state"
 	"github.com/kong/deck/utils"
 	"github.com/kong/go-kong/kong"
-	"github.com/pkg/errors"
 )
 
 // WriteConfig holds settings to use to write the state file.
@@ -621,37 +620,37 @@ func WriteContentToFile(content *Content, filename string, format Format) error 
 			return err
 		}
 	default:
-		return errors.New("unknown file format: " + string(format))
+		return fmt.Errorf("unknown file format: " + string(format))
 	}
 
 	if filename == "-" {
 		if _, err := fmt.Print(string(c)); err != nil {
-			return errors.Wrap(err, "writing file")
+			return fmt.Errorf("writing file: %w", err)
 		}
 	} else {
 		filename = utils.AddExtToFilename(filename, strings.ToLower(string(format)))
 		prefix, _ := filepath.Split(filename)
 		if err := ioutil.WriteFile(filename, c, 0o600); err != nil {
-			return errors.Wrap(err, "writing file")
+			return fmt.Errorf("writing file: %w", err)
 		}
 		for _, sp := range content.ServicePackages {
 			if sp.Document != nil {
 				if err := os.MkdirAll(filepath.Join(prefix, filepath.Dir(*sp.Document.Path)), 0o700); err != nil {
-					return errors.Wrap(err, "creating document directory")
+					return fmt.Errorf("creating document directory: %w", err)
 				}
 				if err := os.WriteFile(filepath.Join(prefix, *sp.Document.Path),
 					[]byte(*sp.Document.Content), 0o600); err != nil {
-					return errors.Wrap(err, "writing document file")
+					return fmt.Errorf("writing document file: %w", err)
 				}
 			}
 			for _, v := range sp.Versions {
 				if v.Document != nil {
 					if err := os.MkdirAll(filepath.Join(prefix, filepath.Dir(*v.Document.Path)), 0o700); err != nil {
-						return errors.Wrap(err, "creating document directory")
+						return fmt.Errorf("creating document directory: %w", err)
 					}
 					if err := os.WriteFile(filepath.Join(prefix, *v.Document.Path),
 						[]byte(*v.Document.Content), 0o600); err != nil {
-						return errors.Wrap(err, "writing document file")
+						return fmt.Errorf("writing document file: %w", err)
 					}
 				}
 			}

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.2.2 // indirect
 	github.com/pelletier/go-toml v1.7.0 // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/shirou/gopsutil/v3 v3.21.4
 	github.com/spf13/afero v1.2.2 // indirect

--- a/konnect/client.go
+++ b/konnect/client.go
@@ -3,13 +3,12 @@ package konnect
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"os"
-
-	"github.com/pkg/errors"
 )
 
 var defaultCtx = context.Background()
@@ -48,7 +47,7 @@ func NewClient(httpClient *http.Client, opts ClientOpts) (*Client, error) {
 	client.client = httpClient
 	url, err := url.ParseRequestURI(opts.BaseURL)
 	if err != nil {
-		return nil, errors.Wrap(err, "parsing URL")
+		return nil, fmt.Errorf("parsing URL: %w", err)
 	}
 	client.baseURL = url.String()
 
@@ -74,7 +73,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request,
 	v interface{}) (*http.Response, error) {
 	var err error
 	if req == nil {
-		return nil, errors.New("request cannot be nil")
+		return nil, fmt.Errorf("request cannot be nil")
 	}
 	if ctx == nil {
 		ctx = defaultCtx
@@ -90,7 +89,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request,
 	// Make the request
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, errors.Wrap(err, "making HTTP request")
+		return nil, fmt.Errorf("making HTTP request: %w", err)
 	}
 
 	// log the response

--- a/konnect/request.go
+++ b/konnect/request.go
@@ -3,10 +3,10 @@ package konnect
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/google/go-querystring/query"
-	"github.com/pkg/errors"
 )
 
 // NewRequest creates a request based on the inputs.
@@ -17,7 +17,7 @@ func (c *Client) NewRequest(method, endpoint string, qs interface{},
 	body interface{}) (*http.Request, error) {
 
 	if endpoint == "" {
-		return nil, errors.New("endpoint can't be nil")
+		return nil, fmt.Errorf("endpoint can't be nil")
 	}
 	// body to be sent in JSON
 	var buf []byte

--- a/reset/reset.go
+++ b/reset/reset.go
@@ -2,17 +2,17 @@ package reset
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/kong/deck/utils"
 	"github.com/kong/go-kong/kong"
-	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 )
 
 // Reset deletes all entities in Kong.
 func Reset(ctx context.Context, state *utils.KongRawState, client *kong.Client) error {
 	if state == nil {
-		return errors.New("state cannot be empty")
+		return fmt.Errorf("state cannot be empty")
 	}
 
 	group, ctx := errgroup.WithContext(ctx)

--- a/solver/solver.go
+++ b/solver/solver.go
@@ -2,6 +2,7 @@ package solver
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/kong/deck/crud"
@@ -10,7 +11,6 @@ import (
 	"github.com/kong/deck/print"
 	"github.com/kong/deck/state"
 	"github.com/kong/go-kong/kong"
-	"github.com/pkg/errors"
 )
 
 // Stats holds the stats related to a Solve.
@@ -90,7 +90,7 @@ func Solve(ctx context.Context, syncer *diff.Syncer,
 			// fire the request to Kong
 			result, err = r.Do(e.Kind, e.Op, e)
 			if err != nil {
-				return nil, errors.Wrapf(err, "%v %v %v failed", e.Op, e.Kind, c.Console())
+				return nil, fmt.Errorf("%v %v %v failed: %w", e.Op, e.Kind, c.Console(), err)
 			}
 		} else {
 			// diff mode

--- a/state/aclgroup.go
+++ b/state/aclgroup.go
@@ -6,12 +6,11 @@ import (
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/kong/deck/state/indexers"
 	"github.com/kong/deck/utils"
-	"github.com/pkg/errors"
 )
 
 var (
-	errGroupRequired    = errors.New("name of ACL group required")
-	errConsumerRequired = errors.New("consumer required")
+	errGroupRequired    = fmt.Errorf("name of ACL group required")
+	errConsumerRequired = fmt.Errorf("consumer required")
 )
 
 const (

--- a/state/builder.go
+++ b/state/builder.go
@@ -1,15 +1,16 @@
 package state
 
 import (
+	"fmt"
+
 	"github.com/kong/deck/utils"
-	"github.com/pkg/errors"
 )
 
 // Get builds a KongState from a raw representation of Kong.
 func Get(raw *utils.KongRawState) (*KongState, error) {
 	kongState, err := NewKongState()
 	if err != nil {
-		return nil, errors.Wrap(err, "creating new in-memory state of Kong")
+		return nil, fmt.Errorf("creating new in-memory state of Kong: %w", err)
 	}
 	err = buildKong(kongState, raw)
 	if err != nil {
@@ -22,19 +23,19 @@ func buildKong(kongState *KongState, raw *utils.KongRawState) error {
 	for _, s := range raw.Services {
 		err := kongState.Services.Add(Service{Service: *s})
 		if err != nil {
-			return errors.Wrap(err, "inserting service into state")
+			return fmt.Errorf("inserting service into state: %w", err)
 		}
 	}
 	for _, r := range raw.Routes {
 		err := kongState.Routes.Add(Route{Route: *r})
 		if err != nil {
-			return errors.Wrap(err, "inserting route into state")
+			return fmt.Errorf("inserting route into state: %w", err)
 		}
 	}
 	for _, c := range raw.Consumers {
 		err := kongState.Consumers.Add(Consumer{Consumer: *c})
 		if err != nil {
-			return errors.Wrap(err, "inserting consumer into state")
+			return fmt.Errorf("inserting consumer into state: %w", err)
 		}
 	}
 	ensureConsumer := func(consumerID string) (bool, error) {
@@ -43,8 +44,8 @@ func buildKong(kongState *KongState, raw *utils.KongRawState) error {
 			if err == ErrNotFound {
 				return false, nil
 			}
-			return false, errors.Wrapf(err,
-				"looking up consumer '%v'", consumerID)
+			return false, fmt.Errorf("looking up consumer %q: %w", consumerID, err)
+
 		}
 		return true, nil
 	}
@@ -58,7 +59,7 @@ func buildKong(kongState *KongState, raw *utils.KongRawState) error {
 		}
 		err = kongState.KeyAuths.Add(KeyAuth{KeyAuth: *cred})
 		if err != nil {
-			return errors.Wrap(err, "inserting key-auth into state")
+			return fmt.Errorf("inserting key-auth into state: %w", err)
 		}
 	}
 	for _, cred := range raw.HMACAuths {
@@ -71,7 +72,7 @@ func buildKong(kongState *KongState, raw *utils.KongRawState) error {
 		}
 		err = kongState.HMACAuths.Add(HMACAuth{HMACAuth: *cred})
 		if err != nil {
-			return errors.Wrap(err, "inserting hmac-auth into state")
+			return fmt.Errorf("inserting hmac-auth into state: %w", err)
 		}
 	}
 	for _, cred := range raw.JWTAuths {
@@ -84,7 +85,7 @@ func buildKong(kongState *KongState, raw *utils.KongRawState) error {
 		}
 		err = kongState.JWTAuths.Add(JWTAuth{JWTAuth: *cred})
 		if err != nil {
-			return errors.Wrap(err, "inserting jwt into state")
+			return fmt.Errorf("inserting jwt into state: %w", err)
 		}
 	}
 	for _, cred := range raw.BasicAuths {
@@ -97,7 +98,7 @@ func buildKong(kongState *KongState, raw *utils.KongRawState) error {
 		}
 		err = kongState.BasicAuths.Add(BasicAuth{BasicAuth: *cred})
 		if err != nil {
-			return errors.Wrap(err, "inserting basic-auth into state")
+			return fmt.Errorf("inserting basic-auth into state: %w", err)
 		}
 	}
 	for _, cred := range raw.Oauth2Creds {
@@ -110,7 +111,7 @@ func buildKong(kongState *KongState, raw *utils.KongRawState) error {
 		}
 		err = kongState.Oauth2Creds.Add(Oauth2Credential{Oauth2Credential: *cred})
 		if err != nil {
-			return errors.Wrap(err, "inserting oauth2-cred into state")
+			return fmt.Errorf("inserting oauth2-cred into state: %w", err)
 		}
 	}
 	for _, cred := range raw.ACLGroups {
@@ -123,7 +124,7 @@ func buildKong(kongState *KongState, raw *utils.KongRawState) error {
 		}
 		err = kongState.ACLGroups.Add(ACLGroup{ACLGroup: *cred})
 		if err != nil {
-			return errors.Wrap(err, "inserting basic-auth into state")
+			return fmt.Errorf("inserting basic-auth into state: %w", err)
 		}
 	}
 	for _, cred := range raw.MTLSAuths {
@@ -136,33 +137,33 @@ func buildKong(kongState *KongState, raw *utils.KongRawState) error {
 		}
 		err = kongState.MTLSAuths.Add(MTLSAuth{MTLSAuth: *cred})
 		if err != nil {
-			return errors.Wrap(err, "inserting mtls-auth into state")
+			return fmt.Errorf("inserting mtls-auth into state: %w", err)
 		}
 	}
 	for _, u := range raw.Upstreams {
 		err := kongState.Upstreams.Add(Upstream{Upstream: *u})
 		if err != nil {
-			return errors.Wrap(err, "inserting upstream into state")
+			return fmt.Errorf("inserting upstream into state: %w", err)
 		}
 	}
 	for _, t := range raw.Targets {
 		err := kongState.Targets.Add(Target{Target: *t})
 		if err != nil {
-			return errors.Wrap(err, "inserting target into state")
+			return fmt.Errorf("inserting target into state: %w", err)
 		}
 	}
 
 	for _, c := range raw.Certificates {
 		err := kongState.Certificates.Add(Certificate{Certificate: *c})
 		if err != nil {
-			return errors.Wrap(err, "inserting certificate into state")
+			return fmt.Errorf("inserting certificate into state: %w", err)
 		}
 	}
 
 	for _, s := range raw.SNIs {
 		err := kongState.SNIs.Add(SNI{SNI: *s})
 		if err != nil {
-			return errors.Wrap(err, "inserting sni into state")
+			return fmt.Errorf("inserting sni into state: %w", err)
 		}
 	}
 
@@ -171,27 +172,27 @@ func buildKong(kongState *KongState, raw *utils.KongRawState) error {
 			CACertificate: *c,
 		})
 		if err != nil {
-			return errors.Wrap(err, "inserting ca_certificate into state")
+			return fmt.Errorf("inserting ca_certificate into state: %w", err)
 		}
 	}
 
 	for _, p := range raw.Plugins {
 		err := kongState.Plugins.Add(Plugin{Plugin: *p})
 		if err != nil {
-			return errors.Wrap(err, "inserting plugins into state")
+			return fmt.Errorf("inserting plugins into state: %w", err)
 		}
 	}
 
 	for _, r := range raw.RBACRoles {
 		err := kongState.RBACRoles.Add(RBACRole{RBACRole: *r})
 		if err != nil {
-			return errors.Wrap(err, "inserting rbac roles into state")
+			return fmt.Errorf("inserting rbac roles into state: %w", err)
 		}
 	}
 	for _, r := range raw.RBACEndpointPermissions {
 		err := kongState.RBACEndpointPermissions.Add(RBACEndpointPermission{RBACEndpointPermission: *r})
 		if err != nil {
-			return errors.Wrap(err, "inserting rbac endpoint permissions into state")
+			return fmt.Errorf("inserting rbac endpoint permissions into state: %w", err)
 		}
 	}
 	return nil
@@ -205,7 +206,7 @@ func buildKonnect(kongState *KongState, raw *utils.KonnectRawState) error {
 			ServicePackage: *servicePackage,
 		})
 		if err != nil {
-			return errors.Wrap(err, "inserting service-package into state")
+			return fmt.Errorf("inserting service-package into state: %w", err)
 		}
 
 		for _, v := range s.Versions {
@@ -215,7 +216,7 @@ func buildKonnect(kongState *KongState, raw *utils.KonnectRawState) error {
 				ServiceVersion: v,
 			})
 			if err != nil {
-				return errors.Wrap(err, "inserting service-version into state")
+				return fmt.Errorf("inserting service-version into state: %w", err)
 			}
 		}
 	}
@@ -225,7 +226,7 @@ func buildKonnect(kongState *KongState, raw *utils.KonnectRawState) error {
 			Document: *document,
 		})
 		if err != nil {
-			return errors.Wrap(err, "inserting document into state")
+			return fmt.Errorf("inserting document into state: %w", err)
 		}
 	}
 	return nil
@@ -235,7 +236,7 @@ func GetKonnectState(rawKong *utils.KongRawState,
 	rawKonnect *utils.KonnectRawState) (*KongState, error) {
 	kongState, err := NewKongState()
 	if err != nil {
-		return nil, errors.Wrap(err, "creating new in-memory state of Kong")
+		return nil, fmt.Errorf("creating new in-memory state of Kong: %w", err)
 	}
 
 	err = buildKong(kongState, rawKong)

--- a/state/certificate.go
+++ b/state/certificate.go
@@ -6,7 +6,6 @@ import (
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/kong/deck/state/indexers"
 	"github.com/kong/deck/utils"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -34,10 +33,10 @@ var certificateTableSchema = &memdb.TableSchema{
 
 func validateCert(certificate Certificate) error {
 	if utils.Empty(certificate.Key) {
-		return errors.New("certificate's Key cannot be empty")
+		return fmt.Errorf("certificate's Key cannot be empty")
 	}
 	if utils.Empty(certificate.Cert) {
-		return errors.New("certificate's Cert cannot be empty")
+		return fmt.Errorf("certificate's Cert cannot be empty")
 	}
 	return nil
 }
@@ -122,7 +121,7 @@ func getCertificateByCertKey(txn *memdb.Txn, cert, key string) (*Certificate, er
 func (k *CertificatesCollection) GetByCertKey(cert,
 	key string) (*Certificate, error) {
 	if cert == "" || key == "" {
-		return nil, errors.New("cert/key cannot be empty string")
+		return nil, fmt.Errorf("cert/key cannot be empty string")
 	}
 
 	txn := k.db.Txn(false)
@@ -192,7 +191,7 @@ func (k *CertificatesCollection) Delete(id string) error {
 // DeleteByCertKey deletes a certificate by looking up it's cert and key.
 func (k *CertificatesCollection) DeleteByCertKey(cert, key string) error {
 	if cert == "" || key == "" {
-		return errors.New("cert/key cannot be empty string")
+		return fmt.Errorf("cert/key cannot be empty string")
 	}
 
 	txn := k.db.Txn(true)

--- a/state/document.go
+++ b/state/document.go
@@ -7,7 +7,6 @@ import (
 	"github.com/kong/deck/konnect"
 	"github.com/kong/deck/state/indexers"
 	"github.com/kong/deck/utils"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -16,8 +15,8 @@ const (
 )
 
 var (
-	errDocumentMissingParent = errors.New("Document has no Parent")
-	errDocumentPathRequired  = errors.New("Document must have a Path")
+	errDocumentMissingParent = fmt.Errorf("Document has no Parent")
+	errDocumentPathRequired  = fmt.Errorf("Document must have a Path")
 )
 
 // DocumentsCollection stores and indexes key-auth credentials.
@@ -81,7 +80,7 @@ func (k *DocumentsCollection) Add(document Document) error {
 
 func getDocument(txn *memdb.Txn, parentKey string, IDs ...string) (*Document, error) {
 	if parentKey == "" {
-		return nil, errors.New("parentKey is required")
+		return nil, fmt.Errorf("parentKey is required")
 	}
 	documents, err := getAllDocsByParentKey(txn, parentKey)
 	if err != nil {

--- a/state/plugin.go
+++ b/state/plugin.go
@@ -6,10 +6,9 @@ import (
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/kong/deck/state/indexers"
 	"github.com/kong/deck/utils"
-	"github.com/pkg/errors"
 )
 
-var errPluginNameRequired = errors.New("name of plugin required")
+var errPluginNameRequired = fmt.Errorf("name of plugin required")
 
 const (
 	pluginTableName     = "plugin"

--- a/state/rbac_endpoint_permission.go
+++ b/state/rbac_endpoint_permission.go
@@ -6,7 +6,6 @@ import (
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/kong/deck/state/indexers"
 	"github.com/kong/deck/utils"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -15,7 +14,7 @@ const (
 )
 
 var (
-	errInvalidRole                    = errors.New("role.ID is required in rbacEndpointPermission")
+	errInvalidRole                    = fmt.Errorf("role.ID is required in rbacEndpointPermission")
 	rbacEndpointPermissionTableSchema = &memdb.TableSchema{
 		Name: rbacEndpointPermissionTableName,
 		Indexes: map[string]*memdb.IndexSchema{

--- a/state/service_version.go
+++ b/state/service_version.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hashicorp/go-memdb"
 	"github.com/kong/deck/state/indexers"
 	"github.com/kong/deck/utils"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -14,7 +13,7 @@ const (
 	versionsByServicePackageID = "serviceVersionsByServicePackageID"
 )
 
-var errInvalidPackage = errors.New("servicePackage.ID is required in ServiceVersion")
+var errInvalidPackage = fmt.Errorf("servicePackage.ID is required in ServiceVersion")
 
 var serviceVersionTableSchema = &memdb.TableSchema{
 	Name: serviceVersionTableName,
@@ -88,7 +87,7 @@ func (k *ServiceVersionsCollection) Add(serviceVersion ServiceVersion) error {
 
 func getServiceVersion(txn *memdb.Txn, packageID string, IDs ...string) (*ServiceVersion, error) {
 	if packageID == "" {
-		return nil, errors.New("packageID is required")
+		return nil, fmt.Errorf("packageID is required")
 	}
 	versions, err := getAllByPackageID(txn, packageID)
 	if err != nil {

--- a/state/sni.go
+++ b/state/sni.go
@@ -6,7 +6,6 @@ import (
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/kong/deck/state/indexers"
 	"github.com/kong/deck/utils"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -14,7 +13,7 @@ const (
 	snisByCertID = "snisByCertID"
 )
 
-var errInvalidCert = errors.New("certificate.ID is required in sni")
+var errInvalidCert = fmt.Errorf("certificate.ID is required in sni")
 
 var sniTableSchema = &memdb.TableSchema{
 	Name: sniTableName,

--- a/state/state.go
+++ b/state/state.go
@@ -1,8 +1,9 @@
 package state
 
 import (
+	"fmt"
+
 	memdb "github.com/hashicorp/go-memdb"
-	"github.com/pkg/errors"
 )
 
 type collection struct {
@@ -81,7 +82,7 @@ func NewKongState() (*KongState, error) {
 
 	memDB, err := memdb.NewMemDB(schema)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating new ServiceCollection")
+		return nil, fmt.Errorf("creating new ServiceCollection: %w", err)
 	}
 	var state KongState
 	state.common = collection{

--- a/state/target.go
+++ b/state/target.go
@@ -6,7 +6,6 @@ import (
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/kong/deck/state/indexers"
 	"github.com/kong/deck/utils"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -14,7 +13,7 @@ const (
 	targetsByUpstreamID = "targetsByUpstreamID"
 )
 
-var errInvalidUpstream = errors.New("upstream.ID is required in target")
+var errInvalidUpstream = fmt.Errorf("upstream.ID is required in target")
 
 var targetTableSchema = &memdb.TableSchema{
 	Name: targetTableName,

--- a/state/utils.go
+++ b/state/utils.go
@@ -1,8 +1,9 @@
 package state
 
 import (
+	"fmt"
+
 	memdb "github.com/hashicorp/go-memdb"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -11,13 +12,13 @@ const (
 
 // ErrNotFound is an error type that is
 // returned when an entity is not found in the state.
-var ErrNotFound = errors.New("entity not found")
+var ErrNotFound = fmt.Errorf("entity not found")
 
 // ErrAlreadyExists represents an entity is already present in the state.
-var ErrAlreadyExists = errors.New("entity already exists")
+var ErrAlreadyExists = fmt.Errorf("entity already exists")
 
 // internal errors
-var errIDRequired = errors.New("ID is required")
+var errIDRequired = fmt.Errorf("ID is required")
 
 // error annotation messages
 const (

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -2,4 +2,6 @@
 
 package tools
 
-import _ "k8s.io/code-generator"
+import (
+	_ "k8s.io/code-generator"
+)

--- a/utils/constants.go
+++ b/utils/constants.go
@@ -1,6 +1,8 @@
 package utils
 
-import "github.com/kong/go-kong/kong"
+import (
+	"github.com/kong/go-kong/kong"
+)
 
 const (
 	defaultPort        = 80

--- a/utils/defaulter.go
+++ b/utils/defaulter.go
@@ -1,10 +1,10 @@
 package utils
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/imdario/mergo"
-	"github.com/pkg/errors"
 )
 
 // Defaulter registers types and fills in struct fields with
@@ -19,19 +19,19 @@ func GetKongDefaulter() (*Defaulter, error) {
 	var d Defaulter
 	err := d.Register(&serviceDefaults)
 	if err != nil {
-		return nil, errors.Wrap(err, "registering service with defaulter")
+		return nil, fmt.Errorf("registering service with defaulter: %w", err)
 	}
 	err = d.Register(&routeDefaults)
 	if err != nil {
-		return nil, errors.Wrap(err, "registering route with defaulter")
+		return nil, fmt.Errorf("registering route with defaulter: %w", err)
 	}
 	err = d.Register(&upstreamDefaults)
 	if err != nil {
-		return nil, errors.Wrap(err, "registering upstream with defaulter")
+		return nil, fmt.Errorf("registering upstream with defaulter: %w", err)
 	}
 	err = d.Register(&targetDefaults)
 	if err != nil {
-		return nil, errors.Wrap(err, "registering target with defaulter")
+		return nil, fmt.Errorf("registering target with defaulter: %w", err)
 	}
 	return &d, nil
 }
@@ -49,7 +49,7 @@ func (d *Defaulter) Register(def interface{}) error {
 	d.once()
 	v := reflect.ValueOf(def)
 	if !v.IsValid() {
-		return errors.New("invalid value")
+		return fmt.Errorf("invalid value")
 	}
 	v = reflect.Indirect(v)
 	d.r[v.Type().String()] = def
@@ -104,16 +104,16 @@ func (d *Defaulter) Set(arg interface{}) error {
 	d.once()
 	v := reflect.ValueOf(arg)
 	if !v.IsValid() {
-		return errors.New("invalid value")
+		return fmt.Errorf("invalid value")
 	}
 	v = reflect.Indirect(v)
 	defValue, ok := d.r[v.Type().String()]
 	if !ok {
-		return errors.New("type not registered: " + reflect.TypeOf(arg).String())
+		return fmt.Errorf("type not registered: %v", reflect.TypeOf(arg))
 	}
 	err := mergo.Merge(arg, defValue, mergo.WithTransformers(kongTransformer{}))
 	if err != nil {
-		err = errors.Wrap(err, "merging")
+		err = fmt.Errorf("merging: %w", err)
 	}
 	return err
 	// return defaulter.Set(arg, defValue)

--- a/utils/tags.go
+++ b/utils/tags.go
@@ -1,9 +1,8 @@
 package utils
 
 import (
+	"fmt"
 	"reflect"
-
-	"github.com/pkg/errors"
 )
 
 // MustMergeTags is same as MergeTags but panics if there is an error.
@@ -21,7 +20,7 @@ func MergeTags(obj interface{}, tags []string) error {
 	}
 	ptr := reflect.ValueOf(obj)
 	if ptr.Kind() != reflect.Ptr {
-		return errors.New("obj is not a pointer")
+		return fmt.Errorf("obj is not a pointer")
 	}
 	v := reflect.Indirect(ptr)
 	structTags := v.FieldByName("Tags")
@@ -64,7 +63,7 @@ func RemoveTags(obj interface{}, tags []string) error {
 
 	ptr := reflect.ValueOf(obj)
 	if ptr.Kind() != reflect.Ptr {
-		return errors.New("obj is not a pointer")
+		return fmt.Errorf("obj is not a pointer")
 	}
 	v := reflect.Indirect(ptr)
 	structTags := v.FieldByName("Tags")

--- a/utils/types.go
+++ b/utils/types.go
@@ -17,7 +17,6 @@ import (
 	"github.com/kong/deck/konnect"
 	"github.com/kong/go-kong/kong"
 	"github.com/kong/go-kong/kong/custom"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -126,7 +125,7 @@ func GetKongClient(opt KongClientConfig) (*kong.Client, error) {
 		certPool := x509.NewCertPool()
 		ok := certPool.AppendCertsFromPEM([]byte(opt.TLSCACert))
 		if !ok {
-			return nil, errors.New("failed to load TLSCACert")
+			return nil, fmt.Errorf("failed to load TLSCACert")
 		}
 		tlsConfig.RootCAs = certPool
 	}
@@ -142,13 +141,13 @@ func GetKongClient(opt KongClientConfig) (*kong.Client, error) {
 
 	headers, err := parseHeaders(opt.Headers)
 	if err != nil {
-		return nil, errors.Wrap(err, "parsing headers")
+		return nil, fmt.Errorf("parsing headers: %w", err)
 	}
 	c = kong.HTTPClientWithHeaders(c, headers)
 
 	url, err := url.ParseRequestURI(address)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to parse kong address")
+		return nil, fmt.Errorf("failed to parse kong address: %w", err)
 	}
 	if opt.Workspace != "" {
 		url.Path = path.Join(url.Path, opt.Workspace)
@@ -156,7 +155,7 @@ func GetKongClient(opt KongClientConfig) (*kong.Client, error) {
 
 	kongClient, err := kong.NewClient(kong.String(url.String()), c)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating client for Kong's Admin API")
+		return nil, fmt.Errorf("creating client for Kong's Admin API: %w", err)
 	}
 	if opt.Debug {
 		kongClient.SetDebugMode(true)

--- a/utils/types_test.go
+++ b/utils/types_test.go
@@ -1,11 +1,11 @@
 package utils
 
 import (
+	"fmt"
 	"net/http"
 	"reflect"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,11 +14,11 @@ func TestErrArrayString(t *testing.T) {
 	var err ErrArray
 	assert.Equal("nil", err.Error())
 
-	err.Errors = append(err.Errors, errors.New("foo failed"))
+	err.Errors = append(err.Errors, fmt.Errorf("foo failed"))
 
 	assert.Equal(err.Error(), "1 errors occurred:\n\tfoo failed\n")
 
-	err.Errors = append(err.Errors, errors.New("bar failed"))
+	err.Errors = append(err.Errors, fmt.Errorf("bar failed"))
 
 	assert.Equal(err.Error(), "2 errors occurred:\n\tfoo failed\n\tbar failed\n")
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,14 +3,13 @@ package utils
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 var kongVersionRegex = regexp.MustCompile(`^\d+\.\d+`)

--- a/utils/zero.go
+++ b/utils/zero.go
@@ -1,6 +1,8 @@
 package utils
 
-import "reflect"
+import (
+	"reflect"
+)
 
 var zero reflect.Value
 


### PR DESCRIPTION
Since this package predates Go 1.13 which introduced error wrapping using `%w`
qualifier. This patch does the following:
- replaces `errors.Wrap` with `fmt.Errorf`
- remove `github.com/pkg/errors` as a dependency
- removes use of `errors.New` stdlib package with `fmt.Errorf`