### PR TITLE
feat: refactor cmd package

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -7,10 +7,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var completionCmd = &cobra.Command{
-	Use:   "completion [bash|zsh|fish|powershell]",
-	Short: "Generate completion script",
-	Long: `To load completions:
+func newCompletionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "completion [bash|zsh|fish|powershell]",
+		Short: "Generate completion script",
+		Long: `To load completions:
 
 Bash:
 
@@ -49,24 +50,21 @@ PowerShell:
   PS> deck completion powershell > deck.ps1
   # and source this file from your PowerShell profile.
 `,
-	DisableFlagsInUseLine: true,
-	Args:                  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		switch args[0] {
-		case "bash":
-			return cmd.Root().GenBashCompletion(os.Stdout)
-		case "zsh":
-			return cmd.Root().GenZshCompletion(os.Stdout)
-		case "fish":
-			return cmd.Root().GenFishCompletion(os.Stdout, true)
-		case "powershell":
-			return cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
-		default:
-			return fmt.Errorf("invalid shell: %q", args[0])
-		}
-	},
-}
-
-func init() {
-	rootCmd.AddCommand(completionCmd)
+		DisableFlagsInUseLine: true,
+		Args:                  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			switch args[0] {
+			case "bash":
+				return cmd.Root().GenBashCompletion(os.Stdout)
+			case "zsh":
+				return cmd.Root().GenZshCompletion(os.Stdout)
+			case "fish":
+				return cmd.Root().GenFishCompletion(os.Stdout, true)
+			case "powershell":
+				return cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+			default:
+				return fmt.Errorf("invalid shell: %q", args[0])
+			}
+		},
+	}
 }

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -15,39 +15,39 @@ var (
 	convertCmdOutputFile        string
 )
 
-// convertCmd represents the convert command
-var convertCmd = &cobra.Command{
-	Use:   "convert",
-	Short: "Convert files from one format into another format",
-	Long: `The convert command changes configuration files from one format
+// newConvertCmd represents the convert command
+func newConvertCmd() *cobra.Command {
+	convertCmd := &cobra.Command{
+		Use:   "convert",
+		Short: "Convert files from one format into another format",
+		Long: `The convert command changes configuration files from one format
 into another compatible format. For example, a configuration for 'kong-gateway'
 can be converted into a 'konnect' configuration file.`,
-	Args: validateNoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		sourceFormat, err := convert.ParseFormat(convertCmdSourceFormat)
-		if err != nil {
-			return err
-		}
-		destinationFormat, err := convert.ParseFormat(convertCmdDestinationFormat)
-		if err != nil {
-			return err
-		}
+		Args: validateNoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			sourceFormat, err := convert.ParseFormat(convertCmdSourceFormat)
+			if err != nil {
+				return err
+			}
+			destinationFormat, err := convert.ParseFormat(convertCmdDestinationFormat)
+			if err != nil {
+				return err
+			}
 
-		if yes, err := utils.ConfirmFileOverwrite(convertCmdOutputFile, "", false); err != nil {
-			return err
-		} else if !yes {
+			if yes, err := utils.ConfirmFileOverwrite(convertCmdOutputFile, "", false); err != nil {
+				return err
+			} else if !yes {
+				return nil
+			}
+
+			err = convert.Convert(convertCmdInputFile, convertCmdOutputFile, sourceFormat, destinationFormat)
+			if err != nil {
+				return fmt.Errorf("converting file: %v", err)
+			}
 			return nil
-		}
+		},
+	}
 
-		err = convert.Convert(convertCmdInputFile, convertCmdOutputFile, sourceFormat, destinationFormat)
-		if err != nil {
-			return fmt.Errorf("converting file: %v", err)
-		}
-		return nil
-	},
-}
-
-func init() {
 	sourceFormats := []convert.Format{convert.FormatKongGateway}
 	destinationFormats := []convert.Format{convert.FormatKonnect}
 	convertCmd.Flags().StringVar(&convertCmdSourceFormat, "from", "",
@@ -58,5 +58,5 @@ func init() {
 		"configuration file to be converted. Use '-' to read from stdin.")
 	convertCmd.Flags().StringVar(&convertCmdOutputFile, "output-file", "",
 		"file to write configuration to after conversion. Use '-' to write to stdout.")
-	rootCmd.AddCommand(convertCmd)
+	return convertCmd
 }

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -13,32 +13,31 @@ var (
 	diffWorkspace          string
 )
 
-// diffCmd represents the diff command
-var diffCmd = &cobra.Command{
-	Use:   "diff",
-	Short: "Diff the current entities in Kong with the one on disks",
-	Long: `The diff command is similar to a dry run of the 'decK sync' command.
+// newDiffCmd represents the diff command
+func newDiffCmd() *cobra.Command {
+	diffCmd := &cobra.Command{
+		Use:   "diff",
+		Short: "Diff the current entities in Kong with the one on disks",
+		Long: `The diff command is similar to a dry run of the 'decK sync' command.
 
 It loads entities from Kong and performs a diff with
 the entities in local files. This allows you to see the entities
 that will be created, updated, or deleted.
 `,
-	Args: validateNoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return syncMain(cmd.Context(), diffCmdKongStateFile, true,
-			diffCmdParallelism, 0, diffWorkspace)
-	},
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		if len(diffCmdKongStateFile) == 0 {
-			return fmt.Errorf("a state file with Kong's configuration " +
-				"must be specified using -s/--state flag")
-		}
-		return preRunSilenceEventsFlag()
-	},
-}
+		Args: validateNoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return syncMain(cmd.Context(), diffCmdKongStateFile, true,
+				diffCmdParallelism, 0, diffWorkspace)
+		},
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if len(diffCmdKongStateFile) == 0 {
+				return fmt.Errorf("a state file with Kong's configuration " +
+					"must be specified using -s/--state flag")
+			}
+			return preRunSilenceEventsFlag()
+		},
+	}
 
-func init() {
-	rootCmd.AddCommand(diffCmd)
 	diffCmd.Flags().StringSliceVarP(&diffCmdKongStateFile,
 		"state", "s", []string{"kong.yaml"}, "file(s) containing Kong's configuration.\n"+
 			"This flag can be specified multiple times for multiple files.\n"+
@@ -63,4 +62,5 @@ func init() {
 			"exit code 0 if no diff is found,\n"+
 			"and exit code 1 if an error occurs.")
 	addSilenceEventsFlag(diffCmd.Flags())
+	return diffCmd
 }

--- a/cmd/konnect.go
+++ b/cmd/konnect.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var konnectAlphaState = `
@@ -9,14 +10,40 @@ var konnectAlphaState = `
 WARNING: This command is currently in alpha state. This command
 might have breaking changes in future releases.`
 
-// konnectCmd represents the konnect command
-var konnectCmd = &cobra.Command{
-	Use:   "konnect",
-	Short: "Configuration tool for Konnect (in alpha)",
-	Long: `The konnect command prints subcommands that can be used to
+//nolint:errcheck
+// newKonnectCmd represents the konnect command
+func newKonnectCmd() *cobra.Command {
+	konnectCmd := &cobra.Command{
+		Use:   "konnect",
+		Short: "Configuration tool for Konnect (in alpha)",
+		Long: `The konnect command prints subcommands that can be used to
 configure Konnect.` + konnectAlphaState,
-}
+	}
+	// konnect-specific flags
+	konnectCmd.PersistentFlags().String("konnect-email", "",
+		"Email address associated with your Konnect account.")
+	viper.BindPFlag("konnect-email",
+		konnectCmd.PersistentFlags().Lookup("konnect-email"))
 
-func init() {
-	rootCmd.AddCommand(konnectCmd)
+	konnectCmd.PersistentFlags().String("konnect-password", "",
+		"Password associated with your Konnect account, "+
+			"this takes precedence over --konnect-password-file flag.")
+	viper.BindPFlag("konnect-password",
+		konnectCmd.PersistentFlags().Lookup("konnect-password"))
+
+	konnectCmd.PersistentFlags().String("konnect-password-file", "",
+		"File containing the password to your Konnect account.")
+	viper.BindPFlag("konnect-password-file",
+		konnectCmd.PersistentFlags().Lookup("konnect-password-file"))
+
+	konnectCmd.PersistentFlags().String("konnect-addr", "https://konnect.konghq.com",
+		"Address of the Konnect endpoint.")
+	viper.BindPFlag("konnect-addr",
+		konnectCmd.PersistentFlags().Lookup("konnect-addr"))
+
+	konnectCmd.AddCommand(newKonnectSyncCmd())
+	konnectCmd.AddCommand(newKonnectPingCmd())
+	konnectCmd.AddCommand(newKonnectDumpCmd())
+	konnectCmd.AddCommand(newKonnectDiffCmd())
+	return konnectCmd
 }

--- a/cmd/konnect_diff.go
+++ b/cmd/konnect_diff.go
@@ -12,31 +12,30 @@ var (
 	konnectDiffCmdNonZeroExitCode bool
 )
 
-// konnectDiffCmd represents the 'deck konnect diff' command.
-var konnectDiffCmd = &cobra.Command{
-	Use:   "diff",
-	Short: "Diff the current entities in Konnect with the one on disks (in alpha)",
-	Long: `The konnect diff command is similar to a dry run of the 'deck konnect sync' command.
+// newKonnectDiffCmd represents the 'deck konnect diff' command.
+func newKonnectDiffCmd() *cobra.Command {
+	konnectDiffCmd := &cobra.Command{
+		Use:   "diff",
+		Short: "Diff the current entities in Konnect with the one on disks (in alpha)",
+		Long: `The konnect diff command is similar to a dry run of the 'deck konnect sync' command.
 
 	It loads entities from Konnect and performs a diff with
 	the entities in local files. This allows you to see the entities
 	that will be created, updated, or deleted.` + konnectAlphaState,
-	Args: validateNoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if konnectDumpCmdKongStateFile == "-" {
-			return fmt.Errorf("writing to stdout is not supported in Konnect mode")
-		}
-		_ = sendAnalytics("konnect-diff", "")
-		return syncKonnect(cmd.Context(), konnectDiffCmdKongStateFile, true,
-			konnectDiffCmdParallelism)
-	},
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		return preRunSilenceEventsFlag()
-	},
-}
+		Args: validateNoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if konnectDumpCmdKongStateFile == "-" {
+				return fmt.Errorf("writing to stdout is not supported in Konnect mode")
+			}
+			_ = sendAnalytics("konnect-diff", "")
+			return syncKonnect(cmd.Context(), konnectDiffCmdKongStateFile, true,
+				konnectDiffCmdParallelism)
+		},
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return preRunSilenceEventsFlag()
+		},
+	}
 
