### PR TITLE
tests: start adding integration tests for sync command

### DIFF
--- a/.ci/setup_kong.sh
+++ b/.ci/setup_kong.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -e
+# download Kong deb
+
+sudo apt-get update
+sudo apt-get install openssl libpcre3 procps perl wget zlibc
+
+function setup_kong(){
+  SWITCH="1.3.000"
+  SWITCH2="2.0.000"
+
+  URL="https://download.konghq.com/gateway-1.x-ubuntu-xenial/pool/all/k/kong/kong_${KONG_VERSION}_all.deb"
+
+  if [[ "$KONG_VERSION" > "$SWITCH" ]];
+  then
+  URL="https://download.konghq.com/gateway-1.x-ubuntu-xenial/pool/all/k/kong/kong_${KONG_VERSION}_amd64.deb"
+  fi
+
+  if [[ "$KONG_VERSION" > "$SWITCH2" ]];
+  then
+  URL="https://download.konghq.com/gateway-2.x-ubuntu-xenial/pool/all/k/kong/kong_${KONG_VERSION}_amd64.deb"
+  fi
+
+  /usr/bin/curl -sL $URL -o kong.deb
+}
+
+function setup_kong_enterprise(){
+  KONG_VERSION="${KONG_VERSION#enterprise-}"
+  SWITCH="1.5.0.100"
+  SWITCH2="2.0.0.000"
+
+  URL="https://download.konghq.com/private/gateway-1.x-ubuntu-xenial/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_${KONG_VERSION}_all.deb"
+
+  if [[ "$KONG_VERSION" > "$SWITCH" ]];
+  then
+  URL="https://download.konghq.com/gateway-1.x-ubuntu-xenial/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_${KONG_VERSION}_all.deb"
+  fi
+
+  if [[ "$KONG_VERSION" > "$SWITCH2" ]];
+  then
+  URL="https://download.konghq.com/gateway-2.x-ubuntu-xenial/pool/all/k/kong-enterprise-edition/kong-enterprise-edition_${KONG_VERSION}_all.deb"
+  fi
+
+  RESPONSE_CODE=$(/usr/bin/curl -sL \
+    -w "%{http_code}" \
+    -u $KONG_ENTERPRISE_REPO_USERNAME:$KONG_ENTERPRISE_REPO_PASSSWORD \
+    $URL -o kong.deb)
+  if [[ $RESPONSE_CODE != "200" ]]; then
+    echo "error retrieving kong enterprise package from ${URL}. response code ${RESPONSE_CODE}"
+    exit 1
+  fi
+}
+
+if [[ $KONG_VERSION == *"enterprise"* ]]; then
+  setup_kong_enterprise
+else
+  setup_kong
+fi
+
+sudo dpkg -i kong.deb
+echo $KONG_LICENSE_DATA | sudo tee /etc/kong/license.json
+export KONG_LICENSE_PATH=/tmp/license.json
+export KONG_PASSWORD=kong
+export KONG_ENFORCE_RBAC=on
+export KONG_PORTAL=on
+
+sudo kong migrations bootstrap
+sudo kong version
+sudo kong start

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,31 @@ on: [push, pull_request]
 
 jobs:
   test:
+    strategy:
+      matrix:
+        kong_version:
+        - '2.0.5'
+        - '2.1.4'
+        - '2.2.2'
+        - '2.3.3'
+        - '2.4.0'
+        - '2.5.1'
+        - '2.6.0'
+        - '2.7.0'
+    env:
+      KONG_VERSION: ${{ matrix.kong_version }}
+      # KONG_ENTERPRISE_REPO_USERNAME: ${{ secrets.KONG_ENTERPRISE_REPO_USERNAME }}
+      # KONG_ENTERPRISE_REPO_PASSSWORD: ${{ secrets.KONG_ENTERPRISE_REPO_PASSSWORD }}
+      # KONG_LICENSE_DATA: ${{ secrets.KONG_LICENSE_DATA }}
+      KONG_ANONYMOUS_REPORTS: "off"
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:11.6-alpine
+        ports:
+          - 5432:5432
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - name: Setup go
         uses: actions/setup-go@v2
@@ -18,6 +42,15 @@ jobs:
           version: v1.40.1
       - name: Verify Codegen
         run: make verify-codegen
+      - name: Setup Postgres
+        run: |
+          psql -c 'create database kong;' -U postgres -h 127.0.0.1 -p 5432
+          psql -c 'create user kong;' -U postgres -h 127.0.0.1 -p 5432
+          psql -c 'GRANT ALL PRIVILEGES ON DATABASE "kong" to kong;' -U postgres -h 127.0.0.1 -p 5432
+      - name: Setup Kong
+        run: make setup-kong
+      - name: Build
+        run: make build
       - name: Run tests with Coverage
         run: make coverage
       - name: Upload Code Coverage
@@ -25,5 +58,3 @@ jobs:
         with:
           name: codecov-deck
           fail_ci_if_error: true
-      - name: Build
-        run: make build

--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,7 @@ coverage:
 generate-cli-docs:
 	mkdir -p $(CLI_DOCS_PATH)
 	go run docs/generate-docs.go -output-path $(CLI_DOCS_PATH)
+
+.PHONY: setup-kong
+setup-kong:
+	bash .ci/setup_kong.sh

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/kong/deck/state"
+	"github.com/kong/deck/utils"
+	"github.com/kong/go-kong/kong"
+)
+
+func getKongAddress() string {
+	if os.Getenv("KONG_ADDRESS") != "" {
+		return os.Getenv("KONG_ADDRESS")
+	}
+	return "http://localhost:8001"
+}
+
+// cleanUpEnv removes all existing entities from Kong.
+func cleanUpEnv(client *kong.Client) error {
+	ctx := context.Background()
+	currentState, err := fetchCurrentState(ctx, client, dumpConfig)
+	if err != nil {
+		return err
+	}
+	targetState, err := state.NewKongState()
+	if err != nil {
+		return err
+	}
+	_, err = performDiff(ctx, currentState, targetState, false, 10, 0, client)
+	return err
+}
+
+func normalizeOutput(content string) string {
+	lines := strings.Split(strings.TrimSuffix(content, "\n"), "\n")
+	sort.Strings(lines)
+	for i := range lines {
+		lines[i] = strings.TrimSpace(lines[i])
+	}
+	return strings.Join(lines, "\n")
+}
+
+func loadExpectedOutput(path string) (string, error) {
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
+}
+
+func testDeckOutput(t *testing.T, outputPath string, got string) {
+	expected, err := loadExpectedOutput(outputPath)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	expectedNormalized := normalizeOutput(expected)
+	obtainedNormalized := normalizeOutput(got)
+	if !reflect.DeepEqual(obtainedNormalized, expectedNormalized) {
+		t.Errorf(cmp.Diff(obtainedNormalized, expectedNormalized))
+	}
+}
+
+func setupTest() (*kong.Client, string, error) {
+	var client *kong.Client
+	var kongVersion string
+
+	config := utils.KongClientConfig{
+		Address: getKongAddress(),
+	}
+	client, err := utils.GetKongClient(config)
+	if err != nil {
+		return client, kongVersion, err
+	}
+
+	if err := cleanUpEnv(client); err != nil {
+		return client, kongVersion, err
+	}
+
+	kongVersion, err = fetchKongVersion(context.Background(), config)
+	if err != nil {
+		return client, kongVersion, err
+	}
+	return client, kongVersion, nil
+}
+
+func Test_Sync_output(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "create_service",
+		},
+		{
+			name: "modify_service",
+		},
+		{
+			name: "create_service_no_change",
+		},
+		{
+			name: "create_route",
+		},
+		{
+			name: "modify_route",
+		},
+		{
+			name: "create_route_no_change",
+		},
+		{
+			name: "create_plugin",
+		},
+		{
+			name: "modify_plugin",
+		},
+		{
+			name: "create_plugin_no_change",
+		},
+	}
+	_, kongVersion, err := setupTest()
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tcPath := fmt.Sprintf("testdata/sync/%s/%s", kongVersion, tc.name)
+			kongFile := fmt.Sprintf("%s/kong.yaml", tcPath)
+			cmd := exec.Command(
+				"../deck",
+				"--kong-addr",
+				getKongAddress(),
+				"sync",
+				"-s",
+				kongFile,
+			) // #nosec G204
+
+			var stdout, stderr bytes.Buffer
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+			if err := cmd.Run(); err != nil {
+				t.Errorf(stderr.String())
+			}
+
+			// Check deck output looks as expected.
+			testDeckOutput(t, fmt.Sprintf("%s/output", tcPath), stdout.String())
+		})
+	}
+}

--- a/cmd/testdata/sync/2.0.5/create_plugin/kong.yaml
+++ b/cmd/testdata/sync/2.0.5/create_plugin/kong.yaml
@@ -1,0 +1,47 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    strip_path: true
+plugins:
+- config:
+    day: null
+    fault_tolerant: true
+    hide_client_headers: false
+    hour: 10
+    limit_by: consumer
+    minute: null
+    month: null
+    policy: cluster
+    redis_database: 0
+    redis_host: null
+    redis_password: null
+    redis_port: 6379
+    redis_timeout: 2000
+    second: null
+    year: null
+  enabled: true
+  id: 20cefd85-13d2-4339-afec-93e33de63fdf
+  name: rate-limiting
+  protocols:
+  - grpc
+  - grpcs
+  - http
+  - https

