### PR TITLE
refactor: make stateBuilder version agnostic

### DIFF
--- a/file/builder.go
+++ b/file/builder.go
@@ -3,7 +3,6 @@ package file
 import (
 	"fmt"
 
-	"github.com/blang/semver/v4"
 	"github.com/kong/deck/konnect"
 	"github.com/kong/deck/state"
 	"github.com/kong/deck/utils"
@@ -16,15 +15,12 @@ type stateBuilder struct {
 	konnectRawState *utils.KonnectRawState
 	currentState    *state.KongState
 	defaulter       *utils.Defaulter
-	kongVersion     semver.Version
 
 	selectTags   []string
 	intermediate *state.KongState
 
 	err error
 }
-
-var kong140Version = semver.MustParse("1.4.0")
 
 // uuid generates a UUID string and returns a pointer to it.
 // It is a variable for testing purpose, to override and supply
@@ -289,9 +285,6 @@ func (b *stateBuilder) ingestKeyAuths(creds []kong.KeyAuth) error {
 				cred.ID = kong.String(*existingCred.ID)
 			}
 		}
-		if b.kongVersion.GTE(kong140Version) {
-			utils.MustMergeTags(&cred, b.selectTags)
-		}
 		b.rawState.KeyAuths = append(b.rawState.KeyAuths, &cred)
 	}
 	return nil
@@ -309,9 +302,6 @@ func (b *stateBuilder) ingestBasicAuths(creds []kong.BasicAuth) error {
 			} else {
 				cred.ID = kong.String(*existingCred.ID)
 			}
-		}
-		if b.kongVersion.GTE(kong140Version) {
-			utils.MustMergeTags(&cred, b.selectTags)
 		}
 		b.rawState.BasicAuths = append(b.rawState.BasicAuths, &cred)
 	}
@@ -331,9 +321,6 @@ func (b *stateBuilder) ingestHMACAuths(creds []kong.HMACAuth) error {
 				cred.ID = kong.String(*existingCred.ID)
 			}
 		}
-		if b.kongVersion.GTE(kong140Version) {
-			utils.MustMergeTags(&cred, b.selectTags)
-		}
 		b.rawState.HMACAuths = append(b.rawState.HMACAuths, &cred)
 	}
 	return nil
@@ -352,9 +339,6 @@ func (b *stateBuilder) ingestJWTAuths(creds []kong.JWTAuth) error {
 				cred.ID = kong.String(*existingCred.ID)
 			}
 		}
-		if b.kongVersion.GTE(kong140Version) {
-			utils.MustMergeTags(&cred, b.selectTags)
-		}
 		b.rawState.JWTAuths = append(b.rawState.JWTAuths, &cred)
 	}
 	return nil
@@ -372,9 +356,6 @@ func (b *stateBuilder) ingestOauth2Creds(creds []kong.Oauth2Credential) error {
 			} else {
 				cred.ID = kong.String(*existingCred.ID)
 			}
-		}
-		if b.kongVersion.GTE(kong140Version) {
-			utils.MustMergeTags(&cred, b.selectTags)
 		}
 		b.rawState.Oauth2Creds = append(b.rawState.Oauth2Creds, &cred)
 	}
@@ -396,26 +377,18 @@ func (b *stateBuilder) ingestACLGroups(creds []kong.ACLGroup) error {
 				cred.ID = kong.String(*existingCred.ID)
 			}
 		}
-		if b.kongVersion.GTE(kong140Version) {
-			utils.MustMergeTags(&cred, b.selectTags)
-		}
 		b.rawState.ACLGroups = append(b.rawState.ACLGroups, &cred)
 	}
 	return nil
 }
 
 func (b *stateBuilder) ingestMTLSAuths(creds []kong.MTLSAuth) {
-	kong230Version := semver.MustParse("2.3.0")
 	for _, cred := range creds {
 		cred := cred
 		// normally, we'd want to look up existing resources in this case
 		// however, this is impossible here: mtls-auth simply has no unique fields other than ID,
 		// so we don't--schema validation requires the ID
 		// there's nothing more to do here
-
-		if b.kongVersion.GTE(kong230Version) {
-			utils.MustMergeTags(&cred, b.selectTags)
-		}
 		b.rawState.MTLSAuths = append(b.rawState.MTLSAuths, &cred)
 	}
 }

