### PR TITLE
fix(builder) set strip_path after defaults

### DIFF
--- a/file/builder_test.go
+++ b/file/builder_test.go
@@ -526,6 +526,33 @@ func Test_stateBuilder_ingestRoute(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "grpc route has strip_path=false",
+			fields: fields{
+				currentState: existingRouteState(),
+			},
+			args: args{
+				route: FRoute{
+					Route: kong.Route{
+						Name:      kong.String("foo"),
+						Protocols: kong.StringSlice("grpc"),
+					},
+				},
+			},
+			wantErr: false,
+			wantState: &utils.KongRawState{
+				Routes: []*kong.Route{
+					{
+						ID:            kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
+						Name:          kong.String("foo"),
+						PreserveHost:  kong.Bool(false),
+						RegexPriority: kong.Int(0),
+						StripPath:     kong.Bool(false),
+						Protocols:     kong.StringSlice("grpc"),
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Edit: the original rationale was wrong, I didn't realize we needed to re-add the mergo replace to KIC modules. This is now only the test.

https://github.com/Kong/kubernetes-ingress-controller/pull/2286 failed when trying to add v1.11.0 to KIC. Something appears to have happened after I tested with https://github.com/Kong/deck/pull/573.

Within ingresRoute, the value is `false` as expected after it's set to the result of `getStripPathBasedOnProtocols()`. It flips back to `true` after https://github.com/Kong/deck/blob/v1.11.0/file/builder.go#L786

I thought this maybe meant something didn't work as expected with https://github.com/Kong/deck/pull/580, but as these were already `*bool` any non-nil value is not zero, so I'm not sure why the default was merging over the original value.

The change here does fix the issue, but I'd like to better understand what's going on here if possible.
