### PR TITLE
feat: don't manage Konnect internal-only plugins

### DIFF
--- a/dump/dump.go
+++ b/dump/dump.go
@@ -168,11 +168,11 @@ func getProxyConfiguration(ctx context.Context, group *errgroup.Group,
 		if err != nil {
 			return fmt.Errorf("plugins: %w", err)
 		}
+		plugins = excludeKonnectManagedPlugins(plugins)
 		if config.SkipConsumers {
-			state.Plugins = excludeConsumersPlugins(plugins)
-		} else {
-			state.Plugins = plugins
+			plugins = excludeConsumersPlugins(plugins)
 		}
+		state.Plugins = plugins
 		return nil
 	})
 

--- a/dump/dump_konnect.go
+++ b/dump/dump_konnect.go
@@ -170,20 +170,23 @@ func kongServiceIDs(cpID string,
 	return res
 }
 
-// excludeKonnectManagedPlugins filter out konnect-managed plugins
+// excludeKonnectManagedPlugins filters out konnect-managed plugins
 func excludeKonnectManagedPlugins(plugins []*kong.Plugin) []*kong.Plugin {
-	var filtered []*kong.Plugin
+	filtered := []*kong.Plugin{}
 	for _, p := range plugins {
-		var konnectManaged bool
-		for _, t := range p.Tags {
-			if *t == konnect.KonnectManagedPluginTag {
-				konnectManaged = true
-			}
-		}
-		if konnectManaged {
+		if isManagedByKonnect(p) {
 			continue
 		}
 		filtered = append(filtered, p)
 	}
 	return filtered
+}
+
+func isManagedByKonnect(plugin *kong.Plugin) bool {
+	for _, t := range plugin.Tags {
+		if *t == konnect.KonnectManagedPluginTag {
+			return true
+		}
+	}
+	return false
 }

--- a/dump/dump_konnect.go
+++ b/dump/dump_konnect.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kong/deck/konnect"
 	"github.com/kong/deck/utils"
+	"github.com/kong/go-kong/kong"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 )
@@ -167,4 +168,22 @@ func kongServiceIDs(cpID string,
 		}
 	}
 	return res
+}
+
+// excludeKonnectManagedPlugins filter out konnect-managed plugins
+func excludeKonnectManagedPlugins(plugins []*kong.Plugin) []*kong.Plugin {
+	var filtered []*kong.Plugin
+	for _, p := range plugins {
+		var konnectManaged bool
+		for _, t := range p.Tags {
+			if *t == konnect.KonnectManagedPluginTag {
+				konnectManaged = true
+			}
+		}
+		if konnectManaged {
+			continue
+		}
+		filtered = append(filtered, p)
+	}
+	return filtered
 }

--- a/dump/dump_konnect_test.go
+++ b/dump/dump_konnect_test.go
@@ -288,7 +288,7 @@ func Test_excludeKonnectManagedPlugins(t *testing.T) {
 		want    []*kong.Plugin
 	}{
 		{
-			name: "eclude konnect tags",
+			name: "exclude konnect tags",
 			plugins: []*kong.Plugin{
 				{
 					Name: kong.String("rate-limiting"),
@@ -329,6 +329,37 @@ func Test_excludeKonnectManagedPlugins(t *testing.T) {
 					Tags: []*string{},
 				},
 			},
+		},
+		{
+			name:    "empty input",
+			plugins: []*kong.Plugin{},
+			want:    []*kong.Plugin{},
+		},
+		{
+			name: "all konnect managed",
+			plugins: []*kong.Plugin{
+				{
+					Name: kong.String("key-auth"),
+					Tags: []*string{
+						kong.String("konnect-app-registration"),
+						kong.String("konnect-managed-plugin"),
+					},
+				},
+				{
+					Name: kong.String("acl"),
+					Tags: []*string{
+						kong.String("konnect-app-registration"),
+						kong.String("konnect-managed-plugin"),
+					},
+				},
+				{
+					Name: kong.String("prometheus"),
+					Tags: []*string{
+						kong.String("konnect-managed-plugin"),
+					},
+				},
+			},
+			want: []*kong.Plugin{},
 		},
 	}
 	for _, tt := range tests {

--- a/dump/dump_konnect_test.go
+++ b/dump/dump_konnect_test.go
@@ -280,3 +280,63 @@ func Test_filterNonKongPackages(t *testing.T) {
 		})
 	}
 }
+
+func Test_excludeKonnectManagedPlugins(t *testing.T) {
+	tests := []struct {
+		name    string
+		plugins []*kong.Plugin
+		want    []*kong.Plugin
+	}{
+		{
+			name: "eclude konnect tags",
+			plugins: []*kong.Plugin{
+				{
+					Name: kong.String("rate-limiting"),
+					Tags: []*string{kong.String("tag1")},
+				},
+				{
+					Name: kong.String("basic-auth"),
+					Tags: []*string{},
+				},
+				{
+					Name: kong.String("key-auth"),
+					Tags: []*string{
+						kong.String("konnect-app-registration"),
+						kong.String("konnect-managed-plugin"),
+					},
+				},
+				{
+					Name: kong.String("acl"),
+					Tags: []*string{
+						kong.String("konnect-app-registration"),
+						kong.String("konnect-managed-plugin"),
+					},
+				},
+				{
+					Name: kong.String("prometheus"),
+					Tags: []*string{
+						kong.String("konnect-managed-plugin"),
+					},
+				},
+			},
+			want: []*kong.Plugin{
+				{
+					Name: kong.String("rate-limiting"),
+					Tags: []*string{kong.String("tag1")},
+				},
+				{
+					Name: kong.String("basic-auth"),
+					Tags: []*string{},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := excludeKonnectManagedPlugins(tt.plugins)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("excludeKonnectManagedPlugins() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/konnect/utils.go
+++ b/konnect/utils.go
@@ -1,5 +1,10 @@
 package konnect
 
+const (
+	// KonnectManagedPluginTag is used by Konnect to tag internally-managed plugins
+	KonnectManagedPluginTag = "konnect-managed-plugin"
+)
+
 func emptyString(p *string) bool {
 	return p == nil || *p == ""
 }


### PR DESCRIPTION
Plugins created by Konnect for internal-use only
are tagged with 'konnect-managed-plugin'. decK should not allow users to
interact with any plugins with this tag.

This skips plugins with internal-only konnect tags.
