### PR TITLE
refactor: drop reset package to simplify codebase

### DIFF
--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -3,8 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/kong/deck/dump"
-	"github.com/kong/deck/reset"
+	"github.com/kong/deck/state"
 	"github.com/kong/deck/utils"
 	"github.com/spf13/cobra"
 )
@@ -29,6 +28,10 @@ By default, this command will ask for a confirmation prompt.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 
+		if resetAllWorkspaces && resetWorkspace != "" {
+			return fmt.Errorf("workspace cannot be specified with --all-workspace flag")
+		}
+
 		if !resetCmdForce {
 			ok, err := utils.Confirm("This will delete all configuration from Kong's database." +
 				"\n> Are you sure? ")
@@ -51,25 +54,13 @@ By default, this command will ask for a confirmation prompt.`,
 		}
 		_ = sendAnalytics("reset", kongVersion)
 
+		var workspaces []string
 		// Kong OSS or default workspace
 		if !resetAllWorkspaces && resetWorkspace == "" {
-			state, err := dump.Get(ctx, rootClient, dumpConfig)
-			if err != nil {
-				return err
-			}
-			err = reset.Reset(ctx, state, rootClient)
-			if err != nil {
-				return err
-			}
-			return nil
-		}
-
-		if resetAllWorkspaces && resetWorkspace != "" {
-			return fmt.Errorf("workspace cannot be specified with --all-workspace flag")
+			workspaces = append(workspaces, "")
 		}
 
 		// Kong Enterprise
-		var workspaces []string
 		if resetAllWorkspaces {
 			workspaces, err = listWorkspaces(ctx, rootClient)
 			if err != nil {
@@ -93,11 +84,15 @@ By default, this command will ask for a confirmation prompt.`,
 			if err != nil {
 				return err
 			}
-			state, err := dump.Get(ctx, wsClient, dumpConfig)
+			currentState, err := fetchCurrentState(ctx, wsClient, dumpConfig)
 			if err != nil {
 				return err
 			}
-			err = reset.Reset(ctx, state, wsClient)
+			targetState, err := state.NewKongState()
+			if err != nil {
+				return err
+			}
+			_, err = performDiff(ctx, currentState, targetState, false, 10, 0, wsClient)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
- reset command follows the same code path as diff and sync commands
i.e. entities are exported and reset using the syncer itself, this gets
rid off reset package entirely and minimizes the amount of code that
needs to be maintained
- Previously, we relied on kong's "on-cascade-delete" meaning, only a
single DELETE request was sent to delete a service, which in turn
deleted all the routes of the service and all the plugins on those
routes, services,etc. Now, reset will delete each and every entity in
the correct order (same as diff and sync). This results in a decrease in
performance of reset command as it will take longer. I don't expect this
to be a problem since reset command is used less often and with
concurrent nature of decK, this should not be a burden.