### PR TITLE
fix: plugin defaults ingestion breaks dedup

### DIFF
--- a/file/builder.go
+++ b/file/builder.go
@@ -829,9 +829,6 @@ func (b *stateBuilder) addPluginDefaults(plugin *FPlugin) error {
 func (b *stateBuilder) ingestPlugins(plugins []FPlugin) error {
 	for _, p := range plugins {
 		p := p
-		if err := b.addPluginDefaults(&p); err != nil {
-			return fmt.Errorf("add defaults to plugin '%v': %v", *p.Name, err)
-		}
 		if utils.Empty(p.ID) {
 			cID, rID, sID := pluginRelations(&p.Plugin)
 			plugin, err := b.currentState.Plugins.GetByProp(*p.Name,
@@ -851,6 +848,9 @@ func (b *stateBuilder) ingestPlugins(plugins []FPlugin) error {
 		err := b.fillPluginConfig(&p)
 		if err != nil {
 			return err
+		}
+		if err := b.addPluginDefaults(&p); err != nil {
+			return fmt.Errorf("add defaults to plugin '%v': %v", *p.Name, err)
 		}
 		utils.MustMergeTags(&p, b.selectTags)
 		b.rawState.Plugins = append(b.rawState.Plugins, &p.Plugin)

--- a/tests/integration/testdata/sync/006-fill-defaults-rate-limiting/kong.yaml
+++ b/tests/integration/testdata/sync/006-fill-defaults-rate-limiting/kong.yaml
@@ -1,0 +1,4 @@
+plugins:
+  - name: rate-limiting
+    config:
+      minute: 123

--- a/tests/integration/testdata/sync/007-fill-defaults-rate-limiting-dedup/kong.yaml
+++ b/tests/integration/testdata/sync/007-fill-defaults-rate-limiting-dedup/kong.yaml
@@ -1,0 +1,7 @@
+_plugin_configs:
+  rate-limiting-one:
+    minute: 123
+
+plugins:
+  - name: rate-limiting
+    _config: rate-limiting-one


### PR DESCRIPTION
Defaults ingestion is happening before filling the
de-duplicate plugins configuration, meaning that
de-duplicate plugins will not benefit of automatic
defaults.

This reverts the order of the two operations.

Before:

```
$ cat kong.yaml
_format_version: "2.1"

_plugin_configs:
  rate-limiting-one:
    minute: 6000
    policy: local
    hide_client_headers: true

services:
- name: sample
  url: https://example.org
  plugins:
    - name: rate-limiting
      _config: rate-limiting-one
  routes:
  - name: sample
    paths:
    - /sample
```

```
$ deck sync
creating plugin rate-limiting for service 6c11f78b-4b12-4556-8058-0bb26832c076
Summary:
  Created: 0
  Updated: 0
  Deleted: 0
Error: 1 errors occurred:
	while processing event: {Create} plugin rate-limiting for service 6c11f78b-4b12-4556-8058-0bb26832c076 failed: HTTP status 400 (message: "schema violation (at least one of these fields must be non-empty: 'config.second', 'config.minute', 'config.hour', 'config.day', 'config.month', 'config.year')")
```

After:

```
$ deck validate --online

$ deck sync
Summary:
  Created: 0
  Updated: 0
  Deleted: 0
```

Relates to https://github.com/Kong/deck/issues/593