-func init() {
-	konnectCmd.AddCommand(konnectDiffCmd)
 	konnectDiffCmd.Flags().StringSliceVarP(&konnectDiffCmdKongStateFile,
 		"state", "s", []string{"konnect.yaml"}, "file(s) containing Konnect's configuration.\n"+
 			"This flag can be specified multiple times for multiple files.")
@@ -50,4 +49,5 @@ func init() {
 			"exit code 0 if no diff is found,\n"+
 			"and exit code 1 if an error occurs.")
 	addSilenceEventsFlag(konnectDiffCmd.Flags())
+	return konnectDiffCmd
 }

--- a/cmd/konnect_dump.go
+++ b/cmd/konnect_dump.go
@@ -16,76 +16,75 @@ var (
 	konnectDumpWithID           bool
 )
 
-// konnectDumpCmd represents the dump2 command
-var konnectDumpCmd = &cobra.Command{
-	Use:   "dump",
-	Short: "Export configuration from Konnect (in alpha)",
-	Long: `The konnect dump command reads all entities present in Konnect
+// newKonnectDumpCmd represents the dump2 command
+func newKonnectDumpCmd() *cobra.Command {
+	konnectDumpCmd := &cobra.Command{
+		Use:   "dump",
+		Short: "Export configuration from Konnect (in alpha)",
+		Long: `The konnect dump command reads all entities present in Konnect
 	and writes them to a local file.
-	
+
 	The file can then be read using the 'deck konnect sync' command or 'deck konnect diff' command to
 	configure Konnect.` + konnectAlphaState,
-	Args: validateNoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		httpClient := utils.HTTPClient()
-		_ = sendAnalytics("konnect-dump", "")
+		Args: validateNoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			httpClient := utils.HTTPClient()
+			_ = sendAnalytics("konnect-dump", "")
 
-		if konnectDumpCmdKongStateFile == "-" {
-			return fmt.Errorf("writing to stdout is not supported in Konnect mode")
-		}
+			if konnectDumpCmdKongStateFile == "-" {
+				return fmt.Errorf("writing to stdout is not supported in Konnect mode")
+			}
 
-		if yes, err := utils.ConfirmFileOverwrite(konnectDumpCmdKongStateFile, dumpCmdStateFormat, assumeYes); err != nil {
-			return err
-		} else if !yes {
-			return nil
-		}
+			if yes, err := utils.ConfirmFileOverwrite(konnectDumpCmdKongStateFile, dumpCmdStateFormat, assumeYes); err != nil {
+				return err
+			} else if !yes {
+				return nil
+			}
 
-		// get Konnect client
-		konnectClient, err := utils.GetKonnectClient(httpClient, konnectConfig)
-		if err != nil {
-			return err
-		}
+			// get Konnect client
+			konnectClient, err := utils.GetKonnectClient(httpClient, konnectConfig)
+			if err != nil {
+				return err
+			}
 
-		// authenticate with konnect
-		_, err = konnectClient.Auth.Login(cmd.Context(),
-			konnectConfig.Email,
-			konnectConfig.Password)
-		if err != nil {
-			return fmt.Errorf("authenticating with Konnect: %w", err)
-		}
+			// authenticate with konnect
+			_, err = konnectClient.Auth.Login(cmd.Context(),
+				konnectConfig.Email,
+				konnectConfig.Password)
+			if err != nil {
+				return fmt.Errorf("authenticating with Konnect: %w", err)
+			}
 
-		// get kong control plane ID
-		kongCPID, err := fetchKongControlPlaneID(cmd.Context(), konnectClient)
-		if err != nil {
-			return err
-		}
+			// get kong control plane ID
+			kongCPID, err := fetchKongControlPlaneID(cmd.Context(), konnectClient)
+			if err != nil {
+				return err
+			}
 
-		// initialize kong client
-		kongClient, err := utils.GetKongClient(utils.KongClientConfig{
-			Address:    konnectConfig.Address + "/api/control_planes/" + kongCPID,
-			HTTPClient: httpClient,
-			Debug:      konnectConfig.Debug,
-		})
-		if err != nil {
-			return err
-		}
+			// initialize kong client
+			kongClient, err := utils.GetKongClient(utils.KongClientConfig{
+				Address:    konnectConfig.Address + "/api/control_planes/" + kongCPID,
+				HTTPClient: httpClient,
+				Debug:      konnectConfig.Debug,
+			})
+			if err != nil {
+				return err
+			}
 
-		ks, err := getKonnectState(cmd.Context(), kongClient, konnectClient, kongCPID,
-			!konnectDumpIncludeConsumers)
-		if err != nil {
-			return err
-		}
+			ks, err := getKonnectState(cmd.Context(), kongClient, konnectClient, kongCPID,
+				!konnectDumpIncludeConsumers)
+			if err != nil {
+				return err
+			}
 
-		return file.KonnectStateToFile(ks, file.WriteConfig{
-			Filename:   konnectDumpCmdKongStateFile,
-			FileFormat: file.Format(strings.ToUpper(konnectDumpCmdStateFormat)),
-			WithID:     dumpWithID,
-		})
-	},
-}
+			return file.KonnectStateToFile(ks, file.WriteConfig{
+				Filename:   konnectDumpCmdKongStateFile,
+				FileFormat: file.Format(strings.ToUpper(konnectDumpCmdStateFormat)),
+				WithID:     dumpWithID,
+			})
+		},
+	}
 
-func init() {
-	konnectCmd.AddCommand(konnectDumpCmd)
 	konnectDumpCmd.Flags().StringVarP(&konnectDumpCmdKongStateFile, "output-file", "o",
 		"konnect", "file to which to write Kong's configuration.")
 	konnectDumpCmd.Flags().StringVar(&konnectDumpCmdStateFormat, "format",
@@ -97,4 +96,5 @@ func init() {
 			"with consumers.")
 	konnectDumpCmd.Flags().BoolVar(&assumeYes, "yes",
 		false, "Assume 'yes' to prompts and run non-interactively.")
+	return konnectDumpCmd
 }

--- a/cmd/konnect_ping.go
+++ b/cmd/konnect_ping.go
@@ -7,34 +7,32 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// konnectPingCmd represents the ping2 command
-var konnectPingCmd = &cobra.Command{
-	Use:   "ping",
-	Short: "Verify connectivity with Konnect (in alpha)",
-	Long: `The konnect ping command can be used to verify if decK
+// newKonnectPingCmd represents the ping2 command
+func newKonnectPingCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "ping",
+		Short: "Verify connectivity with Konnect (in alpha)",
+		Long: `The konnect ping command can be used to verify if decK
 can connect to Konnect's API endpoint. It also validates the supplied
 credentials.` + konnectAlphaState,
-	Args: validateNoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		_ = sendAnalytics("konnect-ping", "")
-		client, err := utils.GetKonnectClient(nil, konnectConfig)
-		if err != nil {
-			return err
-		}
-		res, err := client.Auth.Login(cmd.Context(), konnectConfig.Email,
-			konnectConfig.Password)
-		if err != nil {
-			return fmt.Errorf("authenticating with Konnect: %w", err)
-		}
-		fmt.Printf("Successfully Konnected as %s %s (%s)!\n",
-			res.FirstName, res.LastName, res.Organization)
-		if konnectConfig.Debug {
-			fmt.Printf("Organization ID: %s\n", res.OrganizationID)
-		}
-		return nil
-	},
-}
-
-func init() {
-	konnectCmd.AddCommand(konnectPingCmd)
+		Args: validateNoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_ = sendAnalytics("konnect-ping", "")
+			client, err := utils.GetKonnectClient(nil, konnectConfig)
+			if err != nil {
+				return err
+			}
+			res, err := client.Auth.Login(cmd.Context(), konnectConfig.Email,
+				konnectConfig.Password)
+			if err != nil {
+				return fmt.Errorf("authenticating with Konnect: %w", err)
+			}
+			fmt.Printf("Successfully Konnected as %s %s (%s)!\n",
+				res.FirstName, res.LastName, res.Organization)
+			if konnectConfig.Debug {
+				fmt.Printf("Organization ID: %s\n", res.OrganizationID)
+			}
+			return nil
+		},
+	}
 }