--- a/cmd/testdata/sync/2.0.5/create_plugin/output
+++ b/cmd/testdata/sync/2.0.5/create_plugin/output
@@ -1,0 +1,5 @@
+creating plugin rate-limiting (global)
+Summary:
+  Created: 1
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.0.5/create_plugin_no_change/kong.yaml
+++ b/cmd/testdata/sync/2.0.5/create_plugin_no_change/kong.yaml
@@ -1,0 +1,45 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    strip_path: true
+plugins:
+- config:
+    day: null
+    fault_tolerant: true
+    hide_client_headers: false
+    hour: 100
+    limit_by: consumer
+    minute: null
+    month: null
+    policy: cluster
+    redis_database: 0
+    redis_host: null
+    redis_password: null
+    redis_port: 6380
+    redis_timeout: 1000
+    second: null
+    year: null
+  enabled: true
+  id: 20cefd85-13d2-4339-afec-93e33de63fdf
+  name: rate-limiting
+  protocols:
+  - grpc
+  - grpcs

--- a/cmd/testdata/sync/2.0.5/create_plugin_no_change/output
+++ b/cmd/testdata/sync/2.0.5/create_plugin_no_change/output
@@ -1,0 +1,4 @@
+Summary:
+  Created: 0
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.0.5/create_route/kong.yaml
+++ b/cmd/testdata/sync/2.0.5/create_route/kong.yaml
@@ -1,0 +1,23 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 301
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v0
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true

--- a/cmd/testdata/sync/2.0.5/create_route/output
+++ b/cmd/testdata/sync/2.0.5/create_route/output
@@ -1,0 +1,5 @@
+creating route r1
+Summary:
+  Created: 1
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.0.5/create_route_no_change/kong.yaml
+++ b/cmd/testdata/sync/2.0.5/create_route_no_change/kong.yaml
@@ -1,0 +1,22 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    strip_path: true

--- a/cmd/testdata/sync/2.0.5/create_route_no_change/output
+++ b/cmd/testdata/sync/2.0.5/create_route_no_change/output
@@ -1,0 +1,4 @@
+Summary:
+  Created: 0
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.0.5/create_service/kong.yaml
+++ b/cmd/testdata/sync/2.0.5/create_service/kong.yaml
@@ -1,0 +1,10 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5

--- a/cmd/testdata/sync/2.0.5/create_service/output
+++ b/cmd/testdata/sync/2.0.5/create_service/output
@@ -1,0 +1,5 @@
+creating service svc1
+Summary:
+  Created: 1
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.0.5/create_service_no_change/kong.yaml
+++ b/cmd/testdata/sync/2.0.5/create_service_no_change/kong.yaml
@@ -1,0 +1,10 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10

--- a/cmd/testdata/sync/2.0.5/create_service_no_change/output
+++ b/cmd/testdata/sync/2.0.5/create_service_no_change/output
@@ -1,0 +1,4 @@
+Summary:
+  Created: 0
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.0.5/modify_plugin/kong.yaml
+++ b/cmd/testdata/sync/2.0.5/modify_plugin/kong.yaml
@@ -1,0 +1,45 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    strip_path: true
+plugins:
+- config:
+    day: null
+    fault_tolerant: true
+    hide_client_headers: false
+    hour: 100
+    limit_by: consumer
+    minute: null
+    month: null
+    policy: cluster
+    redis_database: 0
+    redis_host: null
+    redis_password: null
+    redis_port: 6380
+    redis_timeout: 1000
+    second: null
+    year: null
+  enabled: true
+  id: 20cefd85-13d2-4339-afec-93e33de63fdf
+  name: rate-limiting
+  protocols:
+  - grpc
+  - grpcs

--- a/cmd/testdata/sync/2.0.5/modify_plugin/output
+++ b/cmd/testdata/sync/2.0.5/modify_plugin/output
@@ -1,0 +1,36 @@
+updating plugin rate-limiting (global)  {
+   "config": {
+     "day": null,
+     "fault_tolerant": true,
+     "hide_client_headers": false,
+-    "hour": 10,
++    "hour": 100,
+     "limit_by": "consumer",
+     "minute": null,
+     "month": null,
+     "policy": "cluster",
+     "redis_database": 0,
+     "redis_host": null,
+     "redis_password": null,
+-    "redis_port": 6379,
++    "redis_port": 6380,
+-    "redis_timeout": 2000,
++    "redis_timeout": 1000,
+     "second": null,
+     "year": null
+   },
+   "enabled": true,
+   "id": "20cefd85-13d2-4339-afec-93e33de63fdf",
+   "name": "rate-limiting",
+   "protocols": [
+     "grpc",
+     "grpcs",
+-    "http",
+-    "https"
+   ]
+ }
+
+Summary:
+  Created: 0
+  Updated: 1
+  Deleted: 0

--- a/cmd/testdata/sync/2.0.5/modify_route/kong.yaml
+++ b/cmd/testdata/sync/2.0.5/modify_route/kong.yaml
@@ -1,0 +1,22 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    strip_path: true

--- a/cmd/testdata/sync/2.0.5/modify_route/output
+++ b/cmd/testdata/sync/2.0.5/modify_route/output
@@ -1,0 +1,26 @@
+updating route r1  {
+-  "https_redirect_status_code": 301,
++  "https_redirect_status_code": 302,
+   "id": "40898ada-4c87-412d-9206-9bf12bcbd488",
+   "name": "r1",
+-  "path_handling": "v0",
++  "path_handling": "v1",
+   "paths": [
+     "/r1"
+   ],
+   "preserve_host": false,
+   "protocols": [
+     "http",
+-    "https"
+   ],
+   "regex_priority": 0,
+   "service": {
+     "id": "58076db2-28b6-423b-ba39-a797193017f7"
+   },
+   "strip_path": true
+ }
+
+Summary:
+  Created: 0
+  Updated: 1
+  Deleted: 0

--- a/cmd/testdata/sync/2.0.5/modify_service/kong.yaml
+++ b/cmd/testdata/sync/2.0.5/modify_service/kong.yaml
@@ -1,0 +1,10 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10

--- a/cmd/testdata/sync/2.0.5/modify_service/output
+++ b/cmd/testdata/sync/2.0.5/modify_service/output
@@ -1,0 +1,19 @@
+updating service svc1  {
+   "connect_timeout": 60000,
+   "host": "mockbin.org",
+   "id": "58076db2-28b6-423b-ba39-a797193017f7",
+   "name": "svc1",
+-  "port": 80,
++  "port": 8080,
+-  "protocol": "http",
++  "protocol": "https",
+   "read_timeout": 60000,
+-  "retries": 5,
++  "retries": 10,
+   "write_timeout": 60000
+ }
+
+Summary:
+  Created: 0
+  Updated: 1
+  Deleted: 0

--- a/cmd/testdata/sync/2.1.4/create_plugin/kong.yaml
+++ b/cmd/testdata/sync/2.1.4/create_plugin/kong.yaml
@@ -1,0 +1,48 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    strip_path: true
+plugins:
+- config:
+    day: null
+    fault_tolerant: true
+    header_name: null
+    hide_client_headers: false
+    hour: 10
+    limit_by: consumer
+    minute: null
+    month: null
+    policy: cluster
+    redis_database: 0
+    redis_host: null
+    redis_password: null
+    redis_port: 6379
+    redis_timeout: 2000
+    second: null
+    year: null
+  enabled: true
+  id: 20cefd85-13d2-4339-afec-93e33de63fdf
+  name: rate-limiting
+  protocols:
+  - grpc
+  - grpcs
+  - http
+  - https

--- a/cmd/testdata/sync/2.1.4/create_plugin/output
+++ b/cmd/testdata/sync/2.1.4/create_plugin/output
@@ -1,0 +1,5 @@
+creating plugin rate-limiting (global)
+Summary:
+  Created: 1
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.1.4/create_plugin_no_change/kong.yaml
+++ b/cmd/testdata/sync/2.1.4/create_plugin_no_change/kong.yaml
@@ -1,0 +1,46 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    strip_path: true
+plugins:
+- config:
+    day: null
+    fault_tolerant: true
+    header_name: null
+    hide_client_headers: false
+    hour: 100
+    limit_by: consumer
+    minute: null
+    month: null
+    policy: cluster
+    redis_database: 0
+    redis_host: null
+    redis_password: null
+    redis_port: 6380
+    redis_timeout: 1000
+    second: null
+    year: null
+  enabled: true
+  id: 20cefd85-13d2-4339-afec-93e33de63fdf
+  name: rate-limiting
+  protocols:
+  - grpc
+  - grpcs

