### PR TITLE
fix: return error when sync context ends

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -477,6 +477,7 @@ func (sc *Syncer) Run(ctx context.Context, parallelism int, d Do) []error {
 	var errs []error
 	select {
 	case <-ctx.Done():
+		errs = append(errs, fmt.Errorf("sync context ended, some entities were not synced: %w", ctx.Err()))
 	case err, ok := <-sc.errChan:
 		if ok && err != nil {
 			if err != errEnqueueFailed {

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -477,7 +477,7 @@ func (sc *Syncer) Run(ctx context.Context, parallelism int, d Do) []error {
 	var errs []error
 	select {
 	case <-ctx.Done():
-		errs = append(errs, fmt.Errorf("sync context ended, some entities were not synced: %w", ctx.Err()))
+		errs = append(errs, fmt.Errorf("failed to sync all entities: %w", ctx.Err()))
 	case err, ok := <-sc.errChan:
 		if ok && err != nil {
 			if err != errEnqueueFailed {


### PR DESCRIPTION
If a sync context ends, return its Context.Err() in the list of sync errors. This informs downstream clients that the sync did not process all entities, even if there were no events in flight (which generate their own errors, as seen below) at the time the context ended. On the user end, this will look like:

```
11:52:27-0800 esenin $ /tmp/bdeck sync -s /tmp/foo.yaml
creating consumer foo
...
creating upstream foo.8080.svc
^Creceived interrupt , terminating...
Summary:
  Created: 17
  Updated: 0
  Deleted: 0
Error: 5 errors occurred:
	sync context ended, some entities were not synced: context canceled
	while processing event: {Create} upstream bar.8001.svc failed: making HTTP request: Put "http://localhost:8001/upstreams/3acc5ce0-6a3b-40d2-a63c-6ab73d1db221": context canceled
        ...
```

Fixes #528 