### PR TITLE
fix: document creation and deletion race with parent objects

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -251,6 +251,10 @@ func (sc *Syncer) delete() error {
 		return err
 	}
 
+	// barrier for foreign relations
+	// Documents must be deleted before ServiceVersions and Service packages
+	sc.wait()
+
 	err = sc.entityDiffers[types.ServiceVersion].Deletes(sc.queueEvent)
 	if err != nil {
 		return err
@@ -384,6 +388,10 @@ func (sc *Syncer) createUpdate() error {
 	if err != nil {
 		return err
 	}
+
+	// barrier for foreign relations
+	// service versions and packages must be created before documents
+	sc.wait()
 
 	err = sc.entityDiffers[types.Document].CreateAndUpdates(sc.queueEvent)
 	if err != nil {


### PR DESCRIPTION
Document object in Konnect are always associated with either a service
package or a service version.
- If a service version or package is deleted, deleting a document
results in a 404, an error in decK
- If a document is created before the corresponding service package or
version is created, it resulted in 400, again an error

This patch adds the appropriate barriers to prevent such races.