--- a/cmd/testdata/sync/2.1.4/create_plugin_no_change/output
+++ b/cmd/testdata/sync/2.1.4/create_plugin_no_change/output
@@ -1,0 +1,4 @@
+Summary:
+  Created: 0
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.1.4/create_route/kong.yaml
+++ b/cmd/testdata/sync/2.1.4/create_route/kong.yaml
@@ -1,0 +1,23 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 301
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v0
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    strip_path: true

--- a/cmd/testdata/sync/2.1.4/create_route/output
+++ b/cmd/testdata/sync/2.1.4/create_route/output
@@ -1,0 +1,5 @@
+creating route r1
+Summary:
+  Created: 1
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.1.4/create_route_no_change/kong.yaml
+++ b/cmd/testdata/sync/2.1.4/create_route_no_change/kong.yaml
@@ -1,0 +1,22 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    strip_path: true

--- a/cmd/testdata/sync/2.1.4/create_route_no_change/output
+++ b/cmd/testdata/sync/2.1.4/create_route_no_change/output
@@ -1,0 +1,4 @@
+Summary:
+  Created: 0
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.1.4/create_service/kong.yaml
+++ b/cmd/testdata/sync/2.1.4/create_service/kong.yaml
@@ -1,0 +1,10 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5

--- a/cmd/testdata/sync/2.1.4/create_service/output
+++ b/cmd/testdata/sync/2.1.4/create_service/output
@@ -1,0 +1,5 @@
+creating service svc1
+Summary:
+  Created: 1
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.1.4/create_service_no_change/kong.yaml
+++ b/cmd/testdata/sync/2.1.4/create_service_no_change/kong.yaml
@@ -1,0 +1,10 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10

--- a/cmd/testdata/sync/2.1.4/create_service_no_change/output
+++ b/cmd/testdata/sync/2.1.4/create_service_no_change/output
@@ -1,0 +1,4 @@
+Summary:
+  Created: 0
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.1.4/modify_plugin/kong.yaml
+++ b/cmd/testdata/sync/2.1.4/modify_plugin/kong.yaml
@@ -1,0 +1,46 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    strip_path: true
+plugins:
+- config:
+    day: null
+    fault_tolerant: true
+    header_name: null
+    hide_client_headers: false
+    hour: 100
+    limit_by: consumer
+    minute: null
+    month: null
+    policy: cluster
+    redis_database: 0
+    redis_host: null
+    redis_password: null
+    redis_port: 6380
+    redis_timeout: 1000
+    second: null
+    year: null
+  enabled: true
+  id: 20cefd85-13d2-4339-afec-93e33de63fdf
+  name: rate-limiting
+  protocols:
+  - grpc
+  - grpcs

--- a/cmd/testdata/sync/2.1.4/modify_plugin/output
+++ b/cmd/testdata/sync/2.1.4/modify_plugin/output
@@ -1,0 +1,37 @@
+updating plugin rate-limiting (global)  {
+   "config": {
+     "day": null,
+     "fault_tolerant": true,
+     "header_name": null,
+     "hide_client_headers": false,
+-    "hour": 10,
++    "hour": 100,
+     "limit_by": "consumer",
+     "minute": null,
+     "month": null,
+     "policy": "cluster",
+     "redis_database": 0,
+     "redis_host": null,
+     "redis_password": null,
+-    "redis_port": 6379,
++    "redis_port": 6380,
+-    "redis_timeout": 2000,
++    "redis_timeout": 1000,
+     "second": null,
+     "year": null
+   },
+   "enabled": true,
+   "id": "20cefd85-13d2-4339-afec-93e33de63fdf",
+   "name": "rate-limiting",
+   "protocols": [
+     "grpc",
+     "grpcs",
+-    "http",
+-    "https"
+   ]
+ }
+
+Summary:
+  Created: 0
+  Updated: 1
+  Deleted: 0

--- a/cmd/testdata/sync/2.1.4/modify_route/kong.yaml
+++ b/cmd/testdata/sync/2.1.4/modify_route/kong.yaml
@@ -1,0 +1,22 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    strip_path: true

--- a/cmd/testdata/sync/2.1.4/modify_route/output
+++ b/cmd/testdata/sync/2.1.4/modify_route/output
@@ -1,0 +1,26 @@
+updating route r1  {
+-  "https_redirect_status_code": 301,
++  "https_redirect_status_code": 302,
+   "id": "40898ada-4c87-412d-9206-9bf12bcbd488",
+   "name": "r1",
+-  "path_handling": "v0",
++  "path_handling": "v1",
+   "paths": [
+     "/r1"
+   ],
+   "preserve_host": false,
+   "protocols": [
+     "http",
+-    "https"
+   ],
+   "regex_priority": 0,
+   "service": {
+     "id": "58076db2-28b6-423b-ba39-a797193017f7"
+   },
+   "strip_path": true
+ }
+
+Summary:
+  Created: 0
+  Updated: 1
+  Deleted: 0

--- a/cmd/testdata/sync/2.1.4/modify_service/kong.yaml
+++ b/cmd/testdata/sync/2.1.4/modify_service/kong.yaml
@@ -1,0 +1,10 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10

--- a/cmd/testdata/sync/2.1.4/modify_service/output
+++ b/cmd/testdata/sync/2.1.4/modify_service/output
@@ -1,0 +1,19 @@
+updating service svc1  {
+   "connect_timeout": 60000,
+   "host": "mockbin.org",
+   "id": "58076db2-28b6-423b-ba39-a797193017f7",
+   "name": "svc1",
+-  "port": 80,
++  "port": 8080,
+-  "protocol": "http",
++  "protocol": "https",
+   "read_timeout": 60000,
+-  "retries": 5,
++  "retries": 10,
+   "write_timeout": 60000
+ }
+
+Summary:
+  Created: 0
+  Updated: 1
+  Deleted: 0

--- a/cmd/testdata/sync/2.2.2/create_plugin/kong.yaml
+++ b/cmd/testdata/sync/2.2.2/create_plugin/kong.yaml
@@ -1,0 +1,51 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+plugins:
+- config:
+    day: null
+    fault_tolerant: true
+    header_name: null
+    hide_client_headers: false
+    hour: 10
+    limit_by: consumer
+    minute: null
+    month: null
+    path: null
+    policy: cluster
+    redis_database: 0
+    redis_host: null
+    redis_password: null
+    redis_port: 6379
+    redis_timeout: 2000
+    second: null
+    year: null
+  enabled: true
+  id: 20cefd85-13d2-4339-afec-93e33de63fdf
+  name: rate-limiting
+  protocols:
+  - grpc
+  - grpcs
+  - http
+  - https

--- a/cmd/testdata/sync/2.2.2/create_plugin/output
+++ b/cmd/testdata/sync/2.2.2/create_plugin/output
@@ -1,0 +1,5 @@
+creating plugin rate-limiting (global)
+Summary:
+  Created: 1
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.2.2/create_plugin_no_change/kong.yaml
+++ b/cmd/testdata/sync/2.2.2/create_plugin_no_change/kong.yaml
@@ -1,0 +1,49 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+plugins:
+- config:
+    day: null
+    fault_tolerant: true
+    header_name: null
+    hide_client_headers: false
+    hour: 100
+    limit_by: consumer
+    minute: null
+    month: null
+    path: null
+    policy: cluster
+    redis_database: 0
+    redis_host: null
+    redis_password: null
+    redis_port: 6380
+    redis_timeout: 1000
+    second: null
+    year: null
+  enabled: true
+  id: 20cefd85-13d2-4339-afec-93e33de63fdf
+  name: rate-limiting
+  protocols:
+  - grpc
+  - grpcs

--- a/cmd/testdata/sync/2.2.2/create_plugin_no_change/output
+++ b/cmd/testdata/sync/2.2.2/create_plugin_no_change/output
@@ -1,0 +1,4 @@
+Summary:
+  Created: 0
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.2.2/create_route/kong.yaml
+++ b/cmd/testdata/sync/2.2.2/create_route/kong.yaml
@@ -1,0 +1,25 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 301
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v0
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true

--- a/cmd/testdata/sync/2.2.2/create_route/output
+++ b/cmd/testdata/sync/2.2.2/create_route/output
@@ -1,0 +1,5 @@
+creating route r1
+Summary:
+  Created: 1
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.2.2/create_route_no_change/kong.yaml
+++ b/cmd/testdata/sync/2.2.2/create_route_no_change/kong.yaml
@@ -1,0 +1,24 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true

--- a/cmd/testdata/sync/2.2.2/create_route_no_change/output
+++ b/cmd/testdata/sync/2.2.2/create_route_no_change/output
@@ -1,0 +1,4 @@
+Summary:
+  Created: 0
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.2.2/create_service/kong.yaml
+++ b/cmd/testdata/sync/2.2.2/create_service/kong.yaml
@@ -1,0 +1,10 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5

--- a/cmd/testdata/sync/2.2.2/create_service/output
+++ b/cmd/testdata/sync/2.2.2/create_service/output
@@ -1,0 +1,5 @@
+creating service svc1
+Summary:
+  Created: 1
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.2.2/create_service_no_change/kong.yaml
+++ b/cmd/testdata/sync/2.2.2/create_service_no_change/kong.yaml
@@ -1,0 +1,10 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10

