### PR TITLE
fix: update target in-place

### DIFF
--- a/types/target.go
+++ b/types/target.go
@@ -64,7 +64,6 @@ func (s *targetCRUD) Update(ctx context.Context, arg ...crud.Arg) (crud.Arg, err
 	if err != nil {
 		return nil, err
 	}
-	target.ID = nil
 	createdTarget, err := s.client.Targets.Create(ctx,
 		target.Upstream.ID, &target.Target)
 	if err != nil {


### PR DESCRIPTION
Targets in Kong were immutable. They were changed to be mutable a few
months ago but we can't break compatibility.

If target's weight was changed, it resulted in the following:
- diff is detected, an update is issued
- update operations are translated into delete then create, the ID
changes
- the update is then reflected into go-memdb, because the ID is new,
state package emits an error that it can't update an entity that it
didn't previously have

This patch ensures that ID across update remains the same.

The tests for this is here: https://github.com/Kong/go-kong/pull/85