### PR TITLE
Update release instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,32 +2,29 @@
 
 ## Prepare
 
-Ensure that your `go version` is not older than indicated in the header of `go.mod`.
-Create a `docs/changelog-v0.5.0` branch. Substitute v0.5.0 with the version
-you are releasing.
-Write the changelog, ensure the links are all created correctly and
-make sure to write the doc with end-user in mind.
-Commit and push the branch to Github. Ensure that the Markdown is rendered
-correctly. Make changes as needed. The link on the version itself won't
-resolve correctly as the tag is not yet created.
-Once the changelog looks good, open a PR against the main branchpush the commit to main branch. And merge the PR.
-Ensure you have Goreleaser and Docker installed locally.
+1. Create a `docs/changelog-v0.5.0` branch. Substitute v0.5.0 with the version you are releasing.
+2. Add an entry to CHANGELOG.md for your version, with entries for merged PRs since the previous release. Make sure to write the doc with end-user in mind.
+3. Add a ToC entry at the top of CHANGELOG.md (e.g. `- [v0.5.0](#v050)`) and a compare link at the bottom of CHANGELOG.md (e.g. `[v0.5.0]: https://github.com/hbagdi/deck/compare/v0.4.0...v0.5.0`).
+4. Commit and push the branch to Github. Ensure that the Markdown is rendered correctly. Make changes as needed. The link on the version itself won't resolve correctly as the tag is not yet created.
+5. Open a PR against the main branch and merge the PR.
 
 ## Release
 
-- Tag the `HEAD` with your version. In our example, we will tag it `v0.5.0`.
-- Push the tag to remote (Github).
+1. Pull `main` and tag `HEAD` with your version. In our example, we will tag it `v0.5.0`: `git tag v0.5.0`
+2. Push the tag to remote (Github): `git push origin --tags`
 
 As of 1.9.0, the remaining steps are automated on tag pushes to Github. They are unnecessary unless the release job fails.
 
-- Run Goreleaser: `goreleaser release --rm-dist`. This will create
-  a release in Github and upload all the artifacts.
-- Edit the release to remove all the commit messages as the content and
-  instead add a link to the changelog. Refer to older releases for reference.
-- Homebrew release  
-Clone the Kong/homebrew-deck repo
-`cp <deck repo>/dist/deck.rb Formula/`. Make sure only version and checksum is changed and rest all is left as is.
-Git commit, git push to master
+1. Ensure that your `go version` is not older than indicated in the header of `go.mod` and that you have goreleaser installed.
+2. Run Goreleaser: `goreleaser release --rm-dist`. This will create a release in Github and upload all the artifacts.
+3. Edit the release to remove all the commit messages as the content and instead add a link to the changelog. Refer to older releases for reference.
+
+## Homebrew release
+
+1. Clone the [Kong/homebrew-deck](https://github.com/Kong/homebrew-deck) repo.
+2. Download and unpack dist.zip from the release job artifacts.
+3. `cp <unpack directory>/deck.rb <homebrew-deck directory>/Formula/`. Make sure only version and checksum is changed and rest all is left as is.
+4. Commit and push to master.
 
 ## Docker release
 
@@ -38,17 +35,10 @@ Assuming you are on the TAG commit, you need to perform the following:
 ```
 export TAG=$(git describe --abbrev=0 --tags)
 export COMMIT=$(git rev-parse --short $TAG)
-docker build --build-arg TAG=$TAG --build-arg COMMIT=$COMMIT -t hbagdi/deck:$TAG .
-docker push hbagdi/deck:$TAG
-
-docker tag hbagdi/deck:$TAG kong/deck:$TAG
+docker build --build-arg TAG=$TAG --build-arg COMMIT=$COMMIT -t kong/deck:$TAG .
 docker push kong/deck:$TAG
 
-
 # if also the latest release (not for a back-ported patch release):
-docker tag hbagdi/deck:$TAG hbagdi/deck:latest
-docker push hbagdi/deck:latest
-
-docker tag hbagdi/deck:latest kong/deck:latest
+docker tag kong/deck:$TAG kong/deck:latest
 docker push kong/deck:latest
 ```


### PR DESCRIPTION
Further revision of release instructions after running through one automated release. Removed references to the hbagdi/deck Docker repo.