--- a/cmd/testdata/sync/2.2.2/create_service_no_change/output
+++ b/cmd/testdata/sync/2.2.2/create_service_no_change/output
@@ -1,0 +1,4 @@
+Summary:
+  Created: 0
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.2.2/modify_plugin/kong.yaml
+++ b/cmd/testdata/sync/2.2.2/modify_plugin/kong.yaml
@@ -1,0 +1,49 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+plugins:
+- config:
+    day: null
+    fault_tolerant: true
+    header_name: null
+    hide_client_headers: false
+    hour: 100
+    limit_by: consumer
+    minute: null
+    month: null
+    path: null
+    policy: cluster
+    redis_database: 0
+    redis_host: null
+    redis_password: null
+    redis_port: 6380
+    redis_timeout: 1000
+    second: null
+    year: null
+  enabled: true
+  id: 20cefd85-13d2-4339-afec-93e33de63fdf
+  name: rate-limiting
+  protocols:
+  - grpc
+  - grpcs

--- a/cmd/testdata/sync/2.2.2/modify_plugin/output
+++ b/cmd/testdata/sync/2.2.2/modify_plugin/output
@@ -1,0 +1,38 @@
+updating plugin rate-limiting (global)  {
+   "config": {
+     "day": null,
+     "fault_tolerant": true,
+     "header_name": null,
+     "hide_client_headers": false,
+-    "hour": 10,
++    "hour": 100,
+     "limit_by": "consumer",
+     "minute": null,
+     "month": null,
+     "path": null,
+     "policy": "cluster",
+     "redis_database": 0,
+     "redis_host": null,
+     "redis_password": null,
+-    "redis_port": 6379,
++    "redis_port": 6380,
+-    "redis_timeout": 2000,
++    "redis_timeout": 1000,
+     "second": null,
+     "year": null
+   },
+   "enabled": true,
+   "id": "20cefd85-13d2-4339-afec-93e33de63fdf",
+   "name": "rate-limiting",
+   "protocols": [
+     "grpc",
+     "grpcs",
+-    "http",
+-    "https"
+   ]
+ }
+
+Summary:
+  Created: 0
+  Updated: 1
+  Deleted: 0

--- a/cmd/testdata/sync/2.2.2/modify_route/kong.yaml
+++ b/cmd/testdata/sync/2.2.2/modify_route/kong.yaml
@@ -1,0 +1,24 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true

--- a/cmd/testdata/sync/2.2.2/modify_route/output
+++ b/cmd/testdata/sync/2.2.2/modify_route/output
@@ -1,0 +1,28 @@
+updating route r1  {
+-  "https_redirect_status_code": 301,
++  "https_redirect_status_code": 302,
+   "id": "40898ada-4c87-412d-9206-9bf12bcbd488",
+   "name": "r1",
+-  "path_handling": "v0",
++  "path_handling": "v1",
+   "paths": [
+     "/r1"
+   ],
+   "preserve_host": false,
+   "protocols": [
+     "http",
+-    "https"
+   ],
+   "regex_priority": 0,
+   "request_buffering": true,
+   "response_buffering": true,
+   "service": {
+     "id": "58076db2-28b6-423b-ba39-a797193017f7"
+   },
+   "strip_path": true
+ }
+
+Summary:
+  Created: 0
+  Updated: 1
+  Deleted: 0

--- a/cmd/testdata/sync/2.2.2/modify_service/kong.yaml
+++ b/cmd/testdata/sync/2.2.2/modify_service/kong.yaml
@@ -1,0 +1,10 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10

--- a/cmd/testdata/sync/2.2.2/modify_service/output
+++ b/cmd/testdata/sync/2.2.2/modify_service/output
@@ -1,0 +1,19 @@
+updating service svc1  {
+   "connect_timeout": 60000,
+   "host": "mockbin.org",
+   "id": "58076db2-28b6-423b-ba39-a797193017f7",
+   "name": "svc1",
+-  "port": 80,
++  "port": 8080,
+-  "protocol": "http",
++  "protocol": "https",
+   "read_timeout": 60000,
+-  "retries": 5,
++  "retries": 10,
+   "write_timeout": 60000
+ }
+
+Summary:
+  Created: 0
+  Updated: 1
+  Deleted: 0

--- a/cmd/testdata/sync/2.3.3/create_plugin/kong.yaml
+++ b/cmd/testdata/sync/2.3.3/create_plugin/kong.yaml
@@ -1,0 +1,51 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+plugins:
+- config:
+    day: null
+    fault_tolerant: true
+    header_name: null
+    hide_client_headers: false
+    hour: 10
+    limit_by: consumer
+    minute: null
+    month: null
+    path: null
+    policy: cluster
+    redis_database: 0
+    redis_host: null
+    redis_password: null
+    redis_port: 6379
+    redis_timeout: 2000
+    second: null
+    year: null
+  enabled: true
+  id: 20cefd85-13d2-4339-afec-93e33de63fdf
+  name: rate-limiting
+  protocols:
+  - grpc
+  - grpcs
+  - http
+  - https

--- a/cmd/testdata/sync/2.3.3/create_plugin/output
+++ b/cmd/testdata/sync/2.3.3/create_plugin/output
@@ -1,0 +1,5 @@
+creating plugin rate-limiting (global)
+Summary:
+  Created: 1
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.3.3/create_plugin_no_change/kong.yaml
+++ b/cmd/testdata/sync/2.3.3/create_plugin_no_change/kong.yaml
@@ -1,0 +1,49 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+plugins:
+- config:
+    day: null
+    fault_tolerant: true
+    header_name: null
+    hide_client_headers: false
+    hour: 100
+    limit_by: consumer
+    minute: null
+    month: null
+    path: null
+    policy: cluster
+    redis_database: 0
+    redis_host: null
+    redis_password: null
+    redis_port: 6380
+    redis_timeout: 1000
+    second: null
+    year: null
+  enabled: true
+  id: 20cefd85-13d2-4339-afec-93e33de63fdf
+  name: rate-limiting
+  protocols:
+  - grpc
+  - grpcs

--- a/cmd/testdata/sync/2.3.3/create_plugin_no_change/output
+++ b/cmd/testdata/sync/2.3.3/create_plugin_no_change/output
@@ -1,0 +1,4 @@
+Summary:
+  Created: 0
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.3.3/create_route/kong.yaml
+++ b/cmd/testdata/sync/2.3.3/create_route/kong.yaml
@@ -1,0 +1,25 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 301
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v0
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true

--- a/cmd/testdata/sync/2.3.3/create_route/output
+++ b/cmd/testdata/sync/2.3.3/create_route/output
@@ -1,0 +1,5 @@
+creating route r1
+Summary:
+  Created: 1
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.3.3/create_route_no_change/kong.yaml
+++ b/cmd/testdata/sync/2.3.3/create_route_no_change/kong.yaml
@@ -1,0 +1,24 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true

--- a/cmd/testdata/sync/2.3.3/create_route_no_change/output
+++ b/cmd/testdata/sync/2.3.3/create_route_no_change/output
@@ -1,0 +1,4 @@
+Summary:
+  Created: 0
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.3.3/create_service/kong.yaml
+++ b/cmd/testdata/sync/2.3.3/create_service/kong.yaml
@@ -1,0 +1,10 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5

--- a/cmd/testdata/sync/2.3.3/create_service/output
+++ b/cmd/testdata/sync/2.3.3/create_service/output
@@ -1,0 +1,5 @@
+creating service svc1
+Summary:
+  Created: 1
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.3.3/create_service_no_change/kong.yaml
+++ b/cmd/testdata/sync/2.3.3/create_service_no_change/kong.yaml
@@ -1,0 +1,10 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10

--- a/cmd/testdata/sync/2.3.3/create_service_no_change/output
+++ b/cmd/testdata/sync/2.3.3/create_service_no_change/output
@@ -1,0 +1,4 @@
+Summary:
+  Created: 0
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.3.3/modify_plugin/kong.yaml
+++ b/cmd/testdata/sync/2.3.3/modify_plugin/kong.yaml
@@ -1,0 +1,49 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+plugins:
+- config:
+    day: null
+    fault_tolerant: true
+    header_name: null
+    hide_client_headers: false
+    hour: 100
+    limit_by: consumer
+    minute: null
+    month: null
+    path: null
+    policy: cluster
+    redis_database: 0
+    redis_host: null
+    redis_password: null
+    redis_port: 6380
+    redis_timeout: 1000
+    second: null
+    year: null
+  enabled: true
+  id: 20cefd85-13d2-4339-afec-93e33de63fdf
+  name: rate-limiting
+  protocols:
+  - grpc
+  - grpcs

