### PR TITLE
feat: support sync with multiple workspaces

### DIFF
--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -92,7 +92,7 @@ By default, this command will ask for confirmation.`,
 			if err != nil {
 				return err
 			}
-			_, err = performDiff(ctx, currentState, targetState, false, 10, 0, wsClient)
+			_, err = performDiff(ctx, currentState, targetState, false, 10, 0, wsClient, workspace)
 			if err != nil {
 				return err
 			}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -7,14 +7,19 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func printStats(stats diff.Stats) {
+func printStats(stats diff.Stats, workspace string) {
 	// do not use github.com/kong/deck/print because that package
 	// is used only for events logs
 	printFn := color.New(color.FgGreen, color.Bold).PrintfFunc()
-	printFn("Summary:\n")
+	if workspace != "" {
+		printFn("Summary (%s):\n", workspace)
+	} else {
+		printFn("Summary:\n")
+	}
 	printFn("  Created: %d\n", stats.CreateOps.Count())
 	printFn("  Updated: %d\n", stats.UpdateOps.Count())
 	printFn("  Deleted: %d\n", stats.DeleteOps.Count())
+	printFn("\n")
 }
 
 var silenceEvents bool

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -39,24 +39,26 @@ func Convert(inputFilename, outputFilename string, from, to Format) error {
 		err           error
 	)
 
-	inputContent, err := file.GetContentFromFiles([]string{inputFilename})
+	inputContents, err := file.GetContentFromFiles([]string{inputFilename})
 	if err != nil {
 		return err
 	}
 
-	switch {
-	case from == FormatKongGateway && to == FormatKonnect:
-		outputContent, err = convertKongGatewayToKonnect(inputContent)
+	for _, inputContent := range inputContents {
+		switch {
+		case from == FormatKongGateway && to == FormatKonnect:
+			outputContent, err = convertKongGatewayToKonnect(inputContent)
+			if err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("cannot convert from '%s' to '%s' format", from, to)
+		}
+
+		err = file.WriteContentToFile(outputContent, outputFilename, file.YAML)
 		if err != nil {
 			return err
 		}
-	default:
-		return fmt.Errorf("cannot convert from '%s' to '%s' format", from, to)
-	}
-
-	err = file.WriteContentToFile(outputContent, outputFilename, file.YAML)
-	if err != nil {
-		return err
 	}
 	return nil
 }

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -140,6 +140,8 @@ func zeroOutID(sp file.FServicePackage) file.FServicePackage {
 }
 
 func Test_Convert(t *testing.T) {
+	// if not set otherwise in input, workspace is an empty string
+	var workspace string
 	type args struct {
 		inputFilename          string
 		outputFilename         string
@@ -200,16 +202,16 @@ func Test_Convert(t *testing.T) {
 			}
 
 			if err == nil {
-				got, err := file.GetContentFromFiles([]string{tt.args.outputFilename})
+				gotMap, err := file.GetContentFromFiles([]string{tt.args.outputFilename})
 				if err != nil {
 					t.Errorf("failed to read output file: %v", err)
 				}
-				want, err := file.GetContentFromFiles([]string{tt.args.expectedOutputFilename})
+				wantMap, err := file.GetContentFromFiles([]string{tt.args.expectedOutputFilename})
 				if err != nil {
 					t.Errorf("failed to read output file: %v", err)
 				}
-				got = wipeServiceID(got)
-				want = wipeServiceID(want)
+				got := wipeServiceID(gotMap[workspace])
+				want := wipeServiceID(wantMap[workspace])
 				assert.Equal(t, want, got)
 			}
 		})

--- a/file/reader.go
+++ b/file/reader.go
@@ -33,7 +33,7 @@ type RenderConfig struct {
 //
 // It will return an error if the file representation is invalid
 // or if there is any error during processing.
-func GetContentFromFiles(filenames []string) (*Content, error) {
+func GetContentFromFiles(filenames []string) (map[string]*Content, error) {
 	if len(filenames) == 0 {
 		return nil, ErrorFilenameEmpty
 	}

--- a/file/readfile_test.go
+++ b/file/readfile_test.go
@@ -132,7 +132,7 @@ func Test_getContent(t *testing.T) {
 		name    string
 		args    args
 		envVars map[string]string
-		want    *Content
+		want    map[string]*Content
 		wantErr bool
 	}{
 		{
@@ -144,13 +144,15 @@ func Test_getContent(t *testing.T) {
 		{
 			name:    "empty directory",
 			args:    args{[]string{"testdata/emptydir"}},
-			want:    &Content{},
+			want:    nil,
 			wantErr: false,
 		},
 		{
-			name:    "directory with empty files",
-			args:    args{[]string{"testdata/emptyfiles"}},
-			want:    &Content{},
+			name: "directory with empty files",
+			args: args{[]string{"testdata/emptyfiles"}},
+			want: map[string]*Content{
+				"": {},
+			},
 			wantErr: false,
 		},
 		{
@@ -171,28 +173,30 @@ func Test_getContent(t *testing.T) {
 			envVars: map[string]string{
 				"DECK_SVC2_HOST": "2.example.com",
 			},
-			want: &Content{
-				Services: []FService{
-					{
-						Service: kong.Service{
-							Name: kong.String("svc2"),
-							Host: kong.String("2.example.com"),
-							Tags: kong.StringSlice("<"),
-						},
-						Routes: []*FRoute{
-							{
-								Route: kong.Route{
-									Name:  kong.String("r2"),
-									Paths: kong.StringSlice("/r2"),
+			want: map[string]*Content{
+				"": {
+					Services: []FService{
+						{
+							Service: kong.Service{
+								Name: kong.String("svc2"),
+								Host: kong.String("2.example.com"),
+								Tags: kong.StringSlice("<"),
+							},
+							Routes: []*FRoute{
+								{
+									Route: kong.Route{
+										Name:  kong.String("r2"),
+										Paths: kong.StringSlice("/r2"),
+									},
 								},
 							},
 						},
 					},
-				},
-				Plugins: []FPlugin{
-					{
-						Plugin: kong.Plugin{
-							Name: kong.String("prometheus"),
+					Plugins: []FPlugin{
+						{
+							Plugin: kong.Plugin{
+								Name: kong.String("prometheus"),
+							},
 						},
 					},
 				},
@@ -215,40 +219,42 @@ func Test_getContent(t *testing.T) {
 			envVars: map[string]string{
 				"DECK_SVC2_HOST": "2.example.com",
 			},
-			want: &Content{
-				Services: []FService{
-					{
-						Service: kong.Service{
-							Name: kong.String("svc2"),
-							Host: kong.String("2.example.com"),
-							Tags: kong.StringSlice("<"),
-						},
-						Routes: []*FRoute{
-							{
-								Route: kong.Route{
-									Name:  kong.String("r2"),
-									Paths: kong.StringSlice("/r2"),
+			want: map[string]*Content{
+				"": {
+					Services: []FService{
+						{
+							Service: kong.Service{
+								Name: kong.String("svc2"),
+								Host: kong.String("2.example.com"),
+								Tags: kong.StringSlice("<"),
+							},
+							Routes: []*FRoute{
+								{
+									Route: kong.Route{
+										Name:  kong.String("r2"),
+										Paths: kong.StringSlice("/r2"),
+									},
 								},
 							},
 						},
 					},
-				},
-				Plugins: []FPlugin{
-					{
-						Plugin: kong.Plugin{
-							Name: kong.String("prometheus"),
+					Plugins: []FPlugin{
+						{
+							Plugin: kong.Plugin{
+								Name: kong.String("prometheus"),
+							},
 						},
 					},
-				},
-				Consumers: []FConsumer{
-					{
-						Consumer: kong.Consumer{
-							Username: kong.String("foo"),
+					Consumers: []FConsumer{
+						{
+							Consumer: kong.Consumer{
+								Username: kong.String("foo"),
+							},
 						},
-					},
-					{
-						Consumer: kong.Consumer{
-							Username: kong.String("bar"),
+						{
+							Consumer: kong.Consumer{
+								Username: kong.String("bar"),
+							},
 						},
 					},
 				},
@@ -258,62 +264,83 @@ func Test_getContent(t *testing.T) {
 		{
 			name: "valid directory",
 			args: args{[]string{"testdata/valid"}},
-			want: &Content{
-				Info: &Info{
-					SelectorTags: []string{"tag1"},
-				},
-				Services: []FService{
-					{
-						Service: kong.Service{
-							Name: kong.String("svc2"),
-							Host: kong.String("2.example.com"),
+			want: map[string]*Content{
+				"": {
+					Info: &Info{
+						SelectorTags: []string{"tag1"},
+					},
+					Services: []FService{
+						{
+							Service: kong.Service{
+								Name: kong.String("svc2"),
+								Host: kong.String("2.example.com"),
+							},
+							Routes: []*FRoute{
+								{
+									Route: kong.Route{
+										Name:  kong.String("r2"),
+										Paths: kong.StringSlice("/r2"),
+									},
+								},
+							},
 						},
-						Routes: []*FRoute{
-							{
-								Route: kong.Route{
-									Name:  kong.String("r2"),
-									Paths: kong.StringSlice("/r2"),
+						{
+							Service: kong.Service{
+								Name: kong.String("svc1"),
+								Host: kong.String("1.example.com"),
+								Tags: kong.StringSlice("team-svc1"),
+							},
+							Routes: []*FRoute{
+								{
+									Route: kong.Route{
+										Name:  kong.String("r1"),
+										Paths: kong.StringSlice("/r1"),
+									},
 								},
 							},
 						},
 					},
-					{
-						Service: kong.Service{
-							Name: kong.String("svc1"),
-							Host: kong.String("1.example.com"),
-							Tags: kong.StringSlice("team-svc1"),
+					Consumers: []FConsumer{
+						{
+							Consumer: kong.Consumer{
+								Username: kong.String("foo"),
+							},
 						},
-						Routes: []*FRoute{
-							{
-								Route: kong.Route{
-									Name:  kong.String("r1"),
-									Paths: kong.StringSlice("/r1"),
-								},
+						{
+							Consumer: kong.Consumer{
+								Username: kong.String("bar"),
+							},
+						},
+						{
+							Consumer: kong.Consumer{
+								Username: kong.String("harry"),
+							},
+						},
+					},
+					Plugins: []FPlugin{
+						{
+							Plugin: kong.Plugin{
+								Name: kong.String("prometheus"),
 							},
 						},
 					},
 				},
-				Consumers: []FConsumer{
-					{
-						Consumer: kong.Consumer{
-							Username: kong.String("foo"),
-						},
-					},
-					{
-						Consumer: kong.Consumer{
-							Username: kong.String("bar"),
-						},
-					},
-					{
-						Consumer: kong.Consumer{
-							Username: kong.String("harry"),
-						},
-					},
-				},
-				Plugins: []FPlugin{
-					{
-						Plugin: kong.Plugin{
-							Name: kong.String("prometheus"),
+				"testWs": {
+					Workspace: "testWs",
+					Services: []FService{
+						{
+							Service: kong.Service{
+								Name: kong.String("svc3"),
+								Host: kong.String("3.example.com"),
+							},
+							Routes: []*FRoute{
+								{
+									Route: kong.Route{
+										Name:  kong.String("r3"),
+										Paths: kong.StringSlice("/r3"),
+									},
+								},
+							},
 						},
 					},
 				},

--- a/file/testdata/valid/baz.yaml
+++ b/file/testdata/valid/baz.yaml
@@ -1,0 +1,8 @@
+_workspace: testWs
+services:
+- name: svc3
+  host: 3.example.com
+  routes:
+  - name: r3
+    paths:
+    - /r3


### PR DESCRIPTION
As highlighted in https://github.com/Kong/deck/issues/506, currently `deck` is not able to deploy multiple state files with multiple workspaces, and it actually mistakenly deploys all of them into a single workspace.

This PR is a proposal to start supporting such cases.

The main change is about the `file.getContent` function, which used to return a single `file.Content` pointer, but here it's returning a map of workspaces (`map[string]*Content`). All the other changes are consequences of this.

As a result, `deck` would show different reports per-workspace too.

Sample usage:

```
$ deck sync -s ws1.yaml -s ws2.yaml
creating service svc1
Summary (ws1):
  Created: 1
  Updated: 0
  Deleted: 0

creating service svc2
Summary (ws3):
  Created: 1
  Updated: 0
  Deleted: 0
```

```
$ deck reset --all-workspaces
This will delete all configuration from Kong's database.
> Are you sure? y
Summary (ws2):
  Created: 0
  Updated: 0
  Deleted: 0

deleting service svc1
Summary (ws1):
  Created: 0
  Updated: 0
  Deleted: 1

Summary (default):
  Created: 0
  Updated: 0
  Deleted: 0
```
 
@rainest  @hbagdi thoughts? 