--- a/cmd/konnect_sync.go
+++ b/cmd/konnect_sync.go
@@ -6,29 +6,28 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// konnectSyncCmd represents the 'deck konnect diff' command.
-var konnectSyncCmd = &cobra.Command{
-	Use: "sync",
-	Short: "Sync performs operations to get Konnect's configuration " +
-		"to match the state file (in alpha)",
-	Long: `The konnect sync command reads the state file and performs operations in Konnect
+// newKonnectSyncCmd represents the 'deck konnect diff' command.
+func newKonnectSyncCmd() *cobra.Command {
+	konnectSyncCmd := &cobra.Command{
+		Use: "sync",
+		Short: "Sync performs operations to get Konnect's configuration " +
+			"to match the state file (in alpha)",
+		Long: `The konnect sync command reads the state file and performs operations in Konnect
 to get Konnect's state in sync with the input state.` + konnectAlphaState,
-	Args: validateNoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if konnectDumpCmdKongStateFile == "-" {
-			return fmt.Errorf("writing to stdout is not supported in Konnect mode")
-		}
-		_ = sendAnalytics("konnect-sync", "")
-		return syncKonnect(cmd.Context(), konnectDiffCmdKongStateFile, false,
-			konnectDiffCmdParallelism)
-	},
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		return preRunSilenceEventsFlag()
-	},
-}
+		Args: validateNoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if konnectDumpCmdKongStateFile == "-" {
+				return fmt.Errorf("writing to stdout is not supported in Konnect mode")
+			}
+			_ = sendAnalytics("konnect-sync", "")
+			return syncKonnect(cmd.Context(), konnectDiffCmdKongStateFile, false,
+				konnectDiffCmdParallelism)
+		},
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return preRunSilenceEventsFlag()
+		},
+	}
 
