### PR TITLE
feat: add support to validate via Kong API

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -26,6 +26,19 @@ var (
 	assumeYes  bool
 )
 
+func performValidate(ctx context.Context, kongClient *kong.Client, entity string) (bool, error) {
+	endpoint := fmt.Sprintf("/schemas/%s/validate", entity)
+	req, err := kongClient.NewRequest("POST", endpoint, nil, nil)
+	if err != nil {
+		return false, err
+	}
+	resp, err := kongClient.Do(ctx, req, nil)
+	if err != nil {
+		return false, err
+	}
+	return resp.StatusCode == http.StatusOK, nil
+}
+
 // workspaceExists checks if workspace exists in Kong.
 func workspaceExists(ctx context.Context, config utils.KongClientConfig, workspaceName string) (bool, error) {
 	rootConfig := config.ForWorkspace("")

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -26,20 +26,6 @@ var (
 	assumeYes  bool
 )
 
-func validateEntity(ctx context.Context, kongClient *kong.Client, entityType string, entity interface{}) (bool, error) {
-	errWrap := "validate entity '%s': %s"
-	endpoint := fmt.Sprintf("/schemas/%s/validate", entityType)
-	req, err := kongClient.NewRequest(http.MethodPost, endpoint, nil, entity)
-	if err != nil {
-		return false, fmt.Errorf(errWrap, entityType, err)
-	}
-	resp, err := kongClient.Do(ctx, req, nil)
-	if err != nil {
-		return false, fmt.Errorf(errWrap, entityType, err)
-	}
-	return resp.StatusCode == http.StatusOK, nil
-}
-
 // workspaceExists checks if workspace exists in Kong.
 func workspaceExists(ctx context.Context, config utils.KongClientConfig, workspaceName string) (bool, error) {
 	rootConfig := config.ForWorkspace("")

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -58,7 +58,7 @@ func workspaceExists(ctx context.Context, config utils.KongClientConfig, workspa
 		return false, err
 	}
 
-	exists, err := rootClient.Workspaces.Exists(ctx, &workspaceName)
+	exists, err := rootClient.Workspaces.ExistsByName(ctx, &workspaceName)
 	if err != nil {
 		return false, fmt.Errorf("checking if workspace exists: %w", err)
 	}

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -65,11 +65,11 @@ func workspaceExists(ctx context.Context, config utils.KongClientConfig, workspa
 	return exists, nil
 }
 
-func getWorkspaceName(workspace string, targetContent *file.Content) string {
-	if workspace != targetContent.Workspace && workspace != "" {
+func getWorkspaceName(workspaceFlag string, targetContent *file.Content) string {
+	if workspaceFlag != targetContent.Workspace && workspaceFlag != "" {
 		cprint.DeletePrintf("Warning: Workspace '%v' specified via --workspace flag is "+
-			"different from workspace '%v' found in state file(s).\n", workspace, targetContent.Workspace)
-		return workspace
+			"different from workspace '%v' found in state file(s).\n", workspaceFlag, targetContent.Workspace)
+		return workspaceFlag
 	}
 	return targetContent.Workspace
 }

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -26,9 +26,9 @@ var (
 	assumeYes  bool
 )
 
-func performValidate(ctx context.Context, kongClient *kong.Client, entity string) (bool, error) {
-	endpoint := fmt.Sprintf("/schemas/%s/validate", entity)
-	req, err := kongClient.NewRequest("POST", endpoint, nil, nil)
+func performValidate(ctx context.Context, kongClient *kong.Client, entity interface{}, entityType string) (bool, error) {
+	endpoint := fmt.Sprintf("/schemas/%s/validate", entityType)
+	req, err := kongClient.NewRequest("POST", endpoint, nil, entity)
 	if err != nil {
 		return false, err
 	}

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -26,15 +26,16 @@ var (
 	assumeYes  bool
 )
 
-func performValidate(ctx context.Context, kongClient *kong.Client, entity interface{}, entityType string) (bool, error) {
+func validateEntity(ctx context.Context, kongClient *kong.Client, entityType string, entity interface{}) (bool, error) {
+	errWrap := "validate entity '%s': %s"
 	endpoint := fmt.Sprintf("/schemas/%s/validate", entityType)
-	req, err := kongClient.NewRequest("POST", endpoint, nil, entity)
+	req, err := kongClient.NewRequest(http.MethodPost, endpoint, nil, entity)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf(errWrap, entityType, err)
 	}
 	resp, err := kongClient.Do(ctx, req, nil)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf(errWrap, entityType, err)
 	}
 	return resp.StatusCode == http.StatusOK, nil
 }

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -118,6 +118,12 @@ func validateEntities(ctx context.Context, obj interface{}, kongClient *kong.Cli
 
 func validateWithKong(cmd *cobra.Command, ks *state.KongState) []error {
 	ctx := cmd.Context()
+	// make sure we are able to connect to Kong
+	_, err := fetchKongVersion(ctx, rootConfig)
+	if err != nil {
+		return []error{fmt.Errorf("couldn't fetch Kong version: %w", err)}
+	}
+
 	kongClient, err := utils.GetKongClient(rootConfig)
 	allErr := []error{}
 	if err != nil {

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -66,7 +66,7 @@ this command unless --online flag is used.
 		}
 
 		if validateOnline {
-			if errs := validateWithKong(cmd, ks, targetContent); errs != nil {
+			if errs := validateWithKong(cmd, ks, targetContent); len(errs) != 0 {
 				for _, e := range errs {
 					fmt.Println(e)
 				}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -22,6 +22,18 @@ var (
 	validateParallelism          int
 )
 
+type validateErrorsWrapper struct {
+	errors []error
+}
+
+func (v validateErrorsWrapper) Error() string {
+	var errStr string
+	for _, e := range v.errors {
+		errStr += fmt.Sprintf("%s\n", e.Error())
+	}
+	return errStr
+}
+
 // validateCmd represents the diff command
 var validateCmd = &cobra.Command{
 	Use:   "validate",
@@ -66,10 +78,7 @@ this command unless --online flag is used.
 
 		if validateOnline {
 			if errs := validateWithKong(cmd, ks, targetContent); len(errs) != 0 {
-				for _, e := range errs {
-					fmt.Println(e)
-				}
-				os.Exit(1)
+				return validateErrorsWrapper{errors: errs}
 			}
 		}
 		return nil

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/kong/deck/file"
 	"github.com/kong/deck/state"
@@ -103,7 +102,15 @@ func validateWithKong(cmd *cobra.Command, ks *state.KongState, targetContent *fi
 	if err != nil {
 		return []error{err}
 	}
-	validator := validate.NewValidator(ctx, ks, kongClient, validateParallelism, validateCmdRBACResourcesOnly)
+
+	opts := validate.ValidatorOpts{
+		Ctx:               ctx,
+		State:             ks,
+		Client:            kongClient,
+		Parallelism:       validateParallelism,
+		RBACResourcesOnly: validateCmdRBACResourcesOnly,
+	}
+	validator := validate.NewValidator(opts)
 	return validator.Validate()
 }
 
@@ -190,7 +197,6 @@ func init() {
 		10, "Maximum number of concurrent requests to Kong.")
 
 	if err := ensureGetAllMethods(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		panic(err.Error())
 	}
 }

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -81,14 +81,6 @@ this command unless --online flag is used.
 	},
 }
 
-func validate(ctx context.Context, entity interface{}, kongClient *kong.Client, entityType string) error {
-	_, err := validateEntity(ctx, kongClient, entityType, entity)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 func validateEntities(ctx context.Context, obj interface{}, kongClient *kong.Client, entityType string) []error {
 	entities := callGetAll(obj)
 	errors := []error{}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 	"reflect"
 	"sync"
 
@@ -68,6 +69,7 @@ this command unless --online flag is used.
 				for _, e := range errs {
 					fmt.Println(e)
 				}
+				os.Exit(1)
 			}
 		}
 		return nil
@@ -169,6 +171,12 @@ func validateWithKong(cmd *cobra.Command, ks *state.KongState) []error {
 	if err := validateEntities(ctx, ks.Upstreams, kongClient, "upstreams"); err != nil {
 		allErr = append(allErr, err...)
 	}
+	if err := validateEntities(ctx, ks.RBACEndpointPermissions, kongClient, "rbac-endpointpermission"); err != nil {
+		allErr = append(allErr, err...)
+	}
+	if err := validateEntities(ctx, ks.RBACRoles, kongClient, "rbac-role"); err != nil {
+		allErr = append(allErr, err...)
+	}
 	return allErr
 }
 
@@ -201,6 +209,8 @@ func ensureGetAllMethods() {
 	callGetAll(dummyEmptyState.SNIs)
 	callGetAll(dummyEmptyState.Targets)
 	callGetAll(dummyEmptyState.Upstreams)
+	callGetAll(dummyEmptyState.RBACEndpointPermissions)
+	callGetAll(dummyEmptyState.RBACRoles)
 }
 
 func init() {

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -85,14 +85,17 @@ func validateWithKong(cmd *cobra.Command, ks *state.KongState, targetContent *fi
 		return []error{fmt.Errorf("couldn't fetch Kong version: %w", err)}
 	}
 
-	// check if workspace exists
-	workspaceName := getWorkspaceName(validateWorkspace, targetContent)
-	workspaceExists, err := workspaceExists(ctx, rootConfig, workspaceName)
-	if err != nil {
-		return []error{err}
-	}
-	if !workspaceExists {
-		return []error{fmt.Errorf("workspace doesn't exist: %s", workspaceName)}
+	workspaceName := validateWorkspace
+	if validateWorkspace != "" {
+		// check if workspace exists
+		workspaceName := getWorkspaceName(validateWorkspace, targetContent)
+		workspaceExists, err := workspaceExists(ctx, rootConfig, workspaceName)
+		if err != nil {
+			return []error{err}
+		}
+		if !workspaceExists {
+			return []error{fmt.Errorf("workspace doesn't exist: %s", workspaceName)}
+		}
 	}
 
 	wsConfig := rootConfig.ForWorkspace(workspaceName)

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,69 +1,120 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"sync"
 
+	"github.com/fatih/color"
 	"github.com/kong/deck/file"
 	"github.com/kong/deck/state"
+	"github.com/kong/deck/utils"
+	"github.com/kong/go-kong/kong"
 	"github.com/spf13/cobra"
 )
 
 var (
 	validateCmdKongStateFile     []string
 	validateCmdRBACResourcesOnly bool
+	validateCmdKongAPI           bool
+	validateCmdKongAPIEntity     []string
 )
 
 // validateCmd represents the diff command
 var validateCmd = &cobra.Command{
 	Use:   "validate",
-	Short: "Validate the state file",
-	Long: `The validate command reads the state file and ensures validity.
+	Short: "Validate configuration",
+	Long: `The validate command supports 2 modes to ensure validity:
+	- reads the state file (default)
+	- queries Kong API
 
-It reads all the specified state files and reports YAML/JSON
+By default, it reads all the specified state files and reports YAML/JSON
 parsing issues. It also checks for foreign relationships
 and alerts if there are broken relationships, or missing links present.
-No communication takes places between decK and Kong during the execution of
-this command.
+
+When ran with the --use-kong-api flag, it uses the 'validate' endpoint in Kong
+to validate entities configuration.
 `,
 	Args: validateNoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		_ = sendAnalytics("validate", "")
-		// read target file
-		// this does json schema validation as well
-		targetContent, err := file.GetContentFromFiles(validateCmdKongStateFile)
-		if err != nil {
-			return err
+		if validateCmdKongAPI {
+			return validateWithKong(cmd, validateCmdKongAPIEntity)
 		}
-
-		dummyEmptyState, err := state.NewKongState()
-		if err != nil {
-			return err
-		}
-
-		rawState, err := file.Get(targetContent, file.RenderConfig{
-			CurrentState: dummyEmptyState,
-		})
-		if err != nil {
-			return err
-		}
-		if err := checkForRBACResources(*rawState, validateCmdRBACResourcesOnly); err != nil {
-			return err
-		}
-		// this catches foreign relation errors
-		_, err = state.Get(rawState)
-		if err != nil {
-			return err
-		}
-
-		return nil
+		return validateWithFile()
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if len(validateCmdKongStateFile) == 0 {
 			return fmt.Errorf("a state file with Kong's configuration " +
 				"must be specified using -s/--state flag")
+		} else if validateCmdKongAPI && len(validateCmdKongAPIEntity) == 0 {
+			return fmt.Errorf("a list of entities must be specified " +
+				"using the -e/--entity flag when validating via Kong API " +
+				"(e.g. -e entity1 -e entity2)")
 		}
 		return nil
 	},
+}
+
+func validate(ctx context.Context, entity string, kongClient *kong.Client) string {
+	_, err := performValidate(ctx, kongClient, entity)
+	output := color.New(color.FgGreen, color.Bold).Sprintf("%s: schema validation successful", entity)
+	if err != nil {
+		output = color.New(color.FgRed, color.Bold).Sprintf("%s: %v", entity, err)
+	}
+	return output
+}
+
+func validateWithKong(cmd *cobra.Command, entity []string) error {
+	ctx := cmd.Context()
+	kongClient, err := utils.GetKongClient(rootConfig)
+	if err != nil {
+		return err
+	}
+	var wg sync.WaitGroup
+	wg.Add(len(entity))
+
+	for _, e := range entity {
+		go func(e string) {
+			defer wg.Done()
+			output := validate(ctx, e, kongClient)
+			fmt.Println(output)
+		}(e)
+	}
+	wg.Wait()
+
+	return nil
+}
+
+func validateWithFile() error {
+	// read target file
+	// this does json schema validation as well
+	targetContent, err := file.GetContentFromFiles(validateCmdKongStateFile)
+	if err != nil {
+		return err
+	}
+
+	dummyEmptyState, err := state.NewKongState()
+	if err != nil {
+		return err
+	}
+
+	rawState, err := file.Get(targetContent, file.RenderConfig{
+		CurrentState: dummyEmptyState,
+	})
+	if err != nil {
+		return err
+	}
+	if err := checkForRBACResources(*rawState, validateCmdRBACResourcesOnly); err != nil {
+		return err
+	}
+	// this catches foreign relation errors
+	_, err = state.Get(rawState)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func init() {
@@ -74,4 +125,9 @@ func init() {
 		"state", "s", []string{"kong.yaml"}, "file(s) containing Kong's configuration.\n"+
 			"This flag can be specified multiple times for multiple files.\n"+
 			"Use '-' to read from stdin.")
+	validateCmd.Flags().BoolVar(&validateCmdKongAPI, "use-kong-api",
+		false, "whether to leverage Kong's API to validate configuration.")
+	validateCmd.Flags().StringSliceVarP(&validateCmdKongAPIEntity,
+		"entity", "e", []string{}, "entities to be validated via Kong API "+
+			"(e.g. -e entity1 -e entity2)")
 }

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -174,6 +174,7 @@ func callGetAll(obj interface{}) reflect.Value {
 }
 
 func validateGetAllMethod() {
+	// let's make sure ASAP that all resources have the expected GetAll method
 	dummyEmptyState, _ := state.NewKongState()
 	callGetAll(dummyEmptyState.Services)
 	callGetAll(dummyEmptyState.ACLGroups)

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ func registerSignalHandler() context.Context {
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
+		defer signal.Stop(sigs)
 		sig := <-sigs
 		fmt.Println("received", sig, ", terminating...")
 		cancel()

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -59,7 +59,7 @@ func CallGetAll(obj interface{}) (reflect.Value, error) {
 	var result reflect.Value
 	method := reflect.ValueOf(obj).MethodByName("GetAll")
 	if !method.IsValid() {
-		return result, fmt.Errorf("GetAll() method not found for %v. "+
+		return result, fmt.Errorf("GetAll() method not found for type '%v'. "+
 			"Please file a bug with Kong Inc", reflect.ValueOf(obj).Type())
 	}
 	entities := method.Call([]reflect.Value{})[0].Interface()

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -60,7 +60,7 @@ func CallGetAll(obj interface{}) (reflect.Value, error) {
 	method := reflect.ValueOf(obj).MethodByName("GetAll")
 	if !method.IsValid() {
 		return result, fmt.Errorf("GetAll() method not found for %v. "+
-			"Please file a bug with Kong Inc.", reflect.ValueOf(obj).Type())
+			"Please file a bug with Kong Inc", reflect.ValueOf(obj).Type())
 	}
 	entities := method.Call([]reflect.Value{})[0].Interface()
 	result = reflect.ValueOf(entities)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strings"
 )
@@ -51,4 +52,17 @@ func NameToFilename(name string) string {
 // if that separator was included originally, and only some names (document paths) typically include one.
 func FilenameToName(filename string) string {
 	return strings.ReplaceAll(filename, url.PathEscape(string(os.PathSeparator)), string(os.PathSeparator))
+}
+
+func CallGetAll(obj interface{}) (reflect.Value, error) {
+	// call GetAll method on entity
+	var result reflect.Value
+	method := reflect.ValueOf(obj).MethodByName("GetAll")
+	if !method.IsValid() {
+		return result, fmt.Errorf("GetAll() method not found for %v. "+
+			"Please file a bug with Kong Inc.", reflect.ValueOf(obj).Type())
+	}
+	entities := method.Call([]reflect.Value{})[0].Interface()
+	result = reflect.ValueOf(entities)
+	return result, nil
 }

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -19,19 +19,21 @@ type Validator struct {
 	rbacResourcesOnly bool
 }
 
-func NewValidator(
-	ctx context.Context,
-	ks *state.KongState,
-	client *kong.Client,
-	parallelism int,
-	rbacResourcesOnly bool,
-) *Validator {
+type ValidatorOpts struct {
+	Ctx               context.Context
+	State             *state.KongState
+	Client            *kong.Client
+	Parallelism       int
+	RBACResourcesOnly bool
+}
+
+func NewValidator(opt ValidatorOpts) *Validator {
 	return &Validator{
-		ctx:               ctx,
-		state:             ks,
-		client:            client,
-		parallelism:       parallelism,
-		rbacResourcesOnly: rbacResourcesOnly,
+		ctx:               opt.Ctx,
+		state:             opt.State,
+		client:            opt.Client,
+		parallelism:       opt.Parallelism,
+		rbacResourcesOnly: opt.RBACResourcesOnly,
 	}
 }
 
@@ -42,7 +44,10 @@ type ErrorsWrapper struct {
 func (v ErrorsWrapper) Error() string {
 	var errStr string
 	for _, e := range v.Errors {
-		errStr += fmt.Sprintf("%s\n", e.Error())
+		errStr += e.Error()
+		if e != v.Errors[len(v.Errors)-1] {
+			errStr += "\n"
+		}
 	}
 	return errStr
 }

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -1,0 +1,158 @@
+package validate
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/kong/go-kong/kong"
+
+	"github.com/kong/deck/state"
+	"github.com/kong/deck/utils"
+)
+
+type Validator struct {
+	ctx               context.Context
+	state             *state.KongState
+	client            *kong.Client
+	parallelism       int
+	rbacResourcesOnly bool
+}
+
+func NewValidator(ctx context.Context, ks *state.KongState, client *kong.Client, parallelism int, rbacResourcesOnly bool) *Validator {
+	return &Validator{
+		ctx:               ctx,
+		state:             ks,
+		client:            client,
+		parallelism:       parallelism,
+		rbacResourcesOnly: rbacResourcesOnly,
+	}
+}
+
+type ErrorsWrapper struct {
+	Errors []error
+}
+
+func (v ErrorsWrapper) Error() string {
+	var errStr string
+	for _, e := range v.Errors {
+		errStr += fmt.Sprintf("%s\n", e.Error())
+	}
+	return errStr
+}
+
+func (v *Validator) validateEntity(entityType string, entity interface{}) (bool, error) {
+	errWrap := "validate entity '%s': %s"
+	endpoint := fmt.Sprintf("/schemas/%s/validate", entityType)
+	req, err := v.client.NewRequest(http.MethodPost, endpoint, nil, entity)
+	if err != nil {
+		return false, fmt.Errorf(errWrap, entityType, err)
+	}
+	resp, err := v.client.Do(v.ctx, req, nil)
+	if err != nil {
+		return false, fmt.Errorf(errWrap, entityType, err)
+	}
+	return resp.StatusCode == http.StatusOK, nil
+}
+
+func (v *Validator) entities(obj interface{}, entityType string) []error {
+	entities, err := utils.CallGetAll(obj)
+	if err != nil {
+		return []error{err}
+	}
+	errors := []error{}
+
+	// create a buffer of channels. Creation of new coroutines
+	// are allowed only if the buffer is not full.
+	chanBuff := make(chan struct{}, v.parallelism)
+
+	var wg sync.WaitGroup
+	wg.Add(entities.Len())
+	// each coroutine will append on a slice of errors.
+	// since slices are not thread-safe, let's add a mutex
+	// to handle access to the slice.
+	mu := &sync.Mutex{}
+	for i := 0; i < entities.Len(); i++ {
+		// reserve a slot
+		chanBuff <- struct{}{}
+		go func(i int) {
+			defer wg.Done()
+			// release a slot when completed
+			defer func() { <-chanBuff }()
+			_, err := v.validateEntity(entityType, entities.Index(i).Interface())
+			if err != nil {
+				mu.Lock()
+				errors = append(errors, err)
+				mu.Unlock()
+			}
+		}(i)
+	}
+	wg.Wait()
+	return errors
+}
+
+func (v *Validator) Validate() []error {
+	allErr := []error{}
+
+	// validate RBAC resources first.
+	if err := v.entities(v.state.RBACEndpointPermissions, "rbac-endpointpermission"); err != nil {
+		allErr = append(allErr, err...)
+	}
+	if err := v.entities(v.state.RBACRoles, "rbac-role"); err != nil {
+		allErr = append(allErr, err...)
+	}
+	if v.rbacResourcesOnly {
+		return allErr
+	}
+
+	if err := v.entities(v.state.Services, "services"); err != nil {
+		allErr = append(allErr, err...)
+	}
+	if err := v.entities(v.state.ACLGroups, "acls"); err != nil {
+		allErr = append(allErr, err...)
+	}
+	if err := v.entities(v.state.BasicAuths, "basicauth_credentials"); err != nil {
+		allErr = append(allErr, err...)
+	}
+	if err := v.entities(v.state.CACertificates, "ca_certificates"); err != nil {
+		allErr = append(allErr, err...)
+	}
+	if err := v.entities(v.state.Certificates, "certificates"); err != nil {
+		allErr = append(allErr, err...)
+	}
+	if err := v.entities(v.state.Consumers, "consumers"); err != nil {
+		allErr = append(allErr, err...)
+	}
+	if err := v.entities(v.state.Documents, "documents"); err != nil {
+		allErr = append(allErr, err...)
+	}
+	if err := v.entities(v.state.HMACAuths, "hmacauth_credentials"); err != nil {
+		allErr = append(allErr, err...)
+	}
+	if err := v.entities(v.state.JWTAuths, "jwt_secrets"); err != nil {
+		allErr = append(allErr, err...)
+	}
+	if err := v.entities(v.state.KeyAuths, "keyauth_credentials"); err != nil {
+		allErr = append(allErr, err...)
+	}
+	if err := v.entities(v.state.Oauth2Creds, "oauth2_credentials"); err != nil {
+		allErr = append(allErr, err...)
+	}
+	if err := v.entities(v.state.Plugins, "plugins"); err != nil {
+		allErr = append(allErr, err...)
+	}
+	if err := v.entities(v.state.Routes, "routes"); err != nil {
+		allErr = append(allErr, err...)
+	}
+	if err := v.entities(v.state.SNIs, "snis"); err != nil {
+		allErr = append(allErr, err...)
+	}
+	if err := v.entities(v.state.Targets, "targets"); err != nil {
+		allErr = append(allErr, err...)
+	}
+	if err := v.entities(v.state.Upstreams, "upstreams"); err != nil {
+		allErr = append(allErr, err...)
+	}
+	return allErr
+}

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -6,10 +6,9 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/kong/go-kong/kong"
-
 	"github.com/kong/deck/state"
 	"github.com/kong/deck/utils"
+	"github.com/kong/go-kong/kong"
 )
 
 type Validator struct {

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -19,7 +19,13 @@ type Validator struct {
 	rbacResourcesOnly bool
 }
 
-func NewValidator(ctx context.Context, ks *state.KongState, client *kong.Client, parallelism int, rbacResourcesOnly bool) *Validator {
+func NewValidator(
+	ctx context.Context,
+	ks *state.KongState,
+	client *kong.Client,
+	parallelism int,
+	rbacResourcesOnly bool,
+) *Validator {
 	return &Validator{
 		ctx:               ctx,
 		state:             ks,


### PR DESCRIPTION
Hi! In order to get more familiarity with the tool and the codebase, I decided to give it a try and work on the proposal discussed in https://github.com/Kong/deck/issues/190

Sample usage:

```
$ deck validate --help
The validate command reads the state file and ensures validity.
It reads all the specified state files and reports YAML/JSON
parsing issues. It also checks for foreign relationships
and alerts if there are broken relationships, or missing links present.

When ran with the --use-kong-api flag, it also uses the 'validate' endpoint in Kong
to validate entities configuration.

Usage:
  deck validate [flags]

Flags:
  -h, --help                  help for validate
      --rbac-resources-only   indicate that the state file(s) contains RBAC resources only (Kong Enterprise only).
  -s, --state strings         file(s) containing Kong's configuration.
                              This flag can be specified multiple times for multiple files.
                              Use '-' to read from stdin. (default [kong.yaml])
      --use-kong-api          perform schema validation against Kong API.
```

Sample input:

```
services:
- name: svc1
  host: mockbin.org:80
  tags:
  - team-svc1
  routes:
  - name: r1
    https_redirect_status_code: 301
    paths:
    - /r1
certificates:
- id: 13c562a1-191c-4464-9b18-e5222b46035b
  cert: |
    -----BEGIN CERTIFICATE-----
    -----END CERTIFICATE-----
  key: |
    -----BEGIN PRIVATE KEY-----
    -----END PRIVATE KEY-----
  tags:
  - cloudops-managed
  snis:
  - name: demo1.example.com:123
  - name: demo2.example.com
  - name: demo3.example.com
plugins:
- name: prometheus
  enabled: true
  protocols:
  - httpss
  - https
 ```

Sample output:

```
$ deck validate --use-kong-api
services: HTTP status 400 (message: "schema violation (host: must not have a port)")
certificates: HTTP status 400 (message: "2 schema violations (cert: invalid certificate: x509.new: asn1/tasn_dec.c:309:error:0D07803A:asn1 encoding routines:asn1_item_embed_d2i:nested asn1 error; key: invalid key: pkey.new:load_key: asn1/tasn_dec.c:309:error:0D07803A:asn1 encoding routines:asn1_item_embed_d2i:nested asn1 error)")
plugins: HTTP status 400 (message: "schema violation (protocols.1: expected one of: grpc, grpcs, http, https, tcp, tls, udp)")
snis: HTTP status 400 (message: "schema violation (name: must not have a port)")
```


Let me know what you think! :)