### PR TITLE
fix(sync) apply --select-tag to new entities

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -114,7 +114,7 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 				sort.Strings(dumpConfig.SelectorTags)
 				sort.Strings(targetContent.Info.SelectorTags)
 				if !reflect.DeepEqual(dumpConfig.SelectorTags, targetContent.Info.SelectorTags) {
-					return fmt.Errorf("different tags specified by state file and --select-tags differ")
+					return fmt.Errorf("tags specified in the state file and via --select-tags flag are different. decK expects tags to be specified in either via flag or via state file. In case both are specified, they must match.")
 				}
 			} else {
 				dumpConfig.SelectorTags = targetContent.Info.SelectorTags

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"reflect"
+	"sort"
 
 	"github.com/blang/semver/v4"
 	"github.com/kong/deck/cprint"
@@ -107,7 +109,17 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 	}
 
 	if targetContent.Info != nil {
-		dumpConfig.SelectorTags = targetContent.Info.SelectorTags
+		if len(targetContent.Info.SelectorTags) > 0 {
+			if len(dumpConfig.SelectorTags) > 0 {
+				sort.Strings(dumpConfig.SelectorTags)
+				sort.Strings(targetContent.Info.SelectorTags)
+				if !reflect.DeepEqual(dumpConfig.SelectorTags, targetContent.Info.SelectorTags) {
+					return fmt.Errorf("different tags specified by state file and --select-tags differ")
+				}
+			} else {
+				dumpConfig.SelectorTags = targetContent.Info.SelectorTags
+			}
+		}
 	}
 
 	// read the current state

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -137,7 +137,7 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 	rawState, err := file.Get(targetContent, file.RenderConfig{
 		CurrentState: currentState,
 		KongVersion:  parsedKongVersion,
-	})
+	}, dumpConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -108,18 +108,9 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 		return err
 	}
 
-	if targetContent.Info != nil {
-		if len(targetContent.Info.SelectorTags) > 0 {
-			if len(dumpConfig.SelectorTags) > 0 {
-				sort.Strings(dumpConfig.SelectorTags)
-				sort.Strings(targetContent.Info.SelectorTags)
-				if !reflect.DeepEqual(dumpConfig.SelectorTags, targetContent.Info.SelectorTags) {
-					return fmt.Errorf("tags specified in the state file and via --select-tags flag are different. decK expects tags to be specified in either via flag or via state file. In case both are specified, they must match.")
-				}
-			} else {
-				dumpConfig.SelectorTags = targetContent.Info.SelectorTags
-			}
-		}
+	dumpConfig.SelectorTags, err = determineSelectorTag(*targetContent, dumpConfig)
+	if err != nil {
+		return err
 	}
 
 	// read the current state
@@ -170,6 +161,28 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 		os.Exit(exitCodeDiffDetection)
 	}
 	return nil