-func init() {
-	konnectCmd.AddCommand(konnectSyncCmd)
 	konnectSyncCmd.Flags().StringSliceVarP(&konnectDiffCmdKongStateFile,
 		"state", "s", []string{"konnect.yaml"}, "file(s) containing Konnect's configuration.\n"+
 			"This flag can be specified multiple times for multiple files.")
@@ -38,4 +37,5 @@ func init() {
 	konnectSyncCmd.Flags().IntVar(&konnectDiffCmdParallelism, "parallelism",
 		100, "Maximum number of concurrent operations.")
 	addSilenceEventsFlag(konnectSyncCmd.Flags())
+	return konnectSyncCmd
 }

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -8,32 +8,32 @@ import (
 
 var pingWorkspace string
 
-// pingCmd represents the ping command
-var pingCmd = &cobra.Command{
-	Use:   "ping",
-	Short: "Verify connectivity with Kong",
-	Long: `The ping command can be used to verify if decK
+// newPingCmd represents the ping command
+func newPingCmd() *cobra.Command {
+	pingCmd := &cobra.Command{
+		Use:   "ping",
+		Short: "Verify connectivity with Kong",
+		Long: `The ping command can be used to verify if decK
 can connect to Kong's Admin API.`,
-	Args: validateNoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx := cmd.Context()
+		Args: validateNoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 
-		wsConfig := rootConfig.ForWorkspace(pingWorkspace)
-		version, err := fetchKongVersion(ctx, wsConfig)
-		if err != nil {
-			return fmt.Errorf("reading Kong version: %w", err)
-		}
-		_ = sendAnalytics("ping", version)
-		fmt.Println("Successfully connected to Kong!")
-		fmt.Println("Kong version: ", version)
-		return nil
-	},
-}
+			wsConfig := rootConfig.ForWorkspace(pingWorkspace)
+			version, err := fetchKongVersion(ctx, wsConfig)
+			if err != nil {
+				return fmt.Errorf("reading Kong version: %w", err)
+			}
+			_ = sendAnalytics("ping", version)
+			fmt.Println("Successfully connected to Kong!")
+			fmt.Println("Kong version: ", version)
+			return nil
+		},
+	}
 
