### PR TITLE
hotfix: correct the kind for HMACAuth

### DIFF
--- a/types/core.go
+++ b/types/core.go
@@ -387,7 +387,7 @@ func NewEntity(t string, opts EntityOpts) (Entity, error) {
 				currentState: opts.CurrentState,
 			},
 			differ: &hmacAuthDiffer{
-				kind:         BasicAuth,
+				kind:         HMACAuth,
 				currentState: opts.CurrentState,
 				targetState:  opts.TargetState,
 			},


### PR DESCRIPTION
This reverts a mistake that was introduced in #436.