--- a/cmd/testdata/sync/2.3.3/modify_plugin/output
+++ b/cmd/testdata/sync/2.3.3/modify_plugin/output
@@ -1,0 +1,38 @@
+updating plugin rate-limiting (global)  {
+   "config": {
+     "day": null,
+     "fault_tolerant": true,
+     "header_name": null,
+     "hide_client_headers": false,
+-    "hour": 10,
++    "hour": 100,
+     "limit_by": "consumer",
+     "minute": null,
+     "month": null,
+     "path": null,
+     "policy": "cluster",
+     "redis_database": 0,
+     "redis_host": null,
+     "redis_password": null,
+-    "redis_port": 6379,
++    "redis_port": 6380,
+-    "redis_timeout": 2000,
++    "redis_timeout": 1000,
+     "second": null,
+     "year": null
+   },
+   "enabled": true,
+   "id": "20cefd85-13d2-4339-afec-93e33de63fdf",
+   "name": "rate-limiting",
+   "protocols": [
+     "grpc",
+     "grpcs",
+-    "http",
+-    "https"
+   ]
+ }
+
+Summary:
+  Created: 0
+  Updated: 1
+  Deleted: 0

--- a/cmd/testdata/sync/2.3.3/modify_route/kong.yaml
+++ b/cmd/testdata/sync/2.3.3/modify_route/kong.yaml
@@ -1,0 +1,24 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true

--- a/cmd/testdata/sync/2.3.3/modify_route/output
+++ b/cmd/testdata/sync/2.3.3/modify_route/output
@@ -1,0 +1,28 @@
+updating route r1  {
+-  "https_redirect_status_code": 301,
++  "https_redirect_status_code": 302,
+   "id": "40898ada-4c87-412d-9206-9bf12bcbd488",
+   "name": "r1",
+-  "path_handling": "v0",
++  "path_handling": "v1",
+   "paths": [
+     "/r1"
+   ],
+   "preserve_host": false,
+   "protocols": [
+     "http",
+-    "https"
+   ],
+   "regex_priority": 0,
+   "request_buffering": true,
+   "response_buffering": true,
+   "service": {
+     "id": "58076db2-28b6-423b-ba39-a797193017f7"
+   },
+   "strip_path": true
+ }
+
+Summary:
+  Created: 0
+  Updated: 1
+  Deleted: 0

--- a/cmd/testdata/sync/2.3.3/modify_service/kong.yaml
+++ b/cmd/testdata/sync/2.3.3/modify_service/kong.yaml
@@ -1,0 +1,10 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10

--- a/cmd/testdata/sync/2.3.3/modify_service/output
+++ b/cmd/testdata/sync/2.3.3/modify_service/output
@@ -1,0 +1,19 @@
+updating service svc1  {
+   "connect_timeout": 60000,
+   "host": "mockbin.org",
+   "id": "58076db2-28b6-423b-ba39-a797193017f7",
+   "name": "svc1",
+-  "port": 80,
++  "port": 8080,
+-  "protocol": "http",
++  "protocol": "https",
+   "read_timeout": 60000,
+-  "retries": 5,
++  "retries": 10,
+   "write_timeout": 60000
+ }
+
+Summary:
+  Created: 0
+  Updated: 1
+  Deleted: 0

--- a/cmd/testdata/sync/2.4.0/create_plugin/kong.yaml
+++ b/cmd/testdata/sync/2.4.0/create_plugin/kong.yaml
@@ -1,0 +1,51 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+plugins:
+- config:
+    day: null
+    fault_tolerant: true
+    header_name: null
+    hide_client_headers: false
+    hour: 10
+    limit_by: consumer
+    minute: null
+    month: null
+    path: null
+    policy: cluster
+    redis_database: 0
+    redis_host: null
+    redis_password: null
+    redis_port: 6379
+    redis_timeout: 2000
+    second: null
+    year: null
+  enabled: true
+  id: 20cefd85-13d2-4339-afec-93e33de63fdf
+  name: rate-limiting
+  protocols:
+  - grpc
+  - grpcs
+  - http
+  - https

--- a/cmd/testdata/sync/2.4.0/create_plugin/output
+++ b/cmd/testdata/sync/2.4.0/create_plugin/output
@@ -1,0 +1,5 @@
+creating plugin rate-limiting (global)
+Summary:
+  Created: 1
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.4.0/create_plugin_no_change/kong.yaml
+++ b/cmd/testdata/sync/2.4.0/create_plugin_no_change/kong.yaml
@@ -1,0 +1,49 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+plugins:
+- config:
+    day: null
+    fault_tolerant: true
+    header_name: null
+    hide_client_headers: false
+    hour: 100
+    limit_by: consumer
+    minute: null
+    month: null
+    path: null
+    policy: cluster
+    redis_database: 0
+    redis_host: null
+    redis_password: null
+    redis_port: 6380
+    redis_timeout: 1000
+    second: null
+    year: null
+  enabled: true
+  id: 20cefd85-13d2-4339-afec-93e33de63fdf
+  name: rate-limiting
+  protocols:
+  - grpc
+  - grpcs

--- a/cmd/testdata/sync/2.4.0/create_plugin_no_change/output
+++ b/cmd/testdata/sync/2.4.0/create_plugin_no_change/output
@@ -1,0 +1,4 @@
+Summary:
+  Created: 0
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.4.0/create_route/kong.yaml
+++ b/cmd/testdata/sync/2.4.0/create_route/kong.yaml
@@ -1,0 +1,25 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 301
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v0
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true

--- a/cmd/testdata/sync/2.4.0/create_route/output
+++ b/cmd/testdata/sync/2.4.0/create_route/output
@@ -1,0 +1,5 @@
+creating route r1
+Summary:
+  Created: 1
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.4.0/create_route_no_change/kong.yaml
+++ b/cmd/testdata/sync/2.4.0/create_route_no_change/kong.yaml
@@ -1,0 +1,24 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true

--- a/cmd/testdata/sync/2.4.0/create_route_no_change/output
+++ b/cmd/testdata/sync/2.4.0/create_route_no_change/output
@@ -1,0 +1,4 @@
+Summary:
+  Created: 0
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.4.0/create_service/kong.yaml
+++ b/cmd/testdata/sync/2.4.0/create_service/kong.yaml
@@ -1,0 +1,10 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5

--- a/cmd/testdata/sync/2.4.0/create_service/output
+++ b/cmd/testdata/sync/2.4.0/create_service/output
@@ -1,0 +1,5 @@
+creating service svc1
+Summary:
+  Created: 1
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.4.0/create_service_no_change/kong.yaml
+++ b/cmd/testdata/sync/2.4.0/create_service_no_change/kong.yaml
@@ -1,0 +1,10 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10

--- a/cmd/testdata/sync/2.4.0/create_service_no_change/output
+++ b/cmd/testdata/sync/2.4.0/create_service_no_change/output
@@ -1,0 +1,4 @@
+Summary:
+  Created: 0
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.4.0/modify_plugin/kong.yaml
+++ b/cmd/testdata/sync/2.4.0/modify_plugin/kong.yaml
@@ -1,0 +1,49 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+plugins:
+- config:
+    day: null
+    fault_tolerant: true
+    header_name: null
+    hide_client_headers: false
+    hour: 100
+    limit_by: consumer
+    minute: null
+    month: null
+    path: null
+    policy: cluster
+    redis_database: 0
+    redis_host: null
+    redis_password: null
+    redis_port: 6380
+    redis_timeout: 1000
+    second: null
+    year: null
+  enabled: true
+  id: 20cefd85-13d2-4339-afec-93e33de63fdf
+  name: rate-limiting
+  protocols:
+  - grpc
+  - grpcs

--- a/cmd/testdata/sync/2.4.0/modify_plugin/output
+++ b/cmd/testdata/sync/2.4.0/modify_plugin/output
@@ -1,0 +1,38 @@
+updating plugin rate-limiting (global)  {
+   "config": {
+     "day": null,
+     "fault_tolerant": true,
+     "header_name": null,
+     "hide_client_headers": false,
+-    "hour": 10,
++    "hour": 100,
+     "limit_by": "consumer",
+     "minute": null,
+     "month": null,
+     "path": null,
+     "policy": "cluster",
+     "redis_database": 0,
+     "redis_host": null,
+     "redis_password": null,
+-    "redis_port": 6379,
++    "redis_port": 6380,
+-    "redis_timeout": 2000,
++    "redis_timeout": 1000,
+     "second": null,
+     "year": null
+   },
+   "enabled": true,
+   "id": "20cefd85-13d2-4339-afec-93e33de63fdf",
+   "name": "rate-limiting",
+   "protocols": [
+     "grpc",
+     "grpcs",
+-    "http",
+-    "https"
+   ]
+ }
+
+Summary:
+  Created: 0
+  Updated: 1
+  Deleted: 0

--- a/cmd/testdata/sync/2.4.0/modify_route/kong.yaml
+++ b/cmd/testdata/sync/2.4.0/modify_route/kong.yaml
@@ -1,0 +1,24 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true

