### PR TITLE
fix: unexpected error with --select-tag and multiple files

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -172,12 +172,13 @@ func determineSelectorTag(targetContent file.Content, config dump.Config) ([]str
 	if targetContent.Info != nil {
 		if len(targetContent.Info.SelectorTags) > 0 {
 			if len(config.SelectorTags) > 0 {
+				utils.RemoveDuplicates(&targetContent.Info.SelectorTags)
 				sort.Strings(config.SelectorTags)
 				sort.Strings(targetContent.Info.SelectorTags)
 				if !reflect.DeepEqual(config.SelectorTags, targetContent.Info.SelectorTags) {
-					return nil, fmt.Errorf(`tags specified in the state file and via --select-tags flag are different.
+					return nil, fmt.Errorf(`tags specified in the state file (%v) and via --select-tags flag (%v) are different.
 					decK expects tags to be specified in either via flag or via state file.
-					In case both are specified, they must match`)
+					In case both are specified, they must match`, targetContent.Info.SelectorTags, config.SelectorTags)
 				}
 				// Both present and equal, return whichever
 				return targetContent.Info.SelectorTags, nil

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -64,6 +64,24 @@ func TestDetermineSelectorTag(t *testing.T) {
 			want:    []string{"foo"},
 			wantErr: false,
 		},
+		{
+			name: "config has one tag and file has duplicates",
+			args: args{
+				dumpConfig:  dump.Config{SelectorTags: []string{"foo"}},
+				fileContent: file.Content{Info: &file.Info{SelectorTags: []string{"foo", "foo"}}},
+			},
+			want:    []string{"foo"},
+			wantErr: false,
+		},
+		{
+			name: "config has multiple tags and file has duplicates",
+			args: args{
+				dumpConfig:  dump.Config{SelectorTags: []string{"foo", "bar"}},
+				fileContent: file.Content{Info: &file.Info{SelectorTags: []string{"foo", "bar", "foo", "bar"}}},
+			},
+			want:    []string{"bar", "foo"},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -66,3 +66,24 @@ func CallGetAll(obj interface{}) (reflect.Value, error) {
 	result = reflect.ValueOf(entities)
 	return result, nil
 }
+
+func alreadyInSlice(elem string, slice []string) bool {
+	for _, s := range slice {
+		if s == elem {
+			return true
+		}
+	}
+	return false
+}
+
+// RemoveDuplicates removes duplicated elements from a slice.
+func RemoveDuplicates(slice *[]string) {
+	newSlice := []string{}
+	for _, s := range *slice {
+		if alreadyInSlice(s, newSlice) {
+			continue
+		}
+		newSlice = append(newSlice, s)
+	}
+	*slice = newSlice
+}


### PR DESCRIPTION
When running sync with multiple files and `--select-tag`,
deck simply appends the existing `_info.select_tags` of the
various files. If the same tag(s) are present in the files,
these are appended together making `deck` fail because the
tags passed via the command flag and the ones coming from
the files are expected to match, but the way files are
merged may cause duplicates, hence the unexpected failure.

This removes duplicates from the _info.select_tags resulted
from the merged files.

Related to https://github.com/Kong/deck/issues/561