### PR TITLE
chore: release Fat/Universal binaries for macOS

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+universal_binaries:
+- replace: true
 builds:
 - env:
   - CGO_ENABLED=0


### PR DESCRIPTION
I tested this as follows:
- on my [forked repo](https://github.com/GGabriele/deck), I created and pushed a new tag to simulate a release
- I ran `goreleaser release --snapshot --rm-dist` locally to generate the artifacts and include them in a [new release](https://github.com/GGabriele/deck/releases/tag/v1.10.0-testing)
- modified the generated `dist/deck.rb` file to point brew at my repo instead of `Kong/deck`
- use the local file with brew (note this is pulling the `*_darwin_all.tar.gz` "universal" artifact)

```
$ brew install dist/deck.rb
Error: Failed to load cask: dist/deck.rb
Cask 'deck' is unreadable: wrong constant name #<Class:0x000000015b96e108>
Warning: Treating dist/deck.rb as a formula.
==> Downloading https://github.com/GGabriele/deck/releases/download/v1.10.0-testing/deck_v1.10.0-testing_darwin_all.tar.gz
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/412574371/847dd173-643c-409f-bd94-dda41226d735?X-Amz-Al
######################################################################## 100.0%
Warning: deck 1.10.0 is available and more recent than version v1.10.0-testing.
🍺  /opt/homebrew/Cellar/deck/v1.10.0-testing: 6 files, 21.2MB, built in 2 seconds
==> Running `brew cleanup deck`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
Removing: /Users/ggerbino/Library/Caches/Homebrew/deck--v1.10.0-testing.tar.gz... (7.6MB)
```

Verify everything looks good:

```
$ which deck
/opt/homebrew/bin/deck

$ ls -l /opt/homebrew/bin/deck
lrwxr-xr-x  1 ggerbino  admin  39 Feb  9 22:45 /opt/homebrew/bin/deck -> ../Cellar/deck/v1.10.0-testing/bin/deck

$ deck ping
Successfully connected to Kong!
Kong version:  2.7.0.0-enterprise-edition
```

https://github.com/Kong/deck/issues/512