### PR TITLE
doc: add asdf deck plugin install infos

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ You can get the image with the command:
 docker pull kong/deck
 ```
 
+### asdf plugin
+
+If you are using [asdf](https://github.com/asdf-vm/asdf), you can add the deck plugin using the following command:
+
+```
+asdf plugin add deck
+```
+
 ## Documentation
 
 You can use `--help` flag once you've decK installed on your system


### PR DESCRIPTION
Hello,

I added infos in the README to install the asdf plugin for deck.
The plugin is available on asdf plugins, It was accepted and merged this PR: https://github.com/asdf-vm/asdf-plugins/pull/509

