### PR TITLE
chore(ci): codeql-analysis on go 1.16

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16
+        go-version: 1.17
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,6 +40,11 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+      
+    - name: Setup go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
In https://github.com/Kong/deck/runs/3510966256?check_suite_focus=true we can see
>Extraction failed in file/schema.go with error package embed is not in GOROOT (/opt/hostedtoolcache/go/1.15.15/x64/src/embed)

But embed is a 1.16 capacity, using 1.16 is fixing it