--- a/file/builder_test.go
+++ b/file/builder_test.go
@@ -851,7 +851,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				BasicAuths: []*kong.BasicAuth{
@@ -862,7 +861,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				HMACAuths: []*kong.HMACAuth{
@@ -873,7 +871,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				JWTAuths: []*kong.JWTAuth{
@@ -884,7 +881,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				Oauth2Creds: []*kong.Oauth2Credential{
@@ -895,7 +891,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				ACLGroups: []*kong.ACLGroup{
@@ -905,7 +900,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				MTLSAuths: nil,
@@ -1006,7 +1000,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				BasicAuths: []*kong.BasicAuth{
@@ -1017,7 +1010,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				HMACAuths: []*kong.HMACAuth{
@@ -1028,7 +1020,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				JWTAuths: []*kong.JWTAuth{
@@ -1039,7 +1030,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				Oauth2Creds: []*kong.Oauth2Credential{
@@ -1050,7 +1040,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				ACLGroups: []*kong.ACLGroup{
@@ -1060,7 +1049,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				MTLSAuths: []*kong.MTLSAuth{
@@ -1215,14 +1203,11 @@ func Test_stateBuilder_consumers(t *testing.T) {
 			b := &stateBuilder{
 				targetContent: tt.fields.targetContent,
 				currentState:  tt.fields.currentState,
-				kongVersion:   kong140Version,
-			}
-			if tt.fields.kongVersion != nil {
-				b.kongVersion = *tt.fields.kongVersion
 			}
 			d, _ := utils.GetKongDefaulter()
 			b.defaulter = d
 			b.build()
+
 			assert.Equal(tt.want, b.rawState)
 		})
 	}

--- a/file/reader.go
+++ b/file/reader.go
@@ -8,6 +8,11 @@ import (
 	"github.com/kong/deck/utils"
 )
 
+var (
+	kong230Version = semver.MustParse("2.3.0")
+	kong140Version = semver.MustParse("1.4.0")
+)
+
 // RenderConfig contains necessary information to render a correct
 // KongConfig from a file.
 type RenderConfig struct {
@@ -36,12 +41,17 @@ func GetForKonnect(fileContent *Content, opt RenderConfig) (*utils.KongRawState,
 	// setup
 	builder.targetContent = fileContent
 	builder.currentState = opt.CurrentState
-	builder.kongVersion = opt.KongVersion
 
 	kongState, konnectState, err := builder.build()
 	if err != nil {
 		return nil, nil, fmt.Errorf("building state: %w", err)
 	}
+	tags := []string{}
+	if fileContent.Info != nil {
+		tags = fileContent.Info.SelectorTags
+	}
+	mergeSelectorTags(kongState, opt.KongVersion, tags)
+
 	return kongState, konnectState, nil
 }
 
@@ -52,13 +62,33 @@ func Get(fileContent *Content, opt RenderConfig) (*utils.KongRawState, error) {
 	// setup
 	builder.targetContent = fileContent
 	builder.currentState = opt.CurrentState
-	builder.kongVersion = opt.KongVersion
 
 	state, _, err := builder.build()
 	if err != nil {
 		return nil, fmt.Errorf("building state: %w", err)
 	}
+	tags := []string{}
+	if fileContent.Info != nil {
+		tags = fileContent.Info.SelectorTags
+	}
+	mergeSelectorTags(state, opt.KongVersion, tags)
+
 	return state, nil
+}
+
+func mergeSelectorTags(state *utils.KongRawState, version semver.Version, tags []string) {
+	if version.GTE(kong140Version) {
+		utils.MustMergeTags(state.HMACAuths, tags)
+		utils.MustMergeTags(state.ACLGroups, tags)
+		utils.MustMergeTags(state.KeyAuths, tags)
+		utils.MustMergeTags(state.BasicAuths, tags)
+		utils.MustMergeTags(state.JWTAuths, tags)
+		utils.MustMergeTags(state.Oauth2Creds, tags)
+		utils.MustMergeTags(state.HMACAuths, tags)
+	}
+	if version.GTE(kong230Version) {
+		utils.MustMergeTags(state.MTLSAuths, tags)
+	}
 }
 
 func ensureJSON(m map[string]interface{}) map[string]interface{} {

--- a/file/reader_test.go
+++ b/file/reader_test.go
@@ -3,10 +3,14 @@ package file
 import (
 	"bytes"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"reflect"
 	"testing"
 
+	"github.com/blang/semver/v4"
+	"github.com/kong/deck/state"
+	"github.com/kong/deck/utils"
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
 )
@@ -107,4 +111,627 @@ func TestReadKongStateFromStdin(t *testing.T) {
 		Host: kong.String("test.com"),
 	},
 		c.Services[0].Service)
+}
+
+func TestGet(t *testing.T) {
+	assert := assert.New(t)
+	rand.Seed(42)
+	type fields struct {
+		currentState  *state.KongState
+		targetContent *Content
+		kongVersion   semver.Version
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   *utils.KongRawState
+	}{
+		{
+			name: "generates ID for a non-existing consumer",
+			fields: fields{
+				targetContent: &Content{
+					Consumers: []FConsumer{
+						{
+							Consumer: kong.Consumer{
+								Username: kong.String("foo"),
+							},
+						},
+					},
+					Info: &Info{
+						SelectorTags: []string{"tag1"},
+					},
+				},
+				currentState: emptyState(),
+			},
+			want: &utils.KongRawState{
+				Consumers: []*kong.Consumer{
+					{
+						ID:       kong.String("538c7f96-b164-4f1b-97bb-9f4bb472e89f"),
+						Username: kong.String("foo"),
+						Tags:     kong.StringSlice("tag1"),
+					},
+				},
+			},
+		},
+		{
+			name: "generates ID for a non-existing credential",
+			fields: fields{
+				targetContent: &Content{
+					Consumers: []FConsumer{
+						{
+							Consumer: kong.Consumer{
+								Username: kong.String("foo"),
+							},
+							KeyAuths: []*kong.KeyAuth{
+								{
+									Key: kong.String("foo-key"),
+								},
+							},
+							BasicAuths: []*kong.BasicAuth{
+								{
+									Username: kong.String("basic-username"),
+									Password: kong.String("basic-password"),
+								},
+							},
+							HMACAuths: []*kong.HMACAuth{
+								{
+									Username: kong.String("hmac-username"),
+									Secret:   kong.String("hmac-secret"),
+								},
+							},
+							JWTAuths: []*kong.JWTAuth{
+								{
+									Key:    kong.String("jwt-key"),
+									Secret: kong.String("jwt-secret"),
+								},
+							},
+							Oauth2Creds: []*kong.Oauth2Credential{
+								{
+									ClientID: kong.String("oauth2-clientid"),
+									Name:     kong.String("oauth2-name"),
+								},
+							},
+							ACLGroups: []*kong.ACLGroup{
+								{
+									Group: kong.String("foo-group"),
+								},
+							},
+						},
+					},
+					Info: &Info{
+						SelectorTags: []string{"tag1"},
+					},
+				},
+				currentState: emptyState(),
+				kongVersion:  kong140Version,
+			},
+			want: &utils.KongRawState{
+				Consumers: []*kong.Consumer{
+					{
+						ID:       kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
+						Username: kong.String("foo"),
+						Tags:     kong.StringSlice("tag1"),
+					},
+				},
+				KeyAuths: []*kong.KeyAuth{
+					{
+						ID:  kong.String("dfd79b4d-7642-4b61-ba0c-9f9f0d3ba55b"),
+						Key: kong.String("foo-key"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
+						},
+						Tags: kong.StringSlice("tag1"),
+					},
+				},
+				BasicAuths: []*kong.BasicAuth{
+					{
+						ID:       kong.String("0cc0d614-4c88-4535-841a-cbe0709b0758"),
+						Username: kong.String("basic-username"),
+						Password: kong.String("basic-password"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
+						},
+						Tags: kong.StringSlice("tag1"),
+					},
+				},
+				HMACAuths: []*kong.HMACAuth{
+					{
+						ID:       kong.String("083f61d3-75bc-42b4-9df4-f91929e18fda"),
+						Username: kong.String("hmac-username"),
+						Secret:   kong.String("hmac-secret"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
+						},
+						Tags: kong.StringSlice("tag1"),
+					},
+				},
+				JWTAuths: []*kong.JWTAuth{
+					{
+						ID:     kong.String("9e6f82e5-4e74-4e81-a79e-4bbd6fe34cdc"),
+						Key:    kong.String("jwt-key"),
+						Secret: kong.String("jwt-secret"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
+						},
+						Tags: kong.StringSlice("tag1"),
+					},
+				},
+				Oauth2Creds: []*kong.Oauth2Credential{
+					{
+						ID:       kong.String("ba843ee8-d63e-4c4f-be1c-ebea546d8fac"),
+						ClientID: kong.String("oauth2-clientid"),
+						Name:     kong.String("oauth2-name"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
+						},
+						Tags: kong.StringSlice("tag1"),
+					},
+				},
+				ACLGroups: []*kong.ACLGroup{
+					{
+						ID:    kong.String("13dd1aac-04ce-4ea2-877c-5579cfa2c78e"),
+						Group: kong.String("foo-group"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
+						},
+						Tags: kong.StringSlice("tag1"),
+					},
+				},
+				MTLSAuths: nil,
+			},
+		},
+		{
+			name: "matches ID of an existing consumer",
+			fields: fields{
+				targetContent: &Content{
+					Consumers: []FConsumer{
+						{
+							Consumer: kong.Consumer{
+								Username: kong.String("foo"),
+							},
+						},
+					},
+				},
+				currentState: existingConsumerCredState(),
+			},
+			want: &utils.KongRawState{
+				Consumers: []*kong.Consumer{
+					{
+						ID:       kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
+						Username: kong.String("foo"),
+					},
+				},
+			},
+		},
+		{
+			name: "matches ID of an existing credential",
+			fields: fields{
+				targetContent: &Content{
+					Consumers: []FConsumer{
+						{
+							Consumer: kong.Consumer{
+								Username: kong.String("foo"),
+							},
+							KeyAuths: []*kong.KeyAuth{
+								{
+									Key: kong.String("foo-apikey"),
+								},
+							},
+							BasicAuths: []*kong.BasicAuth{
+								{
+									Username: kong.String("basic-username"),
+									Password: kong.String("basic-password"),
+								},
+							},
+							HMACAuths: []*kong.HMACAuth{
+								{
+									Username: kong.String("hmac-username"),
+									Secret:   kong.String("hmac-secret"),
+								},
+							},
+							JWTAuths: []*kong.JWTAuth{
+								{
+									Key:    kong.String("jwt-key"),
+									Secret: kong.String("jwt-secret"),
+								},
+							},
+							Oauth2Creds: []*kong.Oauth2Credential{
+								{
+									ClientID: kong.String("oauth2-clientid"),
+									Name:     kong.String("oauth2-name"),
+								},
+							},
+							ACLGroups: []*kong.ACLGroup{
+								{
+									Group: kong.String("foo-group"),
+								},
+							},
+							MTLSAuths: []*kong.MTLSAuth{
+								{
+									ID:          kong.String("533c259e-bf71-4d77-99d2-97944c70a6a4"),
+									SubjectName: kong.String("test@example.com"),
+								},
+							},
+						},
+					},
+					Info: &Info{
+						SelectorTags: []string{"tag1"},
+					},
+				},
+				currentState: existingConsumerCredState(),
+				kongVersion:  kong140Version,
+			},
+			want: &utils.KongRawState{
+				Consumers: []*kong.Consumer{
+					{
+						ID:       kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
+						Username: kong.String("foo"),
+						Tags:     kong.StringSlice("tag1"),
+					},
+				},
+				KeyAuths: []*kong.KeyAuth{
+					{
+						ID:  kong.String("5f1ef1ea-a2a5-4a1b-adbb-b0d3434013e5"),
+						Key: kong.String("foo-apikey"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
+						},
+						Tags: kong.StringSlice("tag1"),
+					},
+				},
+				BasicAuths: []*kong.BasicAuth{
+					{
+						ID:       kong.String("92f4c849-960b-43af-aad3-f307051408d3"),
+						Username: kong.String("basic-username"),
+						Password: kong.String("basic-password"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
+						},
+						Tags: kong.StringSlice("tag1"),
+					},
+				},
+				HMACAuths: []*kong.HMACAuth{
+					{
+						ID:       kong.String("e5d81b73-bf9e-42b0-9d68-30a1d791b9c9"),
+						Username: kong.String("hmac-username"),
+						Secret:   kong.String("hmac-secret"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
+						},
+						Tags: kong.StringSlice("tag1"),
+					},
+				},
+				JWTAuths: []*kong.JWTAuth{
+					{
+						ID:     kong.String("917b9402-1be0-49d2-b482-ca4dccc2054e"),
+						Key:    kong.String("jwt-key"),
+						Secret: kong.String("jwt-secret"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
+						},
+						Tags: kong.StringSlice("tag1"),
+					},
+				},
+				Oauth2Creds: []*kong.Oauth2Credential{
+					{
+						ID:       kong.String("4eef5285-3d6a-4f6b-b659-8957a940e2ca"),
+						ClientID: kong.String("oauth2-clientid"),
+						Name:     kong.String("oauth2-name"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
+						},
+						Tags: kong.StringSlice("tag1"),
+					},
+				},
+				ACLGroups: []*kong.ACLGroup{
+					{
+						ID:    kong.String("b7c9352a-775a-4ba5-9869-98e926a3e6cb"),
+						Group: kong.String("foo-group"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
+						},
+						Tags: kong.StringSlice("tag1"),
+					},
+				},
+				MTLSAuths: []*kong.MTLSAuth{
+					{
+						ID:          kong.String("533c259e-bf71-4d77-99d2-97944c70a6a4"),
+						SubjectName: kong.String("test@example.com"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "does not inject tags if Kong version is older than 1.4",
+			fields: fields{
+				targetContent: &Content{
+					Consumers: []FConsumer{
+						{
+							Consumer: kong.Consumer{
+								Username: kong.String("foo"),
+							},
+							KeyAuths: []*kong.KeyAuth{
+								{
+									Key: kong.String("foo-apikey"),
+								},
+							},
+							BasicAuths: []*kong.BasicAuth{
+								{
+									Username: kong.String("basic-username"),
+									Password: kong.String("basic-password"),
+								},
+							},
+							HMACAuths: []*kong.HMACAuth{
+								{
+									Username: kong.String("hmac-username"),
+									Secret:   kong.String("hmac-secret"),
+								},
+							},
+							JWTAuths: []*kong.JWTAuth{
+								{
+									Key:    kong.String("jwt-key"),
+									Secret: kong.String("jwt-secret"),
+								},
+							},
+							Oauth2Creds: []*kong.Oauth2Credential{
+								{
+									ClientID: kong.String("oauth2-clientid"),
+									Name:     kong.String("oauth2-name"),
+								},
+							},
+							ACLGroups: []*kong.ACLGroup{
+								{
+									Group: kong.String("foo-group"),
+								},
+							},
+							MTLSAuths: []*kong.MTLSAuth{
+								{
+									ID:          kong.String("533c259e-bf71-4d77-99d2-97944c70a6a4"),
+									SubjectName: kong.String("test@example.com"),
+								},
+							},
+						},
+					},
+					Info: &Info{
+						SelectorTags: []string{"tag1"},
+					},
+				},
+				currentState: existingConsumerCredState(),
+				kongVersion:  kong130Version,
+			},
+			want: &utils.KongRawState{
+				Consumers: []*kong.Consumer{
+					{
+						ID:       kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
+						Username: kong.String("foo"),
+						Tags:     kong.StringSlice("tag1"),
+					},
+				},
+				KeyAuths: []*kong.KeyAuth{
+					{
+						ID:  kong.String("5f1ef1ea-a2a5-4a1b-adbb-b0d3434013e5"),
+						Key: kong.String("foo-apikey"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
+						},
+					},
+				},
+				BasicAuths: []*kong.BasicAuth{
+					{
+						ID:       kong.String("92f4c849-960b-43af-aad3-f307051408d3"),
+						Username: kong.String("basic-username"),
+						Password: kong.String("basic-password"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
+						},
+					},
+				},
+				HMACAuths: []*kong.HMACAuth{
+					{
+						ID:       kong.String("e5d81b73-bf9e-42b0-9d68-30a1d791b9c9"),
+						Username: kong.String("hmac-username"),
+						Secret:   kong.String("hmac-secret"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
+						},
+					},
+				},
+				JWTAuths: []*kong.JWTAuth{
+					{
+						ID:     kong.String("917b9402-1be0-49d2-b482-ca4dccc2054e"),
+						Key:    kong.String("jwt-key"),
+						Secret: kong.String("jwt-secret"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
+						},
+					},
+				},
+				Oauth2Creds: []*kong.Oauth2Credential{
+					{
+						ID:       kong.String("4eef5285-3d6a-4f6b-b659-8957a940e2ca"),
+						ClientID: kong.String("oauth2-clientid"),
+						Name:     kong.String("oauth2-name"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
+						},
+					},
+				},
+				ACLGroups: []*kong.ACLGroup{
+					{
+						ID:    kong.String("b7c9352a-775a-4ba5-9869-98e926a3e6cb"),
+						Group: kong.String("foo-group"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
+						},
+					},
+				},
+				MTLSAuths: []*kong.MTLSAuth{
+					{
+						ID:          kong.String("533c259e-bf71-4d77-99d2-97944c70a6a4"),
+						SubjectName: kong.String("test@example.com"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "inject tags if Kong version is newer than 1.4",
+			fields: fields{
+				targetContent: &Content{
+					Consumers: []FConsumer{
+						{
+							Consumer: kong.Consumer{
+								Username: kong.String("foo"),
+							},
+							KeyAuths: []*kong.KeyAuth{
+								{
+									Key: kong.String("foo-apikey"),
+								},
+							},
+							BasicAuths: []*kong.BasicAuth{
+								{
+									Username: kong.String("basic-username"),
+									Password: kong.String("basic-password"),
+								},
+							},
+							HMACAuths: []*kong.HMACAuth{
+								{
+									Username: kong.String("hmac-username"),
+									Secret:   kong.String("hmac-secret"),
+								},
+							},
+							JWTAuths: []*kong.JWTAuth{
+								{
+									Key:    kong.String("jwt-key"),
+									Secret: kong.String("jwt-secret"),
+								},
+							},
+							Oauth2Creds: []*kong.Oauth2Credential{
+								{
+									ClientID: kong.String("oauth2-clientid"),
+									Name:     kong.String("oauth2-name"),
+								},
+							},
+							ACLGroups: []*kong.ACLGroup{
+								{
+									Group: kong.String("foo-group"),
+								},
+							},
+							MTLSAuths: []*kong.MTLSAuth{
+								{
+									ID:          kong.String("533c259e-bf71-4d77-99d2-97944c70a6a4"),
+									SubjectName: kong.String("test@example.com"),
+								},
+							},
+						},
+					},
+					Info: &Info{
+						SelectorTags: []string{"tag1"},
+					},
+				},
+				currentState: existingConsumerCredState(),
+				kongVersion:  kong230Version,
+			},
+			want: &utils.KongRawState{
+				Consumers: []*kong.Consumer{
+					{
+						ID:       kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
+						Username: kong.String("foo"),
+						Tags:     kong.StringSlice("tag1"),
+					},
+				},
+				KeyAuths: []*kong.KeyAuth{
+					{
+						ID:  kong.String("5f1ef1ea-a2a5-4a1b-adbb-b0d3434013e5"),
+						Key: kong.String("foo-apikey"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
+						},
+						Tags: kong.StringSlice("tag1"),
+					},
+				},
+				BasicAuths: []*kong.BasicAuth{
+					{
+						ID:       kong.String("92f4c849-960b-43af-aad3-f307051408d3"),
+						Username: kong.String("basic-username"),
+						Password: kong.String("basic-password"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
+						},
+						Tags: kong.StringSlice("tag1"),
+					},
+				},
+				HMACAuths: []*kong.HMACAuth{
+					{
+						ID:       kong.String("e5d81b73-bf9e-42b0-9d68-30a1d791b9c9"),
+						Username: kong.String("hmac-username"),
+						Secret:   kong.String("hmac-secret"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
+						},
+						Tags: kong.StringSlice("tag1"),
+					},
+				},
+				JWTAuths: []*kong.JWTAuth{
+					{
+						ID:     kong.String("917b9402-1be0-49d2-b482-ca4dccc2054e"),
+						Key:    kong.String("jwt-key"),
+						Secret: kong.String("jwt-secret"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
+						},
+						Tags: kong.StringSlice("tag1"),
+					},
+				},
+				Oauth2Creds: []*kong.Oauth2Credential{
+					{
+						ID:       kong.String("4eef5285-3d6a-4f6b-b659-8957a940e2ca"),
+						ClientID: kong.String("oauth2-clientid"),
+						Name:     kong.String("oauth2-name"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
+						},
+						Tags: kong.StringSlice("tag1"),
+					},
+				},
+				ACLGroups: []*kong.ACLGroup{
+					{
+						ID:    kong.String("b7c9352a-775a-4ba5-9869-98e926a3e6cb"),
+						Group: kong.String("foo-group"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
+						},
+						Tags: kong.StringSlice("tag1"),
+					},
+				},
+				MTLSAuths: []*kong.MTLSAuth{
+					{
+						ID:          kong.String("533c259e-bf71-4d77-99d2-97944c70a6a4"),
+						SubjectName: kong.String("test@example.com"),
+						Consumer: &kong.Consumer{
+							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
+						},
+						Tags: kong.StringSlice("tag1"),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state, err := Get(tt.fields.targetContent, RenderConfig{
+				CurrentState: tt.fields.currentState,
+				KongVersion:  tt.fields.kongVersion,
+			})
+			if err != nil {
+				panic(err)
+			}
+			assert.Equal(tt.want, state)
+		})
+	}
 }


### PR DESCRIPTION
Hi! I was taking a look at the open Issues and decided to take a first stub at the problem described in https://github.com/Kong/deck/issues/457, more specifically at the first bullet into that list:

> kick kongVersion out of stateBuilder to a higher level, and replace it with knobs that control whether selectTags get applied to all creds, or all creds but mtls-auth, or to none.

In order to make the code a bit cleaner, I decided to refactor a bit the `MergeTags` function as well.
For now, I added a new `reader_test.go` which is, for a good portion, a take over from what's inside `builder_test.go`. I guess the `builder` tests can be improved at a second time when its own refactoring is taken into account as well.

Let me know what you think! :) 