### PR TITLE
fix: drop conditional tagging

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/blang/semver/v4"
 	"github.com/kong/deck/cprint"
 	"github.com/kong/deck/diff"
 	"github.com/kong/deck/dump"
@@ -83,10 +82,6 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 	if err != nil {
 		return fmt.Errorf("reading Kong version: %w", err)
 	}
-	parsedKongVersion, err := parseKongVersion(kongVersion)
-	if err != nil {
-		return fmt.Errorf("parsing Kong version: %w", err)
-	}
 
 	// TODO: instead of guessing the cobra command here, move the sendAnalytics
 	// call to the RunE function. That is not trivial because it requires the
@@ -137,7 +132,6 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 	// read the target state
 	rawState, err := file.Get(targetContent, file.RenderConfig{
 		CurrentState: currentState,
-		KongVersion:  parsedKongVersion,
 	})
 	if err != nil {
 		return err
@@ -229,14 +223,6 @@ func fetchKongVersion(ctx context.Context, config utils.KongClientConfig) (strin
 		version = root["version"].(string)
 	}
 	return version, nil
-}
-
-func parseKongVersion(version string) (semver.Version, error) {
-	v, err := utils.CleanKongVersion(version)
-	if err != nil {
-		return semver.Version{}, err
-	}
-	return semver.ParseTolerant(v)
 }
 
 func validateNoArgs(cmd *cobra.Command, args []string) error {

--- a/file/builder.go
+++ b/file/builder.go
@@ -3,7 +3,6 @@ package file
 import (
 	"fmt"
 
-	"github.com/blang/semver/v4"
 	"github.com/kong/deck/konnect"
 	"github.com/kong/deck/state"
 	"github.com/kong/deck/utils"
@@ -16,15 +15,12 @@ type stateBuilder struct {
 	konnectRawState *utils.KonnectRawState
 	currentState    *state.KongState
 	defaulter       *utils.Defaulter
-	kongVersion     semver.Version
 
 	selectTags   []string
 	intermediate *state.KongState
 
 	err error
 }
-
-var kong140Version = semver.MustParse("1.4.0")
 
 // uuid generates a UUID string and returns a pointer to it.
 // It is a variable for testing purpose, to override and supply
@@ -289,9 +285,7 @@ func (b *stateBuilder) ingestKeyAuths(creds []kong.KeyAuth) error {
 				cred.ID = kong.String(*existingCred.ID)
 			}
 		}
-		if b.kongVersion.GTE(kong140Version) {
-			utils.MustMergeTags(&cred, b.selectTags)
-		}
+		utils.MustMergeTags(&cred, b.selectTags)
 		b.rawState.KeyAuths = append(b.rawState.KeyAuths, &cred)
 	}
 	return nil
@@ -310,9 +304,7 @@ func (b *stateBuilder) ingestBasicAuths(creds []kong.BasicAuth) error {
 				cred.ID = kong.String(*existingCred.ID)
 			}
 		}
-		if b.kongVersion.GTE(kong140Version) {
-			utils.MustMergeTags(&cred, b.selectTags)
-		}
+		utils.MustMergeTags(&cred, b.selectTags)
 		b.rawState.BasicAuths = append(b.rawState.BasicAuths, &cred)
 	}
 	return nil
@@ -331,9 +323,7 @@ func (b *stateBuilder) ingestHMACAuths(creds []kong.HMACAuth) error {
 				cred.ID = kong.String(*existingCred.ID)
 			}
 		}
-		if b.kongVersion.GTE(kong140Version) {
-			utils.MustMergeTags(&cred, b.selectTags)
-		}
+		utils.MustMergeTags(&cred, b.selectTags)
 		b.rawState.HMACAuths = append(b.rawState.HMACAuths, &cred)
 	}
 	return nil
@@ -352,9 +342,7 @@ func (b *stateBuilder) ingestJWTAuths(creds []kong.JWTAuth) error {
 				cred.ID = kong.String(*existingCred.ID)
 			}
 		}
-		if b.kongVersion.GTE(kong140Version) {
-			utils.MustMergeTags(&cred, b.selectTags)
-		}
+		utils.MustMergeTags(&cred, b.selectTags)
 		b.rawState.JWTAuths = append(b.rawState.JWTAuths, &cred)
 	}
 	return nil
