### PR TITLE
feat: implement --dedup-plugin-configs flag for dump

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -168,5 +168,7 @@ configure Kong.`,
 		false, "assume 'yes' to prompts and run non-interactively.")
 	dumpCmd.Flags().BoolVar(&dumpConfig.SkipCACerts, "skip-ca-certificates",
 		false, "do not dump CA certificates.")
+	dumpCmd.Flags().BoolVar(&dumpConfig.DedupPluginsConfig, "dedup-plugin-configs",
+		false, "deduplicate plugins with same configuration.")
 	return dumpCmd
 }

--- a/dump/dump_test.go
+++ b/dump/dump_test.go
@@ -2,6 +2,10 @@ package dump
 
 import (
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/kong/deck/utils"
+	"github.com/kong/go-kong/kong"
 )
 
 func Test_validateConfig(t *testing.T) {
@@ -57,6 +61,421 @@ func Test_validateConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := validateConfig(tt.args.config); (err != nil) != tt.wantErr {
 				t.Errorf("validateConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_dedupPluginsConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		plugins  []*kong.Plugin
+		expected map[string]utils.SharedPlugins
+	}{
+		{
+			name: "same plugin same config",
+			plugins: []*kong.Plugin{
+				{
+					Name: kong.String("rate-limiting"),
+					Consumer: &kong.Consumer{
+						ID: kong.String("c88659d5-f0a4-4ab2-b3e3-56d93ea9af6b"),
+					},
+					Config: kong.Configuration{
+						"minute": 20,
+					},
+				},
+				{
+					Name: kong.String("rate-limiting"),
+					Consumer: &kong.Consumer{
+						ID: kong.String("a49672c8-84e7-4b56-a03a-ef9dccf81d0b"),
+					},
+					Config: kong.Configuration{
+						"minute": 20,
+					},
+				},
+			},
+			expected: map[string]utils.SharedPlugins{
+				"rate-limiting": {
+					"rate-limiting-0": {
+						Config: kong.Configuration{
+							"minute": 20,
+						},
+						Consumers: []string{
+							"c88659d5-f0a4-4ab2-b3e3-56d93ea9af6b",
+							"a49672c8-84e7-4b56-a03a-ef9dccf81d0b",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "same plugin but different configs",
+			plugins: []*kong.Plugin{
+				{
+					Name: kong.String("rate-limiting"),
+					Consumer: &kong.Consumer{
+						ID: kong.String("c88659d5-f0a4-4ab2-b3e3-56d93ea9af6b"),
+					},
+					Config: kong.Configuration{
+						"minute": 20,
+					},
+				},
+				{
+					Name: kong.String("rate-limiting"),
+					Consumer: &kong.Consumer{
+						ID: kong.String("a49672c8-84e7-4b56-a03a-ef9dccf81d0b"),
+					},
+					Config: kong.Configuration{
+						"minute": 20,
+					},
+				},
+				{
+					Name: kong.String("rate-limiting"),
+					Consumer: &kong.Consumer{
+						ID: kong.String("9bfd9929-81a2-4eab-8212-cbf91a2b8726"),
+					},
+					Config: kong.Configuration{
+						"minute": 30,
+					},
+				},
+				{
+					Name: kong.String("rate-limiting"),
+					Consumer: &kong.Consumer{
+						ID: kong.String("1d1f8ad8-85c0-4d6b-8bc9-767b334533e1"),
+					},
+					Config: kong.Configuration{
+						"minute": 30,
+					},
+				},
+			},
+			expected: map[string]utils.SharedPlugins{
+				"rate-limiting": {
+					"rate-limiting-0": {
+						Config: kong.Configuration{
+							"minute": 20,
+						},
+						Consumers: []string{
+							"c88659d5-f0a4-4ab2-b3e3-56d93ea9af6b",
+							"a49672c8-84e7-4b56-a03a-ef9dccf81d0b",
+						},
+					},
+					"rate-limiting-2": {
+						Config: kong.Configuration{
+							"minute": 30,
+						},
+						Consumers: []string{
+							"9bfd9929-81a2-4eab-8212-cbf91a2b8726",
+							"1d1f8ad8-85c0-4d6b-8bc9-767b334533e1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "same plugin but no duplicates",
+			plugins: []*kong.Plugin{
+				{
+					Name: kong.String("rate-limiting"),
+					Consumer: &kong.Consumer{
+						ID: kong.String("c88659d5-f0a4-4ab2-b3e3-56d93ea9af6b"),
+					},
+					Config: kong.Configuration{
+						"minute": 20,
+					},
+				},
+				{
+					Name: kong.String("rate-limiting"),
+					Consumer: &kong.Consumer{
+						ID: kong.String("a49672c8-84e7-4b56-a03a-ef9dccf81d0b"),
+					},
+					Config: kong.Configuration{
+						"minute": 30,
+					},
+				},
+			},
+			expected: map[string]utils.SharedPlugins{},
+		},
+		{
+			name: "different plugins but no duplicates",
+			plugins: []*kong.Plugin{
+				{
+					Name: kong.String("rate-limiting"),
+					Consumer: &kong.Consumer{
+						ID: kong.String("c88659d5-f0a4-4ab2-b3e3-56d93ea9af6b"),
+					},
+					Config: kong.Configuration{
+						"minute": 20,
+					},
+				},
+				{
+					Name: kong.String("prometheus"),
+					Consumer: &kong.Consumer{
+						ID: kong.String("a49672c8-84e7-4b56-a03a-ef9dccf81d0b"),
+					},
+					Config: kong.Configuration{
+						"per_consumer": false,
+					},
+				},
+			},
+			expected: map[string]utils.SharedPlugins{},
+		},
+		{
+			name: "different plugins with duplicates",
+			plugins: []*kong.Plugin{
+				{
+					Name: kong.String("rate-limiting"),
+					Consumer: &kong.Consumer{
+						ID: kong.String("c88659d5-f0a4-4ab2-b3e3-56d93ea9af6b"),
+					},
+					Config: kong.Configuration{
+						"minute": 20,
+					},
+				},
+				{
+					Name: kong.String("rate-limiting"),
+					Consumer: &kong.Consumer{
+						ID: kong.String("a49672c8-84e7-4b56-a03a-ef9dccf81d0b"),
+					},
+					Config: kong.Configuration{
+						"minute": 20,
+					},
+				},
+				{
+					Name: kong.String("prometheus"),
+					Consumer: &kong.Consumer{
+						ID: kong.String("9bfd9929-81a2-4eab-8212-cbf91a2b8726"),
+					},
+					Config: kong.Configuration{
+						"per_consumer": false,
+					},
+				},
+				{
+					Name: kong.String("prometheus"),
+					Consumer: &kong.Consumer{
+						ID: kong.String("1d1f8ad8-85c0-4d6b-8bc9-767b334533e1"),
+					},
+					Config: kong.Configuration{
+						"per_consumer": false,
+					},
+				},
+			},
+			expected: map[string]utils.SharedPlugins{
+				"rate-limiting": {
+					"rate-limiting-0": {
+						Config: kong.Configuration{
+							"minute": 20,
+						},
+						Consumers: []string{
+							"c88659d5-f0a4-4ab2-b3e3-56d93ea9af6b",
+							"a49672c8-84e7-4b56-a03a-ef9dccf81d0b",
+						},
+					},
+				},
+				"prometheus": {
+					"prometheus-2": {
+						Config: kong.Configuration{
+							"per_consumer": false,
+						},
+						Consumers: []string{
+							"9bfd9929-81a2-4eab-8212-cbf91a2b8726",
+							"1d1f8ad8-85c0-4d6b-8bc9-767b334533e1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "same plugin and config with multiple parents",
+			plugins: []*kong.Plugin{
+				{
+					Name: kong.String("rate-limiting"),
+					Consumer: &kong.Consumer{
+						ID: kong.String("c88659d5-f0a4-4ab2-b3e3-56d93ea9af6b"),
+					},
+					Route: &kong.Route{
+						ID: kong.String("ad5f9293-711d-4a17-8c2a-012817866c76"),
+					},
+					Service: &kong.Service{
+						ID: kong.String("bb47e126-e0fb-47e4-9df2-b23bd4cb6fc8"),
+					},
+					Config: kong.Configuration{
+						"minute": 20,
+					},
+				},
+				{
+					Name: kong.String("rate-limiting"),
+					Consumer: &kong.Consumer{
+						ID: kong.String("a49672c8-84e7-4b56-a03a-ef9dccf81d0b"),
+					},
+					Route: &kong.Route{
+						ID: kong.String("ad5f9293-123d-4a17-8c2a-012817866b76"),
+					},
+					Service: &kong.Service{
+						ID: kong.String("bb47e126-e0fb-47e4-9df2-b23bd4123456"),
+					},
+					Config: kong.Configuration{
+						"minute": 20,
+					},
+				},
+			},
+			expected: map[string]utils.SharedPlugins{
+				"rate-limiting": {
+					"rate-limiting-0": {
+						Config: kong.Configuration{
+							"minute": 20,
+						},
+						Consumers: []string{
+							"c88659d5-f0a4-4ab2-b3e3-56d93ea9af6b",
+							"a49672c8-84e7-4b56-a03a-ef9dccf81d0b",
+						},
+						Routes: []string{
+							"ad5f9293-711d-4a17-8c2a-012817866c76",
+							"ad5f9293-123d-4a17-8c2a-012817866b76",
+						},
+						Services: []string{
+							"bb47e126-e0fb-47e4-9df2-b23bd4cb6fc8",
+							"bb47e126-e0fb-47e4-9df2-b23bd4123456",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := dedupPluginsConfig(tt.plugins)
+			if diff := cmp.Diff(&results, &tt.expected); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
+}
+
+func Test_removeSingleEntries(t *testing.T) {
+	tests := []struct {
+		name          string
+		sharedPlugins map[string]utils.SharedPlugins
+		expected      map[string]utils.SharedPlugins
+	}{
+		{
+			name: "shared across multiple consumers",
+			sharedPlugins: map[string]utils.SharedPlugins{
+				"rate-limiting": {
+					"rate-limiting-0": {
+						Config: kong.Configuration{
+							"minute": 20,
+						},
+						Consumers: []string{
+							"c88659d5-f0a4-4ab2-b3e3-56d93ea9af6b",
+							"a49672c8-84e7-4b56-a03a-ef9dccf81d0b",
+						},
+					},
+				},
+			},
+			expected: map[string]utils.SharedPlugins{
+				"rate-limiting": {
+					"rate-limiting-0": {
+						Config: kong.Configuration{
+							"minute": 20,
+						},
+						Consumers: []string{
+							"c88659d5-f0a4-4ab2-b3e3-56d93ea9af6b",
+							"a49672c8-84e7-4b56-a03a-ef9dccf81d0b",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "shared across multiple services",
+			sharedPlugins: map[string]utils.SharedPlugins{
+				"rate-limiting": {
+					"rate-limiting-0": {
+						Config: kong.Configuration{
+							"minute": 20,
+						},
+						Services: []string{
+							"c88659d5-f0a4-4ab2-b3e3-56d93ea9af6b",
+							"a49672c8-84e7-4b56-a03a-ef9dccf81d0b",
+						},
+					},
+				},
+			},
+			expected: map[string]utils.SharedPlugins{
+				"rate-limiting": {
+					"rate-limiting-0": {
+						Config: kong.Configuration{
+							"minute": 20,
+						},
+						Services: []string{
+							"c88659d5-f0a4-4ab2-b3e3-56d93ea9af6b",
+							"a49672c8-84e7-4b56-a03a-ef9dccf81d0b",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "shared across multiple routes",
+			sharedPlugins: map[string]utils.SharedPlugins{
+				"rate-limiting": {
+					"rate-limiting-0": {
+						Config: kong.Configuration{
+							"minute": 20,
+						},
+						Routes: []string{
+							"c88659d5-f0a4-4ab2-b3e3-56d93ea9af6b",
+							"a49672c8-84e7-4b56-a03a-ef9dccf81d0b",
+						},
+					},
+				},
+			},
+			expected: map[string]utils.SharedPlugins{
+				"rate-limiting": {
+					"rate-limiting-0": {
+						Config: kong.Configuration{
+							"minute": 20,
+						},
+						Routes: []string{
+							"c88659d5-f0a4-4ab2-b3e3-56d93ea9af6b",
+							"a49672c8-84e7-4b56-a03a-ef9dccf81d0b",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "not shared",
+			sharedPlugins: map[string]utils.SharedPlugins{
+				"rate-limiting": {
+					"rate-limiting-0": {
+						Config: kong.Configuration{
+							"minute": 20,
+						},
+						Routes: []string{
+							"c88659d5-f0a4-4ab2-b3e3-56d93ea9af6b",
+						},
+					},
+				},
+				"prometheus": {
+					"prometheus-0": {
+						Config: kong.Configuration{
+							"per_consumer": false,
+						},
+						Routes: []string{
+							"a49672c8-84e7-4b56-a03a-ef9dccf81d0b",
+						},
+					},
+				},
+			},
+			expected: map[string]utils.SharedPlugins{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := removeSingleEntries(tt.sharedPlugins)
+			if diff := cmp.Diff(&results, &tt.expected); diff != "" {
+				t.Errorf(diff)
 			}
 		})
 	}

--- a/file/writer.go
+++ b/file/writer.go
@@ -641,33 +641,35 @@ func populateConsumers(kongState *state.KongState, file *Content,
 	return nil
 }
 
-func setPluginSharedConfig(fp *FPlugin, sharedPlugins map[string]utils.SharedPlugin,
-	consumerID, serviceID, routeID string) {
+func getSharedPlugin(sharedPlugins map[string]utils.SharedPlugin,
+	consumerID, serviceID, routeID string) string {
 	for name, content := range sharedPlugins {
 		for _, consumer := range content.Consumers {
-			if consumer != consumerID {
-				continue
+			if consumer == consumerID {
+				return name
 			}
-			fp.Plugin.Config = nil
-			fp.ConfigSource = kong.String(name)
-			break
 		}
 		for _, service := range content.Services {
-			if service != serviceID {
-				continue
+			if service == serviceID {
+				return name
 			}
-			fp.Plugin.Config = nil
-			fp.ConfigSource = kong.String(name)
-			break
 		}
 		for _, route := range content.Routes {
-			if route != routeID {
-				continue
+			if route == routeID {
+				return name
 			}
-			fp.Plugin.Config = nil
-			fp.ConfigSource = kong.String(name)
-			break
 		}
+	}
+	return ""
+}
+
+func setPluginSharedConfig(fp *FPlugin, sharedPlugins map[string]utils.SharedPlugin,
+	consumerID, serviceID, routeID string) {
+	if sharedPlugin := getSharedPlugin(
+		sharedPlugins, consumerID, serviceID, routeID,
+	); sharedPlugin != "" {
+		fp.Plugin.Config = nil
+		fp.ConfigSource = kong.String(sharedPlugin)
 	}
 }
 

--- a/file/writer.go
+++ b/file/writer.go
@@ -642,7 +642,8 @@ func populateConsumers(kongState *state.KongState, file *Content,
 }
 
 func getSharedPlugin(sharedPlugins map[string]utils.SharedPlugin,
-	consumerID, serviceID, routeID string) string {
+	consumerID, serviceID, routeID string,
+) string {
 	for name, content := range sharedPlugins {
 		for _, consumer := range content.Consumers {
 			if consumer == consumerID {
@@ -664,7 +665,8 @@ func getSharedPlugin(sharedPlugins map[string]utils.SharedPlugin,
 }
 
 func setPluginSharedConfig(fp *FPlugin, sharedPlugins map[string]utils.SharedPlugin,
-	consumerID, serviceID, routeID string) {
+	consumerID, serviceID, routeID string,
+) {
 	if sharedPlugin := getSharedPlugin(
 		sharedPlugins, consumerID, serviceID, routeID,
 	); sharedPlugin != "" {

--- a/state/builder.go
+++ b/state/builder.go
@@ -16,6 +16,7 @@ func Get(raw *utils.KongRawState) (*KongState, error) {
 	if err != nil {
 		return nil, err
 	}
+	kongState.RawSharedPluginsMap = raw.SharedPluginMap
 	return kongState, nil
 }
 

--- a/state/builder.go
+++ b/state/builder.go
@@ -16,7 +16,7 @@ func Get(raw *utils.KongRawState) (*KongState, error) {
 	if err != nil {
 		return nil, err
 	}
-	kongState.RawSharedPluginsMap = raw.SharedPluginMap
+	kongState.RawSharedPluginsMap = raw.SharedPluginsMap
 	return kongState, nil
 }
 

--- a/state/state.go
+++ b/state/state.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	memdb "github.com/hashicorp/go-memdb"
+	"github.com/kong/deck/utils"
 )
 
 type collection struct {
@@ -38,6 +39,8 @@ type KongState struct {
 	ServicePackages *ServicePackagesCollection
 	ServiceVersions *ServiceVersionsCollection
 	Documents       *DocumentsCollection
+
+	RawSharedPluginsMap map[string]map[string]utils.SharedPlugin
 }
 
 // NewKongState creates a new in-memory KongState.

--- a/state/state.go
+++ b/state/state.go
@@ -40,7 +40,7 @@ type KongState struct {
 	ServiceVersions *ServiceVersionsCollection
 	Documents       *DocumentsCollection
 
-	RawSharedPluginsMap map[string]map[string]utils.SharedPlugin
+	RawSharedPluginsMap map[string]utils.SharedPlugins
 }
 
 // NewKongState creates a new in-memory KongState.

--- a/utils/types.go
+++ b/utils/types.go
@@ -49,8 +49,10 @@ type KongRawState struct {
 	RBACRoles               []*kong.RBACRole
 	RBACEndpointPermissions []*kong.RBACEndpointPermission
 
-	SharedPluginMap map[string]map[string]SharedPlugin
+	SharedPluginsMap map[string]SharedPlugins
 }
+
+type SharedPlugins map[string]SharedPlugin
 
 type SharedPlugin struct {
 	Config    kong.Configuration

--- a/utils/types.go
+++ b/utils/types.go
@@ -48,6 +48,15 @@ type KongRawState struct {
 
 	RBACRoles               []*kong.RBACRole
 	RBACEndpointPermissions []*kong.RBACEndpointPermission
+
+	SharedPluginMap map[string]map[string]SharedPlugin
+}
+
+type SharedPlugin struct {
+	Config    kong.Configuration
+	Consumers []string
+	Services  []string
+	Routes    []string
 }
 
 // KonnectRawState contains all of Konnect resources.


### PR DESCRIPTION
> `_plugin_configs` feature of decK allows users to abstract out configuration
> of plugins that are used repeatedly and then reference them in
> services/routes/consumers. This helps with de-duplication of configuration
> code. While users would like to take advantage of this, most of them cannot
> because de-duplicating the configuration in the first place is a cumbersome
> and an error-prone process.

https://github.com/Kong/deck/issues/341 ([doc](https://docs.konghq.com/deck/1.10.x/guides/deduplicate-plugin-configuration/))

This implements such flag and feature for the dump command.

Test:
`sync` this file first ([before.yaml.txt](https://github.com/Kong/deck/files/8003745/before.yaml.txt)), having some shared plugins across different consumers, routes and services.

```
$ deck sync
<--omitted->
```

```
$ deck dump --yes --dedup-plugin-configs

$ deck sync
Summary:
  Created: 0
  Updated: 0
  Deleted: 0
```

Result: [after.yaml.txt](https://github.com/Kong/deck/files/8003780/after.yaml.txt)
