### PR TITLE
style: clarify how to disable 'analytics'

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -153,7 +153,8 @@ func init() {
 		rootCmd.PersistentFlags().Lookup("konnect-addr"))
 
 	rootCmd.PersistentFlags().Bool("analytics", true,
-		"Share anonymized data to help improve decK.")
+		"Share anonymized data to help improve decK.\n"+
+			"Use --analytics=false to disable this.")
 	viper.BindPFlag("analytics",
 		rootCmd.PersistentFlags().Lookup("analytics"))
 


### PR DESCRIPTION
Currently decK collects and shares anonymized data with Kong.
This feature is controlled via the '--analytics' flag,
which is True by default. The flag description doesn't
describe how users can prevent decK to share this data though.

This PR makes it clear to use --analytics=false for that.

Related to https://github.com/Kong/deck/issues/399