-func init() {
-	rootCmd.AddCommand(pingCmd)
 	pingCmd.Flags().StringVarP(&pingWorkspace, "workspace", "w",
 		"", "Ping configuration with a specific Workspace "+
 			"(Kong Enterprise only).\n"+
 			"Useful when RBAC permissions are scoped to a Workspace.")
+	return pingCmd
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -7,35 +7,34 @@ import (
 )
 
 var (
-	syncCmdKongStateFile []string
 	syncCmdParallelism   int
 	syncCmdDBUpdateDelay int
 	syncWorkspace        string
 )
 
-// syncCmd represents the sync command
-var syncCmd = &cobra.Command{
-	Use: "sync",
-	Short: "Sync performs operations to get Kong's configuration " +
-		"to match the state file",
-	Long: `The sync command reads the state file and performs operation on Kong
+// newSyncCmd represents the sync command
+func newSyncCmd() *cobra.Command {
+	var syncCmdKongStateFile []string
+	syncCmd := &cobra.Command{
+		Use: "sync",
+		Short: "Sync performs operations to get Kong's configuration " +
+			"to match the state file",
+		Long: `The sync command reads the state file and performs operation on Kong
 to get Kong's state in sync with the input state.`,
-	Args: validateNoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return syncMain(cmd.Context(), syncCmdKongStateFile, false,
-			syncCmdParallelism, syncCmdDBUpdateDelay, syncWorkspace)
-	},
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		if len(syncCmdKongStateFile) == 0 {
-			return fmt.Errorf("a state file with Kong's configuration " +
-				"must be specified using -s/--state flag")
-		}
-		return preRunSilenceEventsFlag()
-	},
-}
+		Args: validateNoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return syncMain(cmd.Context(), syncCmdKongStateFile, false,
+				syncCmdParallelism, syncCmdDBUpdateDelay, syncWorkspace)
+		},
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if len(syncCmdKongStateFile) == 0 {
+				return fmt.Errorf("a state file with Kong's configuration " +
+					"must be specified using -s/--state flag")
+			}
+			return preRunSilenceEventsFlag()
+		},
+	}
 
