### PR TITLE
fix: konnect ping ignores analytics flag

### DIFF
--- a/cmd/konnect_ping.go
+++ b/cmd/konnect_ping.go
@@ -16,7 +16,7 @@ can connect to Konnect's API endpoint. It also validates the supplied
 credentials.` + konnectAlphaState,
 	Args: validateNoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		_ = utils.SendAnalytics("konnect-ping", VERSION, "")
+		_ = sendAnalytics("konnect-ping", "")
 		client, err := utils.GetKonnectClient(nil, konnectConfig)
 		if err != nil {
 			return err


### PR DESCRIPTION
Related to https://github.com/Kong/deck/issues/568