@@ -373,9 +361,7 @@ func (b *stateBuilder) ingestOauth2Creds(creds []kong.Oauth2Credential) error {
 				cred.ID = kong.String(*existingCred.ID)
 			}
 		}
-		if b.kongVersion.GTE(kong140Version) {
-			utils.MustMergeTags(&cred, b.selectTags)
-		}
+		utils.MustMergeTags(&cred, b.selectTags)
 		b.rawState.Oauth2Creds = append(b.rawState.Oauth2Creds, &cred)
 	}
 	return nil
@@ -396,9 +382,7 @@ func (b *stateBuilder) ingestACLGroups(creds []kong.ACLGroup) error {
 				cred.ID = kong.String(*existingCred.ID)
 			}
 		}
-		if b.kongVersion.GTE(kong140Version) {
-			utils.MustMergeTags(&cred, b.selectTags)
-		}
+		utils.MustMergeTags(&cred, b.selectTags)
 		b.rawState.ACLGroups = append(b.rawState.ACLGroups, &cred)
 	}
 	return nil

--- a/file/builder_test.go
+++ b/file/builder_test.go
@@ -7,15 +7,12 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/blang/semver/v4"
 	"github.com/kong/deck/konnect"
 	"github.com/kong/deck/state"
 	"github.com/kong/deck/utils"
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
 )
-
-var kong130Version = semver.MustParse("1.3.0")
 
 func emptyState() *state.KongState {
 	s, _ := state.NewKongState()
@@ -751,7 +748,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 	type fields struct {
 		currentState  *state.KongState
 		targetContent *Content
-		kongVersion   *semver.Version
 	}
 	tests := []struct {
 		name   string
@@ -1130,7 +1126,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 					},
 				},
 				currentState: existingConsumerCredState(),
-				kongVersion:  &kong130Version,
 			},
 			want: &utils.KongRawState{
 				Consumers: []*kong.Consumer{
@@ -1147,6 +1142,7 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						},
+						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				BasicAuths: []*kong.BasicAuth{
@@ -1157,6 +1153,7 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						},
+						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				HMACAuths: []*kong.HMACAuth{
@@ -1167,6 +1164,7 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						},
+						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				JWTAuths: []*kong.JWTAuth{
@@ -1177,6 +1175,7 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						},
+						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				Oauth2Creds: []*kong.Oauth2Credential{
@@ -1187,6 +1186,7 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						},
+						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				ACLGroups: []*kong.ACLGroup{
@@ -1196,6 +1196,7 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						},
+						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				MTLSAuths: []*kong.MTLSAuth{
@@ -1215,10 +1216,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 			b := &stateBuilder{
 				targetContent: tt.fields.targetContent,
 				currentState:  tt.fields.currentState,
-				kongVersion:   kong140Version,
-			}
-			if tt.fields.kongVersion != nil {
-				b.kongVersion = *tt.fields.kongVersion
 			}
 			d, _ := utils.GetKongDefaulter()
 			b.defaulter = d

--- a/file/reader.go
+++ b/file/reader.go
@@ -3,7 +3,6 @@ package file
 import (
 	"fmt"
 
-	"github.com/blang/semver/v4"
 	"github.com/kong/deck/state"
 	"github.com/kong/deck/utils"
 )
@@ -12,7 +11,6 @@ import (
 // KongConfig from a file.
 type RenderConfig struct {
 	CurrentState *state.KongState
-	KongVersion  semver.Version
 }
 
 // GetContentFromFiles reads in a file with a slice of filenames and constructs


### PR DESCRIPTION
When decK v1.7.0 or later is used with select-tag feature and
credentials in state file, decK will error out in most sync runs because
it can't locate the credentials in the current state.
This happens because #282 changed the conditions under which credentials
were exported: only tagged credentials are now exported.

On the other hand, `kongVersion` field in the state builder is not set.
This leads to credentials not being tagged appropriately when they are
read from the state files.

This patch unconditionally tags all credentials and ensures that
credentials are created and updated appropriately.