-func init() {
-	rootCmd.AddCommand(syncCmd)
 	syncCmd.Flags().StringSliceVarP(&syncCmdKongStateFile,
 		"state", "s", []string{"kong.yaml"}, "file(s) containing Kong's configuration.\n"+
 			"This flag can be specified multiple times for multiple files.\n"+
@@ -60,4 +59,5 @@ func init() {
 			"for related entities (usually for Cassandra deployments).\n"+
 			"See 'db_update_propagation' in kong.conf.")
 	addSilenceEventsFlag(syncCmd.Flags())
+	return syncCmd
 }

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -21,11 +21,12 @@ var (
 	validateParallelism          int
 )
 
-// validateCmd represents the diff command
-var validateCmd = &cobra.Command{
-	Use:   "validate",
-	Short: "Validate the state file",
-	Long: `The validate command reads the state file and ensures validity.
+// newValidateCmd represents the diff command
+func newValidateCmd() *cobra.Command {
+	validateCmd := &cobra.Command{
+		Use:   "validate",
+		Short: "Validate the state file",
+		Long: `The validate command reads the state file and ensures validity.
 It reads all the specified state files and reports YAML/JSON
 parsing issues. It also checks for foreign relationships
 and alerts if there are broken relationships, or missing links present.
@@ -33,58 +34,80 @@ and alerts if there are broken relationships, or missing links present.
 No communication takes places between decK and Kong during the execution of
 this command unless --online flag is used.
 `,
-	Args: validateNoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		_ = sendAnalytics("validate", "")
-		// read target file
-		// this does json schema validation as well
-		targetContent, err := file.GetContentFromFiles(validateCmdKongStateFile)
-		if err != nil {
-			return err
-		}
-
-		dummyEmptyState, err := state.NewKongState()
-		if err != nil {
-			return err
-		}
-		ctx := cmd.Context()
-		var kongClient *kong.Client
-		if validateOnline {
-			kongClient, err = getKongClient(ctx, targetContent)
+		Args: validateNoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_ = sendAnalytics("validate", "")
+			// read target file
+			// this does json schema validation as well
+			targetContent, err := file.GetContentFromFiles(validateCmdKongStateFile)
 			if err != nil {
 				return err
 			}
-		}
 
-		rawState, err := file.Get(ctx, targetContent, file.RenderConfig{
-			CurrentState: dummyEmptyState,
-		}, dump.Config{}, kongClient)
-		if err != nil {
-			return err
-		}
-		if err := checkForRBACResources(*rawState, validateCmdRBACResourcesOnly); err != nil {
-			return err
-		}
-		// this catches foreign relation errors
-		ks, err := state.Get(rawState)
-		if err != nil {
-			return err
-		}
-
-		if validateOnline {
-			if errs := validateWithKong(ctx, kongClient, ks); len(errs) != 0 {
-				return validate.ErrorsWrapper{Errors: errs}
+			dummyEmptyState, err := state.NewKongState()
+			if err != nil {
+				return err
 			}
-		}
-		return nil
-	},
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		if len(validateCmdKongStateFile) == 0 {
-			return fmt.Errorf("a state file with Kong's configuration " +
-				"must be specified using -s/--state flag")
-		}
-		return nil
-	},
+			ctx := cmd.Context()
+			var kongClient *kong.Client
+			if validateOnline {
+				kongClient, err = getKongClient(ctx, targetContent)
+				if err != nil {
+					return err
+				}
+			}
+
+			rawState, err := file.Get(ctx, targetContent, file.RenderConfig{
+				CurrentState: dummyEmptyState,
+			}, dump.Config{}, kongClient)
+			if err != nil {
+				return err
+			}
+			if err := checkForRBACResources(*rawState, validateCmdRBACResourcesOnly); err != nil {
+				return err
+			}
+			// this catches foreign relation errors
+			ks, err := state.Get(rawState)
+			if err != nil {
+				return err
+			}
+
+			if validateOnline {
+				if errs := validateWithKong(ctx, kongClient, ks); len(errs) != 0 {
+					return validate.ErrorsWrapper{Errors: errs}
+				}
+			}
+			return nil
+		},
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if len(validateCmdKongStateFile) == 0 {
+				return fmt.Errorf("a state file with Kong's configuration " +
+					"must be specified using -s/--state flag")
+			}
+			return nil
+		},
+	}
+	validateCmd.Flags().BoolVar(&validateCmdRBACResourcesOnly, "rbac-resources-only",
+		false, "indicate that the state file(s) contains RBAC resources only (Kong Enterprise only).")
+	validateCmd.Flags().StringSliceVarP(&validateCmdKongStateFile,
+		"state", "s", []string{"kong.yaml"}, "file(s) containing Kong's configuration.\n"+
+			"This flag can be specified multiple times for multiple files.\n"+
+			"Use '-' to read from stdin.")
+	validateCmd.Flags().BoolVar(&validateOnline, "online",
+		false, "perform validations against Kong API. When this flag is used, validation is done\n"+
+			"via communication with Kong. This increases the time for validation but catches \n"+
+			"significant errors. No resource is created in Kong.")
+	validateCmd.Flags().StringVarP(&validateWorkspace, "workspace", "w",
+		"", "validate configuration of a specific workspace "+
+			"(Kong Enterprise only).\n"+
+			"This takes precedence over _workspace fields in state files.")
+	validateCmd.Flags().IntVar(&validateParallelism, "parallelism",
+		10, "Maximum number of concurrent requests to Kong.")
+
+	if err := ensureGetAllMethods(); err != nil {
+		panic(err.Error())
+	}
+	return validateCmd
 }
 
 func validateWithKong(ctx context.Context, kongClient *kong.Client, ks *state.KongState) []error {
@@ -187,28 +210,4 @@ func ensureGetAllMethods() error {
 		return err
 	}
 	return nil
-}
-
-func init() {
-	rootCmd.AddCommand(validateCmd)
-	validateCmd.Flags().BoolVar(&validateCmdRBACResourcesOnly, "rbac-resources-only",
-		false, "indicate that the state file(s) contains RBAC resources only (Kong Enterprise only).")
-	validateCmd.Flags().StringSliceVarP(&validateCmdKongStateFile,
-		"state", "s", []string{"kong.yaml"}, "file(s) containing Kong's configuration.\n"+
-			"This flag can be specified multiple times for multiple files.\n"+
-			"Use '-' to read from stdin.")
-	validateCmd.Flags().BoolVar(&validateOnline, "online",
-		false, "perform validations against Kong API. When this flag is used, validation is done\n"+
-			"via communication with Kong. This increases the time for validation but catches \n"+
-			"significant errors. No resource is created in Kong.")
-	validateCmd.Flags().StringVarP(&validateWorkspace, "workspace", "w",
-		"", "validate configuration of a specific workspace "+
-			"(Kong Enterprise only).\n"+
-			"This takes precedence over _workspace fields in state files.")
-	validateCmd.Flags().IntVar(&validateParallelism, "parallelism",
-		10, "Maximum number of concurrent requests to Kong.")
-
-	if err := ensureGetAllMethods(); err != nil {
-		panic(err.Error())
-	}
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -14,18 +14,16 @@ var VERSION = "dev"
 // This should be substituted by Git commit hash  during the build process.
 var COMMIT = "unknown"
 
-// versionCmd represents the version command
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Print the decK version",
-	Long: `The version command prints the version of decK along with a Git short
+// newVersionCmd represents the version command
+func newVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the decK version",
+		Long: `The version command prints the version of decK along with a Git short
 commit hash of the source tree.`,
-	Args: validateNoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("decK %s (%s) \n", VERSION, COMMIT)
-	},
-}
-
-func init() {
-	rootCmd.AddCommand(versionCmd)
+		Args: validateNoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("decK %s (%s) \n", VERSION, COMMIT)
+		},
+	}
 }

