### PR TITLE
fix: multiple bugs with credentials and select-tags

### DIFF
--- a/dump/dump.go
+++ b/dump/dump.go
@@ -125,7 +125,16 @@ func getConsumerConfiguration(ctx context.Context, group *errgroup.Group,
 	})
 
 	group.Go(func() error {
-		mtlsAuths, err := GetAllMTLSAuths(ctx, client, config.SelectorTags)
+		// XXX Select-tags based filtering is not performed for mTLS-auth credentials
+		// because of the following problems:
+		// - We currently do not already tag these credentials, filtering these
+		// credentials with tags will break any existing user
+		// - this is not a big issue since only mTLS-auth credentials for tagged
+		// consumers are exported anyway
+		// This feature would only benefit a user who uses tagged consumers but
+		// then managed mtls-auth credentials out-of-band. We expect such users
+		// to be rare or non-existent.
+		mtlsAuths, err := GetAllMTLSAuths(ctx, client, nil)
 		if err != nil {
 			return fmt.Errorf("mtls-auths: %w", err)
 		}

--- a/file/builder.go
+++ b/file/builder.go
@@ -405,6 +405,7 @@ func (b *stateBuilder) ingestACLGroups(creds []kong.ACLGroup) error {
 }
 
 func (b *stateBuilder) ingestMTLSAuths(creds []kong.MTLSAuth) {
+	kong230Version := semver.MustParse("2.3.0")
 	for _, cred := range creds {
 		cred := cred
 		// normally, we'd want to look up existing resources in this case
@@ -412,11 +413,9 @@ func (b *stateBuilder) ingestMTLSAuths(creds []kong.MTLSAuth) {
 		// so we don't--schema validation requires the ID
 		// there's nothing more to do here
 
-		// TODO: this is stub code, since mtls-auth doesn't actually have tag support yet
-		// They probably should, FTI-1706 tracks that request with the Kong Enterprise team
-		//if b.kongVersion.GTE(kong220Version) {
-		//	utils.MustMergeTags(&cred, b.selectTags)
-		//}
+		if b.kongVersion.GTE(kong230Version) {
+			utils.MustMergeTags(&cred, b.selectTags)
+		}
 		b.rawState.MTLSAuths = append(b.rawState.MTLSAuths, &cred)
 	}
 }

--- a/file/reader.go
+++ b/file/reader.go
@@ -36,6 +36,7 @@ func GetForKonnect(fileContent *Content, opt RenderConfig) (*utils.KongRawState,
 	// setup
 	builder.targetContent = fileContent
 	builder.currentState = opt.CurrentState
+	builder.kongVersion = opt.KongVersion
 
 	kongState, konnectState, err := builder.build()
 	if err != nil {
@@ -51,6 +52,7 @@ func Get(fileContent *Content, opt RenderConfig) (*utils.KongRawState, error) {
 	// setup
 	builder.targetContent = fileContent
 	builder.currentState = opt.CurrentState
+	builder.kongVersion = opt.KongVersion
 
 	state, _, err := builder.build()
 	if err != nil {


### PR DESCRIPTION
Please see #414 for some background and an alternate solution that was
considered but had to be dropped for backwards-compatibility reasons.

This patch fixes the following bugs:
- file package
  - statebuilder sets tags on credentials conditionally but the variable
  containing the version of kong was never being set in the first place.
  We do that correctly now. Please note that we don't set these
  variables for the code-path for Konnect because control-plane in
  Konnect is not-versioned from our customer's perspective. That and
  select-tag feature is not available in Konnect.
  - mTLS auth credentials received tagging support in Kong Enterprise
  2.3. decK will now set the select-tag in mtls-auth credentials when
  Kong version is compatible.
- dump package:
  - #282 incorrectly only exported tagged mtls-auth credentials even
  though they weren't tagged (by decK or otherwise). We have resorted to
  always exporting all mtls-auth credentials to avoid a breaking change
  for our existing users. Please see the code comment for how this
  choice shouldn't be a problem for most users.