--- a/cmd/testdata/sync/2.4.0/modify_route/output
+++ b/cmd/testdata/sync/2.4.0/modify_route/output
@@ -1,0 +1,28 @@
+updating route r1  {
+-  "https_redirect_status_code": 301,
++  "https_redirect_status_code": 302,
+   "id": "40898ada-4c87-412d-9206-9bf12bcbd488",
+   "name": "r1",
+-  "path_handling": "v0",
++  "path_handling": "v1",
+   "paths": [
+     "/r1"
+   ],
+   "preserve_host": false,
+   "protocols": [
+     "http",
+-    "https"
+   ],
+   "regex_priority": 0,
+   "request_buffering": true,
+   "response_buffering": true,
+   "service": {
+     "id": "58076db2-28b6-423b-ba39-a797193017f7"
+   },
+   "strip_path": true
+ }
+
+Summary:
+  Created: 0
+  Updated: 1
+  Deleted: 0

--- a/cmd/testdata/sync/2.4.0/modify_service/kong.yaml
+++ b/cmd/testdata/sync/2.4.0/modify_service/kong.yaml
@@ -1,0 +1,10 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10

--- a/cmd/testdata/sync/2.4.0/modify_service/output
+++ b/cmd/testdata/sync/2.4.0/modify_service/output
@@ -1,0 +1,19 @@
+updating service svc1  {
+   "connect_timeout": 60000,
+   "host": "mockbin.org",
+   "id": "58076db2-28b6-423b-ba39-a797193017f7",
+   "name": "svc1",
+-  "port": 80,
++  "port": 8080,
+-  "protocol": "http",
++  "protocol": "https",
+   "read_timeout": 60000,
+-  "retries": 5,
++  "retries": 10,
+   "write_timeout": 60000
+ }
+
+Summary:
+  Created: 0
+  Updated: 1
+  Deleted: 0

--- a/cmd/testdata/sync/2.5.1/create_plugin/kong.yaml
+++ b/cmd/testdata/sync/2.5.1/create_plugin/kong.yaml
@@ -1,0 +1,51 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+plugins:
+- config:
+    day: null
+    fault_tolerant: true
+    header_name: null
+    hide_client_headers: false
+    hour: 10
+    limit_by: consumer
+    minute: null
+    month: null
+    path: null
+    policy: cluster
+    redis_database: 0
+    redis_host: null
+    redis_password: null
+    redis_port: 6379
+    redis_timeout: 2000
+    second: null
+    year: null
+  enabled: true
+  id: 20cefd85-13d2-4339-afec-93e33de63fdf
+  name: rate-limiting
+  protocols:
+  - grpc
+  - grpcs
+  - http
+  - https

--- a/cmd/testdata/sync/2.5.1/create_plugin/output
+++ b/cmd/testdata/sync/2.5.1/create_plugin/output
@@ -1,0 +1,5 @@
+creating plugin rate-limiting (global)
+Summary:
+  Created: 1
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.5.1/create_plugin_no_change/kong.yaml
+++ b/cmd/testdata/sync/2.5.1/create_plugin_no_change/kong.yaml
@@ -1,0 +1,49 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+plugins:
+- config:
+    day: null
+    fault_tolerant: true
+    header_name: null
+    hide_client_headers: false
+    hour: 100
+    limit_by: consumer
+    minute: null
+    month: null
+    path: null
+    policy: cluster
+    redis_database: 0
+    redis_host: null
+    redis_password: null
+    redis_port: 6380
+    redis_timeout: 1000
+    second: null
+    year: null
+  enabled: true
+  id: 20cefd85-13d2-4339-afec-93e33de63fdf
+  name: rate-limiting
+  protocols:
+  - grpc
+  - grpcs

--- a/cmd/testdata/sync/2.5.1/create_plugin_no_change/output
+++ b/cmd/testdata/sync/2.5.1/create_plugin_no_change/output
@@ -1,0 +1,4 @@
+Summary:
+  Created: 0
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.5.1/create_route/kong.yaml
+++ b/cmd/testdata/sync/2.5.1/create_route/kong.yaml
@@ -1,0 +1,25 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 301
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v0
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true

--- a/cmd/testdata/sync/2.5.1/create_route/output
+++ b/cmd/testdata/sync/2.5.1/create_route/output
@@ -1,0 +1,5 @@
+creating route r1
+Summary:
+  Created: 1
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.5.1/create_route_no_change/kong.yaml
+++ b/cmd/testdata/sync/2.5.1/create_route_no_change/kong.yaml
@@ -1,0 +1,24 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true

--- a/cmd/testdata/sync/2.5.1/create_route_no_change/output
+++ b/cmd/testdata/sync/2.5.1/create_route_no_change/output
@@ -1,0 +1,4 @@
+Summary:
+  Created: 0
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.5.1/create_service/kong.yaml
+++ b/cmd/testdata/sync/2.5.1/create_service/kong.yaml
@@ -1,0 +1,10 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5

--- a/cmd/testdata/sync/2.5.1/create_service/output
+++ b/cmd/testdata/sync/2.5.1/create_service/output
@@ -1,0 +1,5 @@
+creating service svc1
+Summary:
+  Created: 1
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.5.1/create_service_no_change/kong.yaml
+++ b/cmd/testdata/sync/2.5.1/create_service_no_change/kong.yaml
@@ -1,0 +1,10 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10

--- a/cmd/testdata/sync/2.5.1/create_service_no_change/output
+++ b/cmd/testdata/sync/2.5.1/create_service_no_change/output
@@ -1,0 +1,4 @@
+Summary:
+  Created: 0
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.5.1/modify_plugin/kong.yaml
+++ b/cmd/testdata/sync/2.5.1/modify_plugin/kong.yaml
@@ -1,0 +1,49 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+plugins:
+- config:
+    day: null
+    fault_tolerant: true
+    header_name: null
+    hide_client_headers: false
+    hour: 100
+    limit_by: consumer
+    minute: null
+    month: null
+    path: null
+    policy: cluster
+    redis_database: 0
+    redis_host: null
+    redis_password: null
+    redis_port: 6380
+    redis_timeout: 1000
+    second: null
+    year: null
+  enabled: true
+  id: 20cefd85-13d2-4339-afec-93e33de63fdf
+  name: rate-limiting
+  protocols:
+  - grpc
+  - grpcs

--- a/cmd/testdata/sync/2.5.1/modify_plugin/output
+++ b/cmd/testdata/sync/2.5.1/modify_plugin/output
@@ -1,0 +1,38 @@
+updating plugin rate-limiting (global)  {
+   "config": {
+     "day": null,
+     "fault_tolerant": true,
+     "header_name": null,
+     "hide_client_headers": false,
+-    "hour": 10,
++    "hour": 100,
+     "limit_by": "consumer",
+     "minute": null,
+     "month": null,
+     "path": null,
+     "policy": "cluster",
+     "redis_database": 0,
+     "redis_host": null,
+     "redis_password": null,
+-    "redis_port": 6379,
++    "redis_port": 6380,
+-    "redis_timeout": 2000,
++    "redis_timeout": 1000,
+     "second": null,
+     "year": null
+   },
+   "enabled": true,
+   "id": "20cefd85-13d2-4339-afec-93e33de63fdf",
+   "name": "rate-limiting",
+   "protocols": [
+     "grpc",
+     "grpcs",
+-    "http",
+-    "https"
+   ]
+ }
+
+Summary:
+  Created: 0
+  Updated: 1
+  Deleted: 0

--- a/cmd/testdata/sync/2.5.1/modify_route/kong.yaml
+++ b/cmd/testdata/sync/2.5.1/modify_route/kong.yaml
@@ -1,0 +1,24 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true

--- a/cmd/testdata/sync/2.5.1/modify_route/output
+++ b/cmd/testdata/sync/2.5.1/modify_route/output
@@ -1,0 +1,28 @@
+updating route r1  {
+-  "https_redirect_status_code": 301,
++  "https_redirect_status_code": 302,
+   "id": "40898ada-4c87-412d-9206-9bf12bcbd488",
+   "name": "r1",
+-  "path_handling": "v0",
++  "path_handling": "v1",
+   "paths": [
+     "/r1"
+   ],
+   "preserve_host": false,
+   "protocols": [
+     "http",
+-    "https"
+   ],
+   "regex_priority": 0,
+   "request_buffering": true,
+   "response_buffering": true,
+   "service": {
+     "id": "58076db2-28b6-423b-ba39-a797193017f7"
+   },
+   "strip_path": true
+ }
+
+Summary:
+  Created: 0
+  Updated: 1
+  Deleted: 0

--- a/cmd/testdata/sync/2.5.1/modify_service/kong.yaml
+++ b/cmd/testdata/sync/2.5.1/modify_service/kong.yaml
@@ -1,0 +1,10 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10

--- a/cmd/testdata/sync/2.5.1/modify_service/output
+++ b/cmd/testdata/sync/2.5.1/modify_service/output
@@ -1,0 +1,19 @@
+updating service svc1  {
+   "connect_timeout": 60000,
+   "host": "mockbin.org",
+   "id": "58076db2-28b6-423b-ba39-a797193017f7",
+   "name": "svc1",
+-  "port": 80,
++  "port": 8080,
+-  "protocol": "http",
++  "protocol": "https",
+   "read_timeout": 60000,
+-  "retries": 5,
++  "retries": 10,
+   "write_timeout": 60000
+ }
+
+Summary:
+  Created: 0
+  Updated: 1
+  Deleted: 0