+}
+
+func determineSelectorTag(targetContent file.Content, config dump.Config) ([]string, error) {
+	if targetContent.Info != nil {
+		if len(targetContent.Info.SelectorTags) > 0 {
+			if len(config.SelectorTags) > 0 {
+				sort.Strings(config.SelectorTags)
+				sort.Strings(targetContent.Info.SelectorTags)
+				if !reflect.DeepEqual(config.SelectorTags, targetContent.Info.SelectorTags) {
+					return nil, fmt.Errorf(`tags specified in the state file and via --select-tags flag are different.
+					decK expects tags to be specified in either via flag or via state file.
+					In case both are specified, they must match`)
+				}
+				// Both present and equal, return whichever
+				return targetContent.Info.SelectorTags, nil
+			}
+			// Only targetContent.Info.SelectorTags present
+			return targetContent.Info.SelectorTags, nil
+		}
+	}
+	// Either targetContent.Info or targetContent.Info.SelectorTags is empty, return config tags
+	return config.SelectorTags, nil
 }
 
 func fetchCurrentState(ctx context.Context, client *kong.Client, dumpConfig dump.Config) (*state.KongState, error) {

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -29,6 +29,15 @@ func TestDetermineSelectorTag(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "both present and equal order invariant",
+			args: args{
+				dumpConfig:  dump.Config{SelectorTags: []string{"foo", "bar"}},
+				fileContent: file.Content{Info: &file.Info{SelectorTags: []string{"bar", "foo"}}},
+			},
+			want:    []string{"bar", "foo"},
+			wantErr: false,
+		},
+		{
 			name: "both present and not equal",
 			args: args{
 				dumpConfig:  dump.Config{SelectorTags: []string{"bar"}},

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kong/deck/dump"
+	"github.com/kong/deck/file"
+)
+
+func TestDetermineSelectorTag(t *testing.T) {
+	type args struct {
+		dumpConfig  dump.Config
+		fileContent file.Content
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "both present and equal",
+			args: args{
+				dumpConfig:  dump.Config{SelectorTags: []string{"foo"}},
+				fileContent: file.Content{Info: &file.Info{SelectorTags: []string{"foo"}}},
+			},
+			want:    []string{"foo"},
+			wantErr: false,
+		},
+		{
+			name: "both present and not equal",
+			args: args{
+				dumpConfig:  dump.Config{SelectorTags: []string{"bar"}},
+				fileContent: file.Content{Info: &file.Info{SelectorTags: []string{"foo"}}},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "only file has tags",
+			args: args{
+				dumpConfig:  dump.Config{},
+				fileContent: file.Content{Info: &file.Info{SelectorTags: []string{"foo"}}},
+			},
+			want:    []string{"foo"},
+			wantErr: false,
+		},
+		{
+			name: "only config has tags",
+			args: args{
+				dumpConfig:  dump.Config{SelectorTags: []string{"foo"}},
+				fileContent: file.Content{Info: &file.Info{}},
+			},
+			want:    []string{"foo"},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := determineSelectorTag(tt.args.fileContent, tt.args.dumpConfig)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("determineSelectorTag() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("determineSelectorTag() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/kong/deck/dump"
 	"github.com/kong/deck/file"
 	"github.com/kong/deck/state"
 	"github.com/spf13/cobra"
@@ -42,7 +43,7 @@ this command.
 
 		rawState, err := file.Get(targetContent, file.RenderConfig{
 			CurrentState: dummyEmptyState,
-		})
+		}, dump.Config{})
 		if err != nil {
 			return err
 		}

--- a/file/builder.go
+++ b/file/builder.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/blang/semver/v4"
 	"github.com/kong/deck/konnect"
@@ -40,7 +41,13 @@ func (b *stateBuilder) build() (*utils.KongRawState, *utils.KonnectRawState, err
 	b.konnectRawState = &utils.KonnectRawState{}
 
 	if b.targetContent.Info != nil {
-		b.selectTags = b.targetContent.Info.SelectorTags
+		if len(b.selectTags) > 0 {
+			if !reflect.DeepEqual(b.selectTags, b.targetContent.Info.SelectorTags) {
+				return nil, nil, fmt.Errorf("different tags specified by state file and --select-tags differ")
+			}
+		} else {
+			b.selectTags = b.targetContent.Info.SelectorTags
+		}
 	}
 	b.intermediate, err = state.NewKongState()
 	if err != nil {

--- a/file/builder.go
+++ b/file/builder.go
@@ -2,8 +2,6 @@ package file
 
 import (
 	"fmt"
-	"reflect"
-	"sort"
 
 	"github.com/blang/semver/v4"
 	"github.com/kong/deck/konnect"
@@ -41,19 +39,6 @@ func (b *stateBuilder) build() (*utils.KongRawState, *utils.KonnectRawState, err
 	b.rawState = &utils.KongRawState{}
 	b.konnectRawState = &utils.KonnectRawState{}
 
-	if b.targetContent.Info != nil {
-		if len(b.targetContent.Info.SelectorTags) > 0 {
-			if len(b.selectTags) > 0 {
-				sort.Strings(b.selectTags)
-				sort.Strings(b.targetContent.Info.SelectorTags)
-				if !reflect.DeepEqual(b.selectTags, b.targetContent.Info.SelectorTags) {
-					return nil, nil, fmt.Errorf("different tags specified by state file and --select-tags differ")
-				}
-			} else {
-				b.selectTags = b.targetContent.Info.SelectorTags
-			}
-		}
-	}
 	b.intermediate, err = state.NewKongState()
 	if err != nil {
 		return nil, nil, err

--- a/file/builder.go
+++ b/file/builder.go
@@ -3,6 +3,7 @@ package file
 import (
 	"fmt"
 	"reflect"
+	"sort"
 
 	"github.com/blang/semver/v4"
 	"github.com/kong/deck/konnect"
@@ -41,12 +42,16 @@ func (b *stateBuilder) build() (*utils.KongRawState, *utils.KonnectRawState, err
 	b.konnectRawState = &utils.KonnectRawState{}
 
 	if b.targetContent.Info != nil {
-		if len(b.selectTags) > 0 {
-			if !reflect.DeepEqual(b.selectTags, b.targetContent.Info.SelectorTags) {
-				return nil, nil, fmt.Errorf("different tags specified by state file and --select-tags differ")
+		if len(b.targetContent.Info.SelectorTags) > 0 {
+			if len(b.selectTags) > 0 {
+				sort.Strings(b.selectTags)
+				sort.Strings(b.targetContent.Info.SelectorTags)
+				if !reflect.DeepEqual(b.selectTags, b.targetContent.Info.SelectorTags) {
+					return nil, nil, fmt.Errorf("different tags specified by state file and --select-tags differ")
+				}
+			} else {
+				b.selectTags = b.targetContent.Info.SelectorTags
 			}
-		} else {
-			b.selectTags = b.targetContent.Info.SelectorTags
 		}
 	}
 	b.intermediate, err = state.NewKongState()

--- a/file/builder_test.go
+++ b/file/builder_test.go
@@ -309,9 +309,7 @@ func Test_stateBuilder_services(t *testing.T) {
 			name: "matches ID of an existing service",
 			fields: fields{
 				targetContent: &Content{
-					Info: &Info{
-						SelectorTags: []string{"tag1"},
-					},
+					Info: &Info{},
 					Services: []FService{
 						{
 							Service: kong.Service{
@@ -361,6 +359,7 @@ func Test_stateBuilder_services(t *testing.T) {
 						ConnectTimeout: kong.Int(60000),
 						WriteTimeout:   kong.Int(60000),
 						ReadTimeout:    kong.Int(60000),
+						Tags:           kong.StringSlice("tag1"),
 					},
 				},
 			},
@@ -371,6 +370,7 @@ func Test_stateBuilder_services(t *testing.T) {
 			b := &stateBuilder{
 				targetContent: tt.fields.targetContent,
 				currentState:  tt.fields.currentState,
+				selectTags:    []string{"tag1"},
 			}
 			b.build()
 			assert.Equal(tt.want, b.rawState)
@@ -769,9 +769,7 @@ func Test_stateBuilder_consumers(t *testing.T) {
 							},
 						},
 					},
-					Info: &Info{
-						SelectorTags: []string{"tag1"},
-					},
+					Info: &Info{},
 				},
 				currentState: emptyState(),
 			},
@@ -780,7 +778,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 					{
 						ID:       kong.String("538c7f96-b164-4f1b-97bb-9f4bb472e89f"),
 						Username: kong.String("foo"),
-						Tags:     kong.StringSlice("tag1"),
 					},
 				},
 			},
@@ -830,9 +827,7 @@ func Test_stateBuilder_consumers(t *testing.T) {
 							},
 						},
 					},
-					Info: &Info{
-						SelectorTags: []string{"tag1"},
-					},
+					Info: &Info{},
 				},
 				currentState: emptyState(),
 			},
@@ -841,7 +836,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 					{
 						ID:       kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
 						Username: kong.String("foo"),
-						Tags:     kong.StringSlice("tag1"),
 					},
 				},
 				KeyAuths: []*kong.KeyAuth{
@@ -851,7 +845,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				BasicAuths: []*kong.BasicAuth{
@@ -862,7 +855,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				HMACAuths: []*kong.HMACAuth{
@@ -873,7 +865,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				JWTAuths: []*kong.JWTAuth{
@@ -884,7 +875,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				Oauth2Creds: []*kong.Oauth2Credential{
@@ -895,7 +885,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				ACLGroups: []*kong.ACLGroup{
@@ -905,7 +894,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				MTLSAuths: nil,
@@ -985,9 +973,7 @@ func Test_stateBuilder_consumers(t *testing.T) {
 							},
 						},
 					},
-					Info: &Info{
-						SelectorTags: []string{"tag1"},
-					},
+					Info: &Info{},
 				},
 				currentState: existingConsumerCredState(),
 			},
@@ -996,7 +982,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 					{
 						ID:       kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						Username: kong.String("foo"),
-						Tags:     kong.StringSlice("tag1"),
 					},
 				},
 				KeyAuths: []*kong.KeyAuth{
@@ -1006,7 +991,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				BasicAuths: []*kong.BasicAuth{
@@ -1017,7 +1001,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				HMACAuths: []*kong.HMACAuth{
@@ -1028,7 +1011,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				JWTAuths: []*kong.JWTAuth{
@@ -1039,7 +1021,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				Oauth2Creds: []*kong.Oauth2Credential{
@@ -1050,7 +1031,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				ACLGroups: []*kong.ACLGroup{
@@ -1060,7 +1040,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				MTLSAuths: []*kong.MTLSAuth{
@@ -1125,9 +1104,7 @@ func Test_stateBuilder_consumers(t *testing.T) {
 							},
 						},
 					},
-					Info: &Info{
-						SelectorTags: []string{"tag1"},
-					},
+					Info: &Info{},
 				},
 				currentState: existingConsumerCredState(),
 				kongVersion:  &kong130Version,
@@ -1137,7 +1114,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 					{
 						ID:       kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						Username: kong.String("foo"),
-						Tags:     kong.StringSlice("tag1"),
 					},
 				},
 				KeyAuths: []*kong.KeyAuth{
@@ -1484,9 +1460,7 @@ func Test_stateBuilder_upstream(t *testing.T) {
 			name: "process a non-existent upstream",
 			fields: fields{
 				targetContent: &Content{
-					Info: &Info{
-						SelectorTags: []string{"tag1"},
-					},
+					Info: &Info{},
 					Upstreams: []FUpstream{
 						{
 							Upstream: kong.Upstream{
@@ -1543,7 +1517,6 @@ func Test_stateBuilder_upstream(t *testing.T) {
 						HashOn:           kong.String("none"),
 						HashFallback:     kong.String("none"),
 						HashOnCookiePath: kong.String("/"),
-						Tags:             kong.StringSlice("tag1"),
 					},
 				},
 			},
@@ -1856,9 +1829,7 @@ func Test_stateBuilder(t *testing.T) {
 			name: "end to end test with all entities",
 			fields: fields{
 				targetContent: &Content{
-					Info: &Info{
-						SelectorTags: []string{"tag1"},
-					},
+					Info: &Info{},
 					Services: []FService{
 						{
 							Service: kong.Service{
@@ -1938,7 +1909,6 @@ func Test_stateBuilder(t *testing.T) {
 						ConnectTimeout: kong.Int(60000),
 						WriteTimeout:   kong.Int(60000),
 						ReadTimeout:    kong.Int(60000),
-						Tags:           kong.StringSlice("tag1"),
 					},
 					{
 						ID:             kong.String("dfd79b4d-7642-4b61-ba0c-9f9f0d3ba55b"),
@@ -1948,7 +1918,6 @@ func Test_stateBuilder(t *testing.T) {
 						ConnectTimeout: kong.Int(60000),
 						WriteTimeout:   kong.Int(60000),
 						ReadTimeout:    kong.Int(60000),
-						Tags:           kong.StringSlice("tag1"),
 					},
 					{
 						ID:             kong.String("9e6f82e5-4e74-4e81-a79e-4bbd6fe34cdc"),
@@ -1958,7 +1927,6 @@ func Test_stateBuilder(t *testing.T) {
 						ConnectTimeout: kong.Int(60000),
 						WriteTimeout:   kong.Int(60000),
 						ReadTimeout:    kong.Int(60000),
-						Tags:           kong.StringSlice("tag1"),
 					},
 				},
 				Routes: []*kong.Route{
@@ -1972,7 +1940,6 @@ func Test_stateBuilder(t *testing.T) {
 						Service: &kong.Service{
 							ID: kong.String("538c7f96-b164-4f1b-97bb-9f4bb472e89f"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 					{
 						ID:            kong.String("d125e79a-297c-414b-bc00-ad3a87be6c2b"),
@@ -1984,7 +1951,6 @@ func Test_stateBuilder(t *testing.T) {
 						Service: &kong.Service{
 							ID: kong.String("538c7f96-b164-4f1b-97bb-9f4bb472e89f"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 					{
 						ID:            kong.String("0cc0d614-4c88-4535-841a-cbe0709b0758"),
@@ -1996,7 +1962,6 @@ func Test_stateBuilder(t *testing.T) {
 						Service: &kong.Service{
 							ID: kong.String("dfd79b4d-7642-4b61-ba0c-9f9f0d3ba55b"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 					{
 						ID:            kong.String("083f61d3-75bc-42b4-9df4-f91929e18fda"),
@@ -2008,7 +1973,6 @@ func Test_stateBuilder(t *testing.T) {
 						Service: &kong.Service{
 							ID: kong.String("dfd79b4d-7642-4b61-ba0c-9f9f0d3ba55b"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 					{
 						ID:            kong.String("ba843ee8-d63e-4c4f-be1c-ebea546d8fac"),
@@ -2020,7 +1984,6 @@ func Test_stateBuilder(t *testing.T) {
 						Service: &kong.Service{
 							ID: kong.String("9e6f82e5-4e74-4e81-a79e-4bbd6fe34cdc"),
 						},
-						Tags:              kong.StringSlice("tag1"),
 						RequestBuffering:  kong.Bool(false),
 						ResponseBuffering: kong.Bool(false),
 					},
@@ -2034,7 +1997,6 @@ func Test_stateBuilder(t *testing.T) {
 						Service: &kong.Service{
 							ID: kong.String("9e6f82e5-4e74-4e81-a79e-4bbd6fe34cdc"),
 						},
-						Tags:              kong.StringSlice("tag1"),
 						RequestBuffering:  kong.Bool(true),
 						ResponseBuffering: kong.Bool(true),
 					},
@@ -2083,7 +2045,6 @@ func Test_stateBuilder(t *testing.T) {
 						HashOn:           kong.String("none"),
 						HashFallback:     kong.String("none"),
 						HashOnCookiePath: kong.String("/"),
-						Tags:             kong.StringSlice("tag1"),
 					},
 				},
 			},
@@ -2093,7 +2054,6 @@ func Test_stateBuilder(t *testing.T) {
 			fields: fields{
 				targetContent: &Content{
 					Info: &Info{
-						SelectorTags: []string{"tag1"},
 						Defaults: KongDefaults{
 							Route: &kong.Route{
 								PathHandling:     kong.String("v0"),
@@ -2233,7 +2193,6 @@ func Test_stateBuilder(t *testing.T) {
 						ConnectTimeout: kong.Int(5000),
 						WriteTimeout:   kong.Int(5000),
 						ReadTimeout:    kong.Int(5000),
-						Tags:           kong.StringSlice("tag1"),
 					},
 					{
 						ID:             kong.String("dfd79b4d-7642-4b61-ba0c-9f9f0d3ba55b"),
@@ -2243,7 +2202,6 @@ func Test_stateBuilder(t *testing.T) {
 						ConnectTimeout: kong.Int(5000),
 						WriteTimeout:   kong.Int(5000),
 						ReadTimeout:    kong.Int(5000),
-						Tags:           kong.StringSlice("tag1"),
 					},
 					{
 						ID:             kong.String("9e6f82e5-4e74-4e81-a79e-4bbd6fe34cdc"),
@@ -2253,7 +2211,6 @@ func Test_stateBuilder(t *testing.T) {
 						ConnectTimeout: kong.Int(5000),
 						WriteTimeout:   kong.Int(5000),
 						ReadTimeout:    kong.Int(5000),
-						Tags:           kong.StringSlice("tag1"),
 					},
 				},
 				Routes: []*kong.Route{
@@ -2269,7 +2226,6 @@ func Test_stateBuilder(t *testing.T) {
 						Service: &kong.Service{
 							ID: kong.String("538c7f96-b164-4f1b-97bb-9f4bb472e89f"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 					{
 						ID:               kong.String("d125e79a-297c-414b-bc00-ad3a87be6c2b"),
@@ -2283,7 +2239,6 @@ func Test_stateBuilder(t *testing.T) {
 						Service: &kong.Service{
 							ID: kong.String("538c7f96-b164-4f1b-97bb-9f4bb472e89f"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 					{
 						ID:               kong.String("0cc0d614-4c88-4535-841a-cbe0709b0758"),
@@ -2297,7 +2252,6 @@ func Test_stateBuilder(t *testing.T) {
 						Service: &kong.Service{
 							ID: kong.String("dfd79b4d-7642-4b61-ba0c-9f9f0d3ba55b"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 					{
 						ID:               kong.String("083f61d3-75bc-42b4-9df4-f91929e18fda"),
@@ -2311,7 +2265,6 @@ func Test_stateBuilder(t *testing.T) {
 						Service: &kong.Service{
 							ID: kong.String("dfd79b4d-7642-4b61-ba0c-9f9f0d3ba55b"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 					{
 						ID:            kong.String("ba843ee8-d63e-4c4f-be1c-ebea546d8fac"),
@@ -2324,7 +2277,6 @@ func Test_stateBuilder(t *testing.T) {
 						Service: &kong.Service{
 							ID: kong.String("9e6f82e5-4e74-4e81-a79e-4bbd6fe34cdc"),
 						},
-						Tags:              kong.StringSlice("tag1"),
 						RequestBuffering:  kong.Bool(false),
 						ResponseBuffering: kong.Bool(false),
 					},
@@ -2339,7 +2291,6 @@ func Test_stateBuilder(t *testing.T) {
 						Service: &kong.Service{
 							ID: kong.String("9e6f82e5-4e74-4e81-a79e-4bbd6fe34cdc"),
 						},
-						Tags:              kong.StringSlice("tag1"),
 						RequestBuffering:  kong.Bool(true),
 						ResponseBuffering: kong.Bool(true),
 					},
@@ -2388,7 +2339,6 @@ func Test_stateBuilder(t *testing.T) {
 						HashOn:           kong.String("none"),
 						HashFallback:     kong.String("none"),
 						HashOnCookiePath: kong.String("/"),
-						Tags:             kong.StringSlice("tag1"),
 					},
 				},
 			},

--- a/file/reader.go
+++ b/file/reader.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/blang/semver/v4"
+	"github.com/kong/deck/dump"
 	"github.com/kong/deck/state"
 	"github.com/kong/deck/utils"
 )
@@ -47,12 +48,15 @@ func GetForKonnect(fileContent *Content, opt RenderConfig) (*utils.KongRawState,
 
 // Get process the fileContent and renders a RawState.
 // IDs of entities are matches based on currentState.
-func Get(fileContent *Content, opt RenderConfig) (*utils.KongRawState, error) {
+func Get(fileContent *Content, opt RenderConfig, dumpConfig dump.Config) (*utils.KongRawState, error) {
 	var builder stateBuilder
 	// setup
 	builder.targetContent = fileContent
 	builder.currentState = opt.CurrentState
 	builder.kongVersion = opt.KongVersion
+	if len(dumpConfig.SelectorTags) > 0 {
+		builder.selectTags = dumpConfig.SelectorTags
+	}
 
 	state, _, err := builder.build()
 	if err != nil {


### PR DESCRIPTION
When syncing entities, use the tags from either --select-tag or state file metadata. Previously, sync only used file metadata for assigning tags to new resources, and --select-tag would only filter entities from the current state for comparison.

If the tags requested by --select-tag and file metadata differ, fail the sync.

Fix #362

This maybe needs some historical information about the development of `--select-tag` to say whether it's actually by design--this does address the issue raised by #362, but is a fairly significant change, so I wanted some confirmation that it does indeed appear to be an unintended omission rather than intentional for some reason.

Without this change, `--select-tag` only filters entities from the current state. Proposed entities will be compare to these, but they won't themselves get the indicated tag. This suggests that the original expected use of `--select-tag` was with files created by a `--select-tag` dump (which includes tag information in file metadata, which _was_ applied prior to this change), since using it without metadata tags resulted in several odd situations:
- As noted in the original issue, tags are not applied to created resources.
- Repeated syncs result in conflicts, since subsequent current states will not include those created resources; they will be filtered out.
- Attempting to sync against resources that already had the indicated tag will actually strip the tag: 
[stripped_tag.txt](https://github.com/Kong/deck/files/7464150/stripped_tag.txt) (bdeck has this patch, odeck does not).

None of these seem useful, so I'm guessing this was indeed intentional.

Though this changes deck's behavior, I'm unsure of any workflows that would reasonably rely on the original behavior: any I can think of would run into one of the traps above, which will prevent you from syncing after 1-2 runs.

Unit tests of `file.Get()` would require a Kong instance or robust mocking, so we're probably stuck on that without integration tests.
