### PR TITLE
refactor: simplify dependency definitions

### DIFF
--- a/diff/order.go
+++ b/diff/order.go
@@ -1,0 +1,90 @@
+package diff
+
+import "github.com/kong/deck/types"
+
+/*
+                                       Root
+                                         |
+         +----------+----------+---------+------------+---------------+
+         |          |          |         |            |               |
+         v          v          v         v            v               v
+L1    Service    RbacRole  Upstream  Certificate  CACertificate  Consumer ---+
+      Package        |         |        |     |      |                |      |
+        |            v         v        v     |      v                v      |
+L2      |        RBACRole   Target     SNI    +-> Service       Credentials  |
+        |        Endpoint                         |  |              (7)      |
+        |                                         |  |                       |
+        |                                         |  |                       |
+L3      +---------------------------> Service <---+  +-> Route               |
+        |                             Version        |     |                 |
+        |                                 |          |     |                 |
+        |                                 |          |     v                 |
+L4      +----------> Document   <---------+          +-> Plugins  <----------+
+*/
+
+// dependencyOrder defines the order in which entities will be synced by decK.
+// Entities at the same level are processed concurrently.
+// Entities at level n will only be processed after all entities at level n-1
+// have been processed.
+// The processing order for create and update stage is top-down while that
+// for delete stage is bottom-up.
+var dependencyOrder = [][]types.EntityType{
+	{
+		types.ServicePackage,
+		types.RBACRole,
+		types.Upstream,
+		types.Certificate,
+		types.CACertificate,
+		types.Consumer,
+	},
+	{
+		types.RBACEndpointPermission,
+		types.Target,
+		types.SNI,
+		types.Service,
+
+		types.KeyAuth, types.HMACAuth, types.JWTAuth,
+		types.BasicAuth, types.OAuth2Cred, types.ACLGroup,
+		types.MTLSAuth,
+	},
+	{
+		types.ServiceVersion,
+		types.Route,
+	},
+	{
+		types.Plugin,
+		types.Document,
+	},
+}
+
+func order() [][]types.EntityType {
+	return deepCopy(dependencyOrder)
+}
+
+func reverseOrder() [][]types.EntityType {
+	order := deepCopy(dependencyOrder)
+	return reverse(order)
+}
+
+func reverse(src [][]types.EntityType) [][]types.EntityType {
+	src = deepCopy(src)
+	i := 0
+	j := len(src) - 1
+	for i < j {
+		temp := src[i]
+		src[i] = src[j]
+		src[j] = temp
+		i++
+		j--
+	}
+	return src
+}
+
+func deepCopy(src [][]types.EntityType) [][]types.EntityType {
+	res := make([][]types.EntityType, len(src))
+	for i := range src {
+		res[i] = make([]types.EntityType, len(src[i]))
+		copy(res[i], src[i])
+	}
+	return res
+}

--- a/diff/order_test.go
+++ b/diff/order_test.go
@@ -1,0 +1,50 @@
+package diff
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kong/deck/types"
+)
+
+func Test_reverse(t *testing.T) {
+	type args struct {
+		src [][]types.EntityType
+	}
+	tests := []struct {
+		name string
+		args args
+		want [][]types.EntityType
+	}{
+		{
+			name: "doesn't panic on empty slice",
+			args: args{
+				src: nil,
+			},
+			want: [][]types.EntityType{},
+		},
+		{
+			name: "doesn't panic on empty slice",
+			args: args{
+				src: [][]types.EntityType{
+					{"foo"},
+					{"bar"},
+					{"baz", "fubar"},
+				},
+			},
+			want: [][]types.EntityType{
+				{"baz", "fubar"},
+				{"bar"},
+				{"foo"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := reverse(tt.args.src); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("reverse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Kong and Konnect's data-model is relational in nature. This requires
decK to order its operations in a certain fashion. Creating an entity
without first ensuring that the present is present results in
violations. Deleting on the other hand, requires deleting every single
child before a parent is deleted to properly account for edges of the
entity relationship graph.

This was historically done by ordering entities in a particular order.
This was prone to some error, but even more so, very hard to grok for
anyone maintaining or reading the code.

This change builds upon the previous refactors(#435,#436) and decouples
the ordering of entities.

The dependency graph has been built up from ground up again to account
for all of 21 entities that decK can manage today.
Most of these entities were added organically and there dependencies
were haphazardly figured out. With this patch, the number of barriers
(`sc.wait()` calls) have been reduced to 4. With some inputs, users
will observe significant speed ups in calls to `decK sync` as
parallelism will be used more effectively.

With implementation, an additional Direct Acyclic Graph (DAG) library was
considered. An initial version even used Terraform's
[DAG](https://pkg.go.dev/github.com/hashicorp/terraform/dag#AcyclicGraph) but had
to be dropped for licensing reasons. The implemenetation is simple
without a DAG and doesn't have any limitations at the moment.

Please note that this change has large consequences since a missing dependency will
cause. Alas, there is no automated testing suite that can catch errors between
dependencies here. Some basic manual testing has been performed.