### PR TITLE
feat (BasicAuthSession support for Kong Admin APIs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ _obj
 _test
 vendor
 
+# Editor/IDEs
+.idea
+
 # Architecture specific extensions/prefixes
 *.[568vq]
 [568vq].out

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -98,7 +98,6 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 	}
 	_ = sendAnalytics(cmd, kongVersion)
 
-
 	workspaceExists, err := workspaceExists(ctx, rootConfig, workspaceName)
 	if err != nil {
 		return err

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -98,6 +98,7 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 	}
 	_ = sendAnalytics(cmd, kongVersion)
 
+
 	workspaceExists, err := workspaceExists(ctx, rootConfig, workspaceName)
 	if err != nil {
 		return err
@@ -230,23 +231,6 @@ func fetchKongVersion(ctx context.Context, config utils.KongClientConfig) (strin
 	client, err := utils.GetKongClient(config)
 	if err != nil {
 		return "", err
-	}
-	//Do the login here if we have a session based client
-	if config.ISSessionClient {
-		req, err := http.NewRequest("GET", utils.CleanAddress(config.Address) + "/auth", nil)
-		req.Header.Add("Authorization","Basic " + utils.BasicAuthFormat(config.Email,config.Password))
-		if err != nil {
-			return "", fmt.Errorf("failed to create session login:%v", err)
-		}
-		res, err := client.DoRAW(ctx, req)
-		if err != nil {
-			return "", err
-		}
-		if res.StatusCode != 200 {
-			return "", fmt.Errorf("failed to authenticate with basicauth at:%s, statuscode:%d",
-				utils.CleanAddress(config.Address) + "/auth", res.StatusCode)
-		}
-		//The client has the session cookies now
 	}
 	root, err := client.Root(ctx)
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -134,7 +134,6 @@ func init() {
 	viper.BindPFlag("kong-password",
 		rootCmd.PersistentFlags().Lookup("kong-password"))
 
-
 	// konnect-specific flags
 	rootCmd.PersistentFlags().String("konnect-email", "",
 		"Email address associated with your Konnect account.")
@@ -222,7 +221,7 @@ func initConfig() {
 	rootConfig.Password = viper.GetString("kong-password")
 	if rootConfig.Email != "" && rootConfig.Password != "" {
 		rootConfig.ISSessionClient = true
-	} else{
+	} else {
 		rootConfig.ISSessionClient = false
 	}
 	color.NoColor = (color.NoColor || viper.GetBool("no-color"))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -123,7 +123,7 @@ func init() {
 	viper.BindPFlag("skip-workspace-crud",
 		rootCmd.PersistentFlags().Lookup("skip-workspace-crud"))
 
-	//Add support for basic auth with sessions for Kong
+	// Add support for basic auth with sessions for Kong
 	rootCmd.PersistentFlags().String("kong-email", "",
 		"Email address associated with your Kong Manager account.")
 	viper.BindPFlag("kong-email",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -123,6 +123,18 @@ func init() {
 	viper.BindPFlag("skip-workspace-crud",
 		rootCmd.PersistentFlags().Lookup("skip-workspace-crud"))
 
+	//Add support for basic auth with sessions for Kong
+	rootCmd.PersistentFlags().String("kong-email", "",
+		"Email address associated with your Kong Manager account.")
+	viper.BindPFlag("kong-email",
+		rootCmd.PersistentFlags().Lookup("kong-email"))
+
+	rootCmd.PersistentFlags().String("kong-password", "",
+		"Password associated with your Kong Manager email.")
+	viper.BindPFlag("kong-password",
+		rootCmd.PersistentFlags().Lookup("kong-password"))
+
+
 	// konnect-specific flags
 	rootCmd.PersistentFlags().String("konnect-email", "",
 		"Email address associated with your Konnect account.")
@@ -206,7 +218,13 @@ func initConfig() {
 	rootConfig.SkipWorkspaceCrud = viper.GetBool("skip-workspace-crud")
 	rootConfig.Debug = (viper.GetInt("verbose") >= 1)
 	rootConfig.Timeout = (viper.GetInt("timeout"))
-
+	rootConfig.Email = viper.GetString("kong-email")
+	rootConfig.Password = viper.GetString("kong-password")
+	if rootConfig.Email != "" && rootConfig.Password != "" {
+		rootConfig.ISSessionClient = true
+	} else{
+		rootConfig.ISSessionClient = false
+	}
 	color.NoColor = (color.NoColor || viper.GetBool("no-color"))
 
 	if err := initKonnectConfig(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/yudai/gojsondiff v1.0.0
 	github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 // indirect
 	github.com/yudai/pp v2.0.1+incompatible // indirect
+	golang.org/x/net v0.0.0-20210520170846-37e1c6afe023 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	k8s.io/code-generator v0.22.4
 )

--- a/utils/types.go
+++ b/utils/types.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"golang.org/x/net/publicsuffix"
 	"net"
 	"net/http"
 	"net/http/cookiejar"
@@ -20,6 +19,7 @@ import (
 	"github.com/kong/deck/konnect"
 	"github.com/kong/go-kong/kong"
 	"github.com/kong/go-kong/kong/custom"
+	"golang.org/x/net/publicsuffix"
 )
 
 var clientTimeout time.Duration
@@ -150,7 +150,7 @@ func GetKongClient(opt KongClientConfig) (*kong.Client, error) {
 	defaultTransport.TLSClientConfig = &tlsConfig
 	c.Transport = defaultTransport
 	address := CleanAddress(opt.Address)
-	//Add Session Cookie support if required
+	// Add Session Cookie support if required
 	if opt.ISSessionClient {
 		jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
 		if err != nil {
@@ -180,13 +180,13 @@ func GetKongClient(opt KongClientConfig) (*kong.Client, error) {
 		kongClient.SetDebugMode(true)
 		kongClient.SetLogger(os.Stderr)
 	}
-	//We should try the hydration here
+	// We should try the hydration here
 	if opt.ISSessionClient {
-		err := loginBasicAuth(opt, kongClient) //we are passing reference so mutation
+		err := loginBasicAuth(opt, kongClient) // we are passing reference so mutation
 		if err != nil {
 			return nil, err
 		}
-		//The client has the session cookies now
+		// The client has the session cookies now
 	}
 	return kongClient, nil
 }
@@ -199,7 +199,7 @@ func loginBasicAuth(opt KongClientConfig, kongClient *kong.Client) error {
 	}
 	ctx := context.Background()
 	res, err := kongClient.DoRAW(ctx, req)
-	defer res.Body.Close() //gracefully
+	defer res.Body.Close() // gracefully
 	if err != nil {
 		return err
 	}

--- a/utils/types.go
+++ b/utils/types.go
@@ -198,6 +198,7 @@ func loginBasicAuth(opt KongClientConfig, kongClient *kong.Client) (error) {
 		return fmt.Errorf("failed to create client with session login:%v", err)
 	}
 	res, err := kongClient.DoRAW(nil, req)
+	defer res.Body.Close() //gracefully
 	if err != nil {
 		return  err
 	}

--- a/utils/types.go
+++ b/utils/types.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -196,12 +197,13 @@ func loginBasicAuth(opt KongClientConfig, kongClient *kong.Client) error {
 	if err != nil {
 		return fmt.Errorf("failed to create client with session login:%v", err)
 	}
-	res, err := kongClient.DoRAW(nil, req)
+	ctx := context.Background()
+	res, err := kongClient.DoRAW(ctx, req)
 	defer res.Body.Close() //gracefully
 	if err != nil {
 		return err
 	}
-	if res.StatusCode != 200 {
+	if res.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed to authenticate with basicauth at:%s, statuscode:%d",
 			CleanAddress(opt.Address)+"/auth", res.StatusCode)
 	}

--- a/utils/types.go
+++ b/utils/types.go
@@ -199,7 +199,9 @@ func loginBasicAuth(opt KongClientConfig, kongClient *kong.Client) error {
 	}
 	ctx := context.Background()
 	res, err := kongClient.DoRAW(ctx, req)
-	defer res.Body.Close() // gracefully
+	if res != nil {
+		defer res.Body.Close() // gracefully
+	}
 	if err != nil {
 		return err
 	}

--- a/utils/types.go
+++ b/utils/types.go
@@ -94,13 +94,13 @@ type KongClientConfig struct {
 	Headers []string
 
 	HTTPClient *http.Client
-	Timeout int
+	Timeout    int
 
 	// Whether to initialize the Http client with a cookie jar or not
 	ISSessionClient bool
 
 	// Email is the username to login to admin server auth endpoint
-	Email    string
+	Email string
 
 	// Password is the associated password with the email.
 	Password string
@@ -120,7 +120,6 @@ func (kc *KongClientConfig) ForWorkspace(name string) KongClientConfig {
 	result.Workspace = name
 	return result
 }
-
 
 // GetKongClient returns a Kong client
 func GetKongClient(opt KongClientConfig) (*kong.Client, error) {
@@ -154,7 +153,7 @@ func GetKongClient(opt KongClientConfig) (*kong.Client, error) {
 	if opt.ISSessionClient {
 		jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
 		if err != nil {
-			return nil, fmt.Errorf("failed to initialize session jar:%w" , err)
+			return nil, fmt.Errorf("failed to initialize session jar:%w", err)
 		}
 		c.Jar = jar
 	}
@@ -182,7 +181,7 @@ func GetKongClient(opt KongClientConfig) (*kong.Client, error) {
 	}
 	//We should try the hydration here
 	if opt.ISSessionClient {
-		err := loginBasicAuth(opt, kongClient)//we are passing reference so mutation
+		err := loginBasicAuth(opt, kongClient) //we are passing reference so mutation
 		if err != nil {
 			return nil, err
 		}
@@ -191,7 +190,7 @@ func GetKongClient(opt KongClientConfig) (*kong.Client, error) {
 	return kongClient, nil
 }
 
-func loginBasicAuth(opt KongClientConfig, kongClient *kong.Client) (error) {
+func loginBasicAuth(opt KongClientConfig, kongClient *kong.Client) error {
 	req, err := http.NewRequest("GET", CleanAddress(opt.Address)+"/auth", nil)
 	req.Header.Add("Authorization", "Basic "+BasicAuthFormat(opt.Email, opt.Password))
 	if err != nil {
@@ -200,7 +199,7 @@ func loginBasicAuth(opt KongClientConfig, kongClient *kong.Client) (error) {
 	res, err := kongClient.DoRAW(nil, req)
 	defer res.Body.Close() //gracefully
 	if err != nil {
-		return  err
+		return err
 	}
 	if res.StatusCode != 200 {
 		return fmt.Errorf("failed to authenticate with basicauth at:%s, statuscode:%d",

--- a/utils/types_test.go
+++ b/utils/types_test.go
@@ -136,3 +136,9 @@ func Test_parseHeaders(t *testing.T) {
 		})
 	}
 }
+
+func Test_loginBasicAuth(t *testing.T){
+	//TODO: Don't see an interface for kong.Client, so can't substitute a mock
+	// to check if the right headers were being passed and we are able to handle
+	// non 200 codes
+}

--- a/utils/types_test.go
+++ b/utils/types_test.go
@@ -137,7 +137,7 @@ func Test_parseHeaders(t *testing.T) {
 	}
 }
 
-func Test_loginBasicAuth(t *testing.T){
+func Test_loginBasicAuth(t *testing.T) {
 	//TODO: Don't see an interface for kong.Client, so can't substitute a mock
 	// to check if the right headers were being passed and we are able to handle
 	// non 200 codes

--- a/utils/types_test.go
+++ b/utils/types_test.go
@@ -138,7 +138,7 @@ func Test_parseHeaders(t *testing.T) {
 }
 
 func Test_loginBasicAuth(t *testing.T) {
-	//TODO: Don't see an interface for kong.Client, so can't substitute a mock
+	// TODO: Don't see an interface for kong.Client, so can't substitute a mock
 	// to check if the right headers were being passed and we are able to handle
 	// non 200 codes
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -54,6 +54,8 @@ func FilenameToName(filename string) string {
 	return strings.ReplaceAll(filename, url.PathEscape(string(os.PathSeparator)), string(os.PathSeparator))
 }
 
+// BasicAuthFormat Given a user (name/email etc.) and password, returns a base64
+//representation that can be sent as an Authorization header for login
 func BasicAuthFormat(username, password string) string {
 	auth := username + ":" + password
 	return base64.StdEncoding.EncodeToString([]byte(auth))

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -55,7 +55,7 @@ func FilenameToName(filename string) string {
 }
 
 // BasicAuthFormat Given a user (name/email etc.) and password, returns a base64
-//representation that can be sent as an Authorization header for login
+// representation that can be sent as an Authorization header for login
 func BasicAuthFormat(username, password string) string {
 	auth := username + ":" + password
 	return base64.StdEncoding.EncodeToString([]byte(auth))

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"encoding/base64"
 	"fmt"
 	"net/url"
 	"os"
@@ -51,4 +52,9 @@ func NameToFilename(name string) string {
 // if that separator was included originally, and only some names (document paths) typically include one.
 func FilenameToName(filename string) string {
 	return strings.ReplaceAll(filename, url.PathEscape(string(os.PathSeparator)), string(os.PathSeparator))
+}
+
+func BasicAuthFormat(username, password string) string {
+	auth := username + ":" + password
+	return base64.StdEncoding.EncodeToString([]byte(auth))
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -201,7 +201,7 @@ func Test_FilenameToName(t *testing.T) {
 	}
 }
 
-func Test_BasicAuthFormat (t *testing.T){
+func Test_BasicAuthFormat(t *testing.T) {
 	type args struct {
 		username string
 		password string

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"encoding/base64"
+	"github.com/stretchr/testify/require"
 	"net/url"
 	"os"
 	"testing"
@@ -195,6 +197,38 @@ func Test_FilenameToName(t *testing.T) {
 			if got := FilenameToName(tt.args.filename); got != tt.want {
 				t.Errorf("FilenameToName() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func Test_BasicAuthFormat (t *testing.T){
+	type args struct {
+		username string
+		password string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "symmetric test",
+			args: args{
+				username: "mickey@mouse.com",
+				password: "showMeTheCheese$",
+			},
+			want: "mickey@mouse.com:showMeTheCheese$",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			//Encode
+			encoded := BasicAuthFormat(tt.args.username, tt.args.password)
+			//Decode
+			decoded := make([]byte, len(tt.want))
+			_, err := base64.StdEncoding.Decode(decoded, []byte(encoded))
+			require.NoError(t, err)
+			require.Equal(t, string(decoded), tt.want)
 		})
 	}
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -2,12 +2,12 @@ package utils
 
 import (
 	"encoding/base64"
-	"github.com/stretchr/testify/require"
 	"net/url"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEmpty(t *testing.T) {
@@ -222,9 +222,9 @@ func Test_BasicAuthFormat(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			//Encode
+			// Encode
 			encoded := BasicAuthFormat(tt.args.username, tt.args.password)
-			//Decode
+			// Decode
 			decoded := make([]byte, len(tt.want))
 			_, err := base64.StdEncoding.Decode(decoded, []byte(encoded))
 			require.NoError(t, err)


### PR DESCRIPTION
Added support for using basic auth for accessing Admin APIs from Deck. This enables users who require OpenId Connect based IDP integration for their credentials. This is in addition to previously supported token based auth