--- a/cmd/testdata/sync/2.6.0/create_plugin/kong.yaml
+++ b/cmd/testdata/sync/2.6.0/create_plugin/kong.yaml
@@ -1,0 +1,51 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+plugins:
+- config:
+    day: null
+    fault_tolerant: true
+    header_name: null
+    hide_client_headers: false
+    hour: 10
+    limit_by: consumer
+    minute: null
+    month: null
+    path: null
+    policy: cluster
+    redis_database: 0
+    redis_host: null
+    redis_password: null
+    redis_port: 6379
+    redis_timeout: 2000
+    second: null
+    year: null
+  enabled: true
+  id: 20cefd85-13d2-4339-afec-93e33de63fdf
+  name: rate-limiting
+  protocols:
+  - grpc
+  - grpcs
+  - http
+  - https

--- a/cmd/testdata/sync/2.6.0/create_plugin/output
+++ b/cmd/testdata/sync/2.6.0/create_plugin/output
@@ -1,0 +1,5 @@
+creating plugin rate-limiting (global)
+Summary:
+  Created: 1
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.6.0/create_plugin_no_change/kong.yaml
+++ b/cmd/testdata/sync/2.6.0/create_plugin_no_change/kong.yaml
@@ -1,0 +1,49 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+plugins:
+- config:
+    day: null
+    fault_tolerant: true
+    header_name: null
+    hide_client_headers: false
+    hour: 100
+    limit_by: consumer
+    minute: null
+    month: null
+    path: null
+    policy: cluster
+    redis_database: 0
+    redis_host: null
+    redis_password: null
+    redis_port: 6380
+    redis_timeout: 1000
+    second: null
+    year: null
+  enabled: true
+  id: 20cefd85-13d2-4339-afec-93e33de63fdf
+  name: rate-limiting
+  protocols:
+  - grpc
+  - grpcs

--- a/cmd/testdata/sync/2.6.0/create_plugin_no_change/output
+++ b/cmd/testdata/sync/2.6.0/create_plugin_no_change/output
@@ -1,0 +1,4 @@
+Summary:
+  Created: 0
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.6.0/create_route/kong.yaml
+++ b/cmd/testdata/sync/2.6.0/create_route/kong.yaml
@@ -1,0 +1,25 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 301
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v0
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true

--- a/cmd/testdata/sync/2.6.0/create_route/output
+++ b/cmd/testdata/sync/2.6.0/create_route/output
@@ -1,0 +1,5 @@
+creating route r1
+Summary:
+  Created: 1
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.6.0/create_route_no_change/kong.yaml
+++ b/cmd/testdata/sync/2.6.0/create_route_no_change/kong.yaml
@@ -1,0 +1,24 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true

--- a/cmd/testdata/sync/2.6.0/create_route_no_change/output
+++ b/cmd/testdata/sync/2.6.0/create_route_no_change/output
@@ -1,0 +1,4 @@
+Summary:
+  Created: 0
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.6.0/create_service/kong.yaml
+++ b/cmd/testdata/sync/2.6.0/create_service/kong.yaml
@@ -1,0 +1,10 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5

--- a/cmd/testdata/sync/2.6.0/create_service/output
+++ b/cmd/testdata/sync/2.6.0/create_service/output
@@ -1,0 +1,5 @@
+creating service svc1
+Summary:
+  Created: 1
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.6.0/create_service_no_change/kong.yaml
+++ b/cmd/testdata/sync/2.6.0/create_service_no_change/kong.yaml
@@ -1,0 +1,10 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10

--- a/cmd/testdata/sync/2.6.0/create_service_no_change/output
+++ b/cmd/testdata/sync/2.6.0/create_service_no_change/output
@@ -1,0 +1,4 @@
+Summary:
+  Created: 0
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.6.0/modify_plugin/kong.yaml
+++ b/cmd/testdata/sync/2.6.0/modify_plugin/kong.yaml
@@ -1,0 +1,49 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+plugins:
+- config:
+    day: null
+    fault_tolerant: true
+    header_name: null
+    hide_client_headers: false
+    hour: 100
+    limit_by: consumer
+    minute: null
+    month: null
+    path: null
+    policy: cluster
+    redis_database: 0
+    redis_host: null
+    redis_password: null
+    redis_port: 6380
+    redis_timeout: 1000
+    second: null
+    year: null
+  enabled: true
+  id: 20cefd85-13d2-4339-afec-93e33de63fdf
+  name: rate-limiting
+  protocols:
+  - grpc
+  - grpcs

--- a/cmd/testdata/sync/2.6.0/modify_plugin/output
+++ b/cmd/testdata/sync/2.6.0/modify_plugin/output
@@ -1,0 +1,38 @@
+updating plugin rate-limiting (global)  {
+   "config": {
+     "day": null,
+     "fault_tolerant": true,
+     "header_name": null,
+     "hide_client_headers": false,
+-    "hour": 10,
++    "hour": 100,
+     "limit_by": "consumer",
+     "minute": null,
+     "month": null,
+     "path": null,
+     "policy": "cluster",
+     "redis_database": 0,
+     "redis_host": null,
+     "redis_password": null,
+-    "redis_port": 6379,
++    "redis_port": 6380,
+-    "redis_timeout": 2000,
++    "redis_timeout": 1000,
+     "second": null,
+     "year": null
+   },
+   "enabled": true,
+   "id": "20cefd85-13d2-4339-afec-93e33de63fdf",
+   "name": "rate-limiting",
+   "protocols": [
+     "grpc",
+     "grpcs",
+-    "http",
+-    "https"
+   ]
+ }
+
+Summary:
+  Created: 0
+  Updated: 1
+  Deleted: 0

--- a/cmd/testdata/sync/2.6.0/modify_route/kong.yaml
+++ b/cmd/testdata/sync/2.6.0/modify_route/kong.yaml
@@ -1,0 +1,24 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true

--- a/cmd/testdata/sync/2.6.0/modify_route/output
+++ b/cmd/testdata/sync/2.6.0/modify_route/output
@@ -1,0 +1,28 @@
+updating route r1  {
+-  "https_redirect_status_code": 301,
++  "https_redirect_status_code": 302,
+   "id": "40898ada-4c87-412d-9206-9bf12bcbd488",
+   "name": "r1",
+-  "path_handling": "v0",
++  "path_handling": "v1",
+   "paths": [
+     "/r1"
+   ],
+   "preserve_host": false,
+   "protocols": [
+     "http",
+-    "https"
+   ],
+   "regex_priority": 0,
+   "request_buffering": true,
+   "response_buffering": true,
+   "service": {
+     "id": "58076db2-28b6-423b-ba39-a797193017f7"
+   },
+   "strip_path": true
+ }
+
+Summary:
+  Created: 0
+  Updated: 1
+  Deleted: 0

--- a/cmd/testdata/sync/2.6.0/modify_service/kong.yaml
+++ b/cmd/testdata/sync/2.6.0/modify_service/kong.yaml
@@ -1,0 +1,10 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10

--- a/cmd/testdata/sync/2.6.0/modify_service/output
+++ b/cmd/testdata/sync/2.6.0/modify_service/output
@@ -1,0 +1,19 @@
+updating service svc1  {
+   "connect_timeout": 60000,
+   "host": "mockbin.org",
+   "id": "58076db2-28b6-423b-ba39-a797193017f7",
+   "name": "svc1",
+-  "port": 80,
++  "port": 8080,
+-  "protocol": "http",
++  "protocol": "https",
+   "read_timeout": 60000,
+-  "retries": 5,
++  "retries": 10,
+   "write_timeout": 60000
+ }
+
+Summary:
+  Created: 0
+  Updated: 1
+  Deleted: 0

--- a/cmd/testdata/sync/2.7.0/create_plugin/kong.yaml
+++ b/cmd/testdata/sync/2.7.0/create_plugin/kong.yaml
@@ -1,0 +1,54 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+plugins:
+- config:
+    day: null
+    fault_tolerant: true
+    header_name: null
+    hide_client_headers: false
+    hour: 10
+    limit_by: consumer
+    minute: null
+    month: null
+    path: null
+    policy: cluster
+    redis_database: 0
+    redis_host: null
+    redis_password: null
+    redis_port: 6379
+    redis_server_name: null
+    redis_ssl: false
+    redis_ssl_verify: false
+    redis_timeout: 2000
+    second: null
+    year: null
+  enabled: true
+  id: 20cefd85-13d2-4339-afec-93e33de63fdf
+  name: rate-limiting
+  protocols:
+  - grpc
+  - grpcs
+  - http
+  - https