--- a/docs/generate-docs.go
+++ b/docs/generate-docs.go
@@ -13,7 +13,7 @@ func main() {
 	flag.StringVar(&outputPath, "output-path", ".", "path to output directory")
 	flag.Parse()
 
-	err := doc.GenMarkdownTree(cmd.RootCmdOnlyForDocsAndTest, outputPath)
+	err := doc.GenMarkdownTree(cmd.NewRootCmd(), outputPath)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -13,20 +13,7 @@ import (
 	"github.com/kong/deck/dump"
 	"github.com/kong/deck/utils"
 	"github.com/kong/go-kong/kong"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
-
-var deckCmd = cmd.RootCmdOnlyForDocsAndTest
-
-var syncCmd = func() *cobra.Command {
-	for _, command := range deckCmd.Commands() {
-		if command.Use == "sync" {
-			return command
-		}
-	}
-	return nil
-}
 
 var (
 	// missing Enable
@@ -257,6 +244,7 @@ func testKongState(t *testing.T, client *kong.Client,
 }
 
 func reset(t *testing.T) {
+	deckCmd := cmd.NewRootCmd()
 	deckCmd.SetArgs([]string{"reset", "--force"})
 	if err := deckCmd.Execute(); err != nil {
 		t.Fatalf(err.Error(), "failed to reset Kong's state")
@@ -270,16 +258,9 @@ func setup(t *testing.T) func(t *testing.T) {
 }
 
 func sync(kongFile string) {
-	// set the --state flag directly due to slice
-	// flags value are persisted across test cases, and not
-	// overwritable otherwise.
-	stateFlag := syncCmd().Flags().Lookup("state")
-	if val, ok := stateFlag.Value.(pflag.SliceValue); ok {
-		_ = val.Replace([]string{kongFile})
-	}
-
-	deckCmd.SetArgs([]string{"sync"})
-	deckCmd.Execute()
+	deckCmd := cmd.NewRootCmd()
+	deckCmd.SetArgs([]string{"sync", "-s", kongFile})
+	deckCmd.ExecuteContext(context.Background())
 }
 
 // test scope:


### PR DESCRIPTION
The current version of the `cmd` package is structured
around some global variables holding the `cobra` commands.
This makes the package hard to test.

This reworks the `cobra` commands definition with 'constructor' helpers.
This also rearranges the existing flags, moving the ones specific
to `konnect` under the `konnect` subcommand.