### PR TITLE
fix: skip consumers when using --skip-consumers with the sync command

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -61,6 +61,9 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 	if err != nil {
 		return err
 	}
+	if dumpConfig.SkipConsumers {
+		targetContent.Consumers = []file.FConsumer{}
+	}
 
 	rootClient, err := utils.GetKongClient(rootConfig)
 	if err != nil {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -45,7 +45,7 @@ func init() {
 			"(Kong Enterprise only).\n"+
 			"This takes precedence over _workspace fields in state files.")
 	syncCmd.Flags().BoolVar(&dumpConfig.SkipConsumers, "skip-consumers",
-		false, "do not diff consumers or "+
+		false, "do not sync consumers or "+
 			"any plugins associated with consumers.")
 	syncCmd.Flags().IntVar(&syncCmdParallelism, "parallelism",
 		10, "Maximum number of concurrent operations.")


### PR DESCRIPTION
In order to have `--skip-consumers` work as expected with the `sync` command, 2 things need to happen:
- `consumers` to be ignored on fetched current state
- `consumers` to be ignored on generated target state

The first bullet is currently taken care of [here](https://github.com/Kong/deck/blob/main/dump/dump.go#L259-L260), which is called by the `syncMain` function [here](https://github.com/Kong/deck/blob/main/cmd/common.go#L189).
The second bullet is what we are currently missing.

**Before the change in this PR:**

```
$ cat kong.yaml
services:
- name: svc1
  host: mockbin.org
  retries: 5
  tags:
  - team-svc1
consumers:
- username: yolo

$ http :8001/consumers
{
    "data": [],
    "next": null
}

$ ./deck sync --skip-consumers
creating consumer yolo
Summary:
  Created: 1
  Updated: 0
  Deleted: 0

```

Not only `deck` is creating the consumer despite the flag, the fact that we are successfully ignoring the `current` state BUT NOT the `target` state makes a second run fail, because `deck` fails to detect the `yolo` consumer already exists and so it tries to create it:

```
$ ./deck sync --skip-consumers
creating consumer yolo
Summary:
  Created: 0
  Updated: 0
  Deleted: 0
Error: 1 errors occurred:
	while processing event: {Create} consumer yolo failed: HTTP status 409 (message: "UNIQUE violation detected on '{username=\"yolo\"}'")
```

**After the change in this PR:**

```
$ cat kong.yaml
services:
- name: svc1
  host: mockbin.org
  retries: 5
  tags:
  - team-svc1
consumers:
- username: yolo

$ http :8001/consumers
{
    "data": [],
    "next": null
}

$ ./deck sync --skip-consumers
Summary:
  Created: 0
  Updated: 0
  Deleted: 0
```

Same goes if some consumer already exist but that's not present in the target file:
```
$ cat kong.yaml
services:
- name: svc1
  host: mockbin.org
  tags:
  - team-svc1
  retries: 5

$ http :8001/consumers
{
    "data": [
        {
            "created_at": 1641491690,
            "custom_id": null,
            "id": "0f994481-a438-4401-a918-835d0a887050",
            "tags": [
                "managed-by-deck",
                "org-unit-42"
            ],
            "username": "yolo"
        }
    ],
    "next": null
}

$ ./deck sync --skip-consumers
Summary:
  Created: 0
  Updated: 0
  Deleted: 0
```

Fixes https://github.com/Kong/deck/issues/532