--- a/cmd/testdata/sync/2.7.0/create_plugin/output
+++ b/cmd/testdata/sync/2.7.0/create_plugin/output
@@ -1,0 +1,5 @@
+creating plugin rate-limiting (global)
+Summary:
+  Created: 1
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.7.0/create_plugin_no_change/kong.yaml
+++ b/cmd/testdata/sync/2.7.0/create_plugin_no_change/kong.yaml
@@ -1,0 +1,52 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+plugins:
+- config:
+    day: null
+    fault_tolerant: true
+    header_name: null
+    hide_client_headers: false
+    hour: 100
+    limit_by: consumer
+    minute: null
+    month: null
+    path: null
+    policy: cluster
+    redis_database: 0
+    redis_host: null
+    redis_password: null
+    redis_port: 6380
+    redis_server_name: null
+    redis_ssl: false
+    redis_ssl_verify: false
+    redis_timeout: 1000
+    second: null
+    year: null
+  enabled: true
+  id: 20cefd85-13d2-4339-afec-93e33de63fdf
+  name: rate-limiting
+  protocols:
+  - grpc
+  - grpcs

--- a/cmd/testdata/sync/2.7.0/create_plugin_no_change/output
+++ b/cmd/testdata/sync/2.7.0/create_plugin_no_change/output
@@ -1,0 +1,4 @@
+Summary:
+  Created: 0
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.7.0/create_route/kong.yaml
+++ b/cmd/testdata/sync/2.7.0/create_route/kong.yaml
@@ -1,0 +1,25 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 301
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v0
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true

--- a/cmd/testdata/sync/2.7.0/create_route/output
+++ b/cmd/testdata/sync/2.7.0/create_route/output
@@ -1,0 +1,5 @@
+creating route r1
+Summary:
+  Created: 1
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.7.0/create_route_no_change/kong.yaml
+++ b/cmd/testdata/sync/2.7.0/create_route_no_change/kong.yaml
@@ -1,0 +1,24 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true

--- a/cmd/testdata/sync/2.7.0/create_route_no_change/output
+++ b/cmd/testdata/sync/2.7.0/create_route_no_change/output
@@ -1,0 +1,4 @@
+Summary:
+  Created: 0
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.7.0/create_service/kong.yaml
+++ b/cmd/testdata/sync/2.7.0/create_service/kong.yaml
@@ -1,0 +1,10 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5

--- a/cmd/testdata/sync/2.7.0/create_service/output
+++ b/cmd/testdata/sync/2.7.0/create_service/output
@@ -1,0 +1,5 @@
+creating service svc1
+Summary:
+  Created: 1
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.7.0/create_service_no_change/kong.yaml
+++ b/cmd/testdata/sync/2.7.0/create_service_no_change/kong.yaml
@@ -1,0 +1,10 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10

--- a/cmd/testdata/sync/2.7.0/create_service_no_change/output
+++ b/cmd/testdata/sync/2.7.0/create_service_no_change/output
@@ -1,0 +1,4 @@
+Summary:
+  Created: 0
+  Updated: 0
+  Deleted: 0

--- a/cmd/testdata/sync/2.7.0/modify_plugin/kong.yaml
+++ b/cmd/testdata/sync/2.7.0/modify_plugin/kong.yaml
@@ -1,0 +1,52 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+plugins:
+- config:
+    day: null
+    fault_tolerant: true
+    header_name: null
+    hide_client_headers: false
+    hour: 100
+    limit_by: consumer
+    minute: null
+    month: null
+    path: null
+    policy: cluster
+    redis_database: 0
+    redis_host: null
+    redis_password: null
+    redis_port: 6380
+    redis_server_name: null
+    redis_ssl: false
+    redis_ssl_verify: false
+    redis_timeout: 1000
+    second: null
+    year: null
+  enabled: true
+  id: 20cefd85-13d2-4339-afec-93e33de63fdf
+  name: rate-limiting
+  protocols:
+  - grpc
+  - grpcs

--- a/cmd/testdata/sync/2.7.0/modify_plugin/output
+++ b/cmd/testdata/sync/2.7.0/modify_plugin/output
@@ -1,0 +1,41 @@
+updating plugin rate-limiting (global)  {
+   "config": {
+     "day": null,
+     "fault_tolerant": true,
+     "header_name": null,
+     "hide_client_headers": false,
+-    "hour": 10,
++    "hour": 100,
+     "limit_by": "consumer",
+     "minute": null,
+     "month": null,
+     "path": null,
+     "policy": "cluster",
+     "redis_database": 0,
+     "redis_host": null,
+     "redis_password": null,
+-    "redis_port": 6379,
++    "redis_port": 6380,
+     "redis_server_name": null,
+     "redis_ssl": false,
+     "redis_ssl_verify": false,
+-    "redis_timeout": 2000,
++    "redis_timeout": 1000,
+     "second": null,
+     "year": null
+   },
+   "enabled": true,
+   "id": "20cefd85-13d2-4339-afec-93e33de63fdf",
+   "name": "rate-limiting",
+   "protocols": [
+     "grpc",
+     "grpcs",
+-    "http",
+-    "https"
+   ]
+ }
+
+Summary:
+  Created: 0
+  Updated: 1
+  Deleted: 0

--- a/cmd/testdata/sync/2.7.0/modify_route/kong.yaml
+++ b/cmd/testdata/sync/2.7.0/modify_route/kong.yaml
@@ -1,0 +1,24 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10
+  routes:
+  - https_redirect_status_code: 302
+    id: 40898ada-4c87-412d-9206-9bf12bcbd488
+    name: r1
+    path_handling: v1
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true

--- a/cmd/testdata/sync/2.7.0/modify_route/output
+++ b/cmd/testdata/sync/2.7.0/modify_route/output
@@ -1,0 +1,28 @@
+updating route r1  {
+-  "https_redirect_status_code": 301,
++  "https_redirect_status_code": 302,
+   "id": "40898ada-4c87-412d-9206-9bf12bcbd488",
+   "name": "r1",
+-  "path_handling": "v0",
++  "path_handling": "v1",
+   "paths": [
+     "/r1"
+   ],
+   "preserve_host": false,
+   "protocols": [
+     "http",
+-    "https"
+   ],
+   "regex_priority": 0,
+   "request_buffering": true,
+   "response_buffering": true,
+   "service": {
+     "id": "58076db2-28b6-423b-ba39-a797193017f7"
+   },
+   "strip_path": true
+ }
+
+Summary:
+  Created: 0
+  Updated: 1
+  Deleted: 0

--- a/cmd/testdata/sync/2.7.0/modify_service/kong.yaml
+++ b/cmd/testdata/sync/2.7.0/modify_service/kong.yaml
@@ -1,0 +1,10 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 8080
+  protocol: https
+  read_timeout: 60000
+  retries: 10

--- a/cmd/testdata/sync/2.7.0/modify_service/output
+++ b/cmd/testdata/sync/2.7.0/modify_service/output
@@ -1,0 +1,19 @@
+updating service svc1  {
+   "connect_timeout": 60000,
+   "host": "mockbin.org",
+   "id": "58076db2-28b6-423b-ba39-a797193017f7",
+   "name": "svc1",
+-  "port": 80,
++  "port": 8080,
+-  "protocol": "http",
++  "protocol": "https",
+   "read_timeout": 60000,
+-  "retries": 5,
++  "retries": 10,
+   "write_timeout": 60000
+ }
+
+Summary:
+  Created: 0
+  Updated: 1
+  Deleted: 0

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.2
 	github.com/fatih/color v1.13.0
 	github.com/ghodss/yaml v1.0.0
+	github.com/google/go-cmp v0.5.7
 	github.com/google/go-querystring v1.1.0
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-memdb v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -203,8 +203,9 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
+github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=


### PR DESCRIPTION
This PR starts introducing some basic integration tests for the `sync` command. The goal is to agree on an overall structure for such tests, so that we can easily iterate over it.

At the moment we are only testing `deck` outputs here, but then we will expand the scope to test Kong state as well.

What this PR introduces:
- [.ci/setup_kong.sh](https://github.com/Kong/deck/blob/intergration_tests/.ci/setup_kong.sh): borrowed from [go-kong](https://github.com/Kong/go-kong/blob/main/.ci/setup_kong.sh), this script setups a Kong instance to be used during tests
- CI setup for OSS [versions](https://github.com/Kong/deck/blob/intergration_tests/.github/workflows/test.yaml#L9-L17) (EE to be added soon)
- a basic structure for test cases. Each test case is "represented" by a folder in `cmd/testdata/sync/$KONG_VERSION`: it's hard to test entities creation and modification across Kong releases since their schemas is not guaranteed to remain the same. For this reason, I'm proposing to version tests too with the mentioned format. This can easily become verbose, but I think it's a fair price to pay in exchange of a more complete testing scope. Each [testcase](https://github.com/Kong/deck/tree/intergration_tests/cmd/testdata/sync/2.0.5/create_service) is composed of a `kong.yaml`, that will be used to deploy Kong, and a `output` file with the expected `deck` results.
- testing logic in [sync_test.go](https://github.com/Kong/deck/blob/intergration_tests/cmd/sync_test.go): clears current Kong environment (the equivalent of running `reset`), collects test case files, deploys the specific `kong.yaml` and finally checks whether the output matches the expectations or not