### PR TITLE
fix: unexpected behaviour with sync and multiple ws

### DIFF
--- a/file/readfile.go
+++ b/file/readfile.go
@@ -20,6 +20,7 @@ import (
 // these files and renders a Content.
 func getContent(filenames []string) (*Content, error) {
 	var allReaders []io.Reader
+	var workspaces []string
 	for _, fileOrDir := range filenames {
 		readers, err := getReaders(fileOrDir)
 		if err != nil {
@@ -33,10 +34,14 @@ func getContent(filenames []string) (*Content, error) {
 		if err != nil {
 			return nil, fmt.Errorf("reading file: %w", err)
 		}
+		workspaces = append(workspaces, content.Workspace)
 		err = mergo.Merge(&res, content, mergo.WithAppendSlice)
 		if err != nil {
 			return nil, fmt.Errorf("merging file contents: %w", err)
 		}
+	}
+	if err := validateWorkspaces(workspaces); err != nil {
+		return nil, err
 	}
 	return &res, nil
 }

--- a/file/readfile_test.go
+++ b/file/readfile_test.go
@@ -320,6 +320,53 @@ func Test_getContent(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name:    "different workspaces",
+			args:    args{[]string{"testdata/differentworkspace"}},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "same workspaces",
+			args: args{[]string{"testdata/sameworkspace"}},
+			want: &Content{
+				FormatVersion: *kong.String("1.1"),
+				Workspace:     *kong.String("bar"),
+				Services: []FService{
+					{
+						Service: kong.Service{
+							Name: kong.String("svc2"),
+							Host: kong.String("2.example.com"),
+							Tags: kong.StringSlice("team-svc2"),
+						},
+						Routes: []*FRoute{
+							{
+								Route: kong.Route{
+									Name:  kong.String("r2"),
+									Paths: kong.StringSlice("/r2"),
+								},
+							},
+						},
+					},
+					{
+						Service: kong.Service{
+							Name: kong.String("svc1"),
+							Host: kong.String("1.example.com"),
+							Tags: kong.StringSlice("team-svc1"),
+						},
+						Routes: []*FRoute{
+							{
+								Route: kong.Route{
+									Name:  kong.String("r1"),
+									Paths: kong.StringSlice("/r1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/file/testdata/differentworkspace/bar.yaml
+++ b/file/testdata/differentworkspace/bar.yaml
@@ -1,0 +1,11 @@
+_format_version: "1.1"
+_workspace: bar
+services:
+- name: svc2
+  host: 2.example.com
+  tags:
+  - team-svc2
+  routes:
+  - name: r2
+    paths:
+    - /r2

--- a/file/testdata/differentworkspace/foo.yaml
+++ b/file/testdata/differentworkspace/foo.yaml
@@ -1,0 +1,11 @@
+_format_version: "1.1"
+_workspace: foo
+services:
+- name: svc1
+  host: 1.example.com
+  tags:
+  - team-svc1
+  routes:
+  - name: r1
+    paths:
+    - /r1

--- a/file/testdata/sameworkspace/bar.yaml
+++ b/file/testdata/sameworkspace/bar.yaml
@@ -1,0 +1,11 @@
+_format_version: "1.1"
+_workspace: bar
+services:
+- name: svc2
+  host: 2.example.com
+  tags:
+  - team-svc2
+  routes:
+  - name: r2
+    paths:
+    - /r2

--- a/file/testdata/sameworkspace/foo.yaml
+++ b/file/testdata/sameworkspace/foo.yaml
@@ -1,0 +1,11 @@
+_format_version: "1.1"
+_workspace: bar
+services:
+- name: svc1
+  host: 1.example.com
+  tags:
+  - team-svc1
+  routes:
+  - name: r1
+    paths:
+    - /r1

--- a/file/validate.go
+++ b/file/validate.go
@@ -35,7 +35,9 @@ func validate(content []byte) error {
 func validateWorkspaces(workspaces []string) error {
 	utils.RemoveDuplicates(&workspaces)
 	if len(workspaces) > 1 {
-		return fmt.Errorf("cannot sync multiple workspaces at the same time: %v", workspaces)
+		return fmt.Errorf("it seems like you are trying to sync multiple workspaces "+
+			"at the same time (%v).\ndecK doesn't support syncing multiple workspaces at the same time, "+
+			"please sync one workspace at a time", workspaces)
 	}
 	return nil
 }

--- a/file/validate.go
+++ b/file/validate.go
@@ -31,3 +31,11 @@ func validate(content []byte) error {
 	}
 	return errs
 }
+
+func validateWorkspaces(workspaces []string) error {
+	utils.RemoveDuplicates(&workspaces)
+	if len(workspaces) > 1 {
+		return fmt.Errorf("cannot sync multiple workspaces at the same time: %v", workspaces)
+	}
+	return nil
+}


### PR DESCRIPTION
When passing to `sync` multiple files (or a folder) with different
_workspace definition, sync merges the files and applies them
only to a single workspace.

This change makes `sync` returning an error when attempting
a deployment with multiple workspaces.