### PR TITLE
Automatically release on tag push

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,97 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*.*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          # either 'goreleaser' (default) or 'goreleaser-pro'
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload assets
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist/*
+
+  build-push-images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add standard tags
+        run: |
+          echo 'TAGS_STANDARD<<EOF' >> $GITHUB_ENV
+          echo 'type=ref,event=branch' >> $GITHUB_ENV
+          echo 'type=semver,pattern={{raw}}' >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2.1.6
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3.5.0
+        with:
+          images: kong/deck
+          tags: ${{ env.TAGS_STANDARD }}${{ env.TAGS_SUPPLEMENTAL }}
+          flavor: |
+            latest=${{ startsWith(github.ref, 'refs/tags/v1') }}
+      - name: Docker meta (Harry's repo)
+        id: harry_meta
+        uses: docker/metadata-action@v3.5.0
+        with:
+          images: hbagdi/deck
+          tags: ${{ env.TAGS_STANDARD }}${{ env.TAGS_SUPPLEMENTAL }}
+          flavor: |
+            latest=${{ startsWith(github.ref, 'refs/tags/v1') }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          file: Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          build-args: |
+            TAG=${{ steps.meta.outputs.tags }}
+            COMMIT=${{ github.sha }}
+      - name: Build and push (Harry's repo)
+        id: docker_build_harry
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          file: Dockerfile
+          tags: ${{ steps.harry_meta.outputs.tags }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          build-args: |
+            TAG=${{ steps.meta.outputs.tags }}
+            COMMIT=${{ github.sha }}


### PR DESCRIPTION
Adds tag push CI jobs that run goreleaser, upload dist output, and build/push images to Docker Hub.

This will absolve us of the need to generate temporary kongbot tokens to push to the Kong Docker Hub. goreleaser has a good simple action also, so may as well add that too to automate the rest of the release.

The goreleaser job uploads dist output to the action artifacts for handling Homebrew releases.

This **does not work yet**. It requires HARRY_DOCKER_USERNAME, HARRY_DOCKER_TOKEN, DOCKER_USERNAME, and DOCKER_TOKEN secrets to actually push to Docker Hub. These should have access to Harry's registry and the Kong registry, respectively.

Example results: https://github.com/rainest/deck/runs/3943012130

```
11:21:46-0700 yagody $ docker run traines/altdeck:v1.8.11 version
decK traines/deck:v1.8.11 (a3c154682ba932e21e4510e20ebe2b247f90a3e4) 
```

This conditions `latest` tagging on the major version, based on the suggestion from https://github.com/docker/metadata-action/issues/80. I think this is probably reasonable, as I don't think we've historically ever done patch releases for older minor versions here (Kong itself is a different story), and would likely only do backports for major versions in the future. If that's true, this is a simple way to track the last release of the current major version with some infrequent manual work (you need to update CI when bumping the major version).

Our foundations repo has some more complicated tooling for determining latest by seeing if the current tag is higher than anything on Docker Hub, but it's difficult to use, as:
- That repo is currently private. It's probably okay to publish some of it but IDK, we'd need to ask.
- It's designed as an all-in-one bash utility. We'd need to hack out bits and pieces to make it work with the rest of the actions tooling.
- We have no way of tracking upstream updates automatically if we import part of it here.