### PR TITLE
fix: support defaulter with not-existing workspaces

### DIFF
--- a/file/builder.go
+++ b/file/builder.go
@@ -813,7 +813,7 @@ func (b *stateBuilder) getPluginSchema(pluginName string) (map[string]interface{
 
 	exists, err := utils.WorkspaceExists(b.ctx, b.client)
 	if err != nil {
-		return nil, fmt.Errorf("getPluginSchema: checking if workspace exists: %w", err)
+		return nil, fmt.Errorf("ensure workspace exists: %w", err)
 	}
 	if !exists {
 		return schema, nil

--- a/file/builder.go
+++ b/file/builder.go
@@ -810,7 +810,16 @@ func (b *stateBuilder) getPluginSchema(pluginName string) (map[string]interface{
 	if schema, ok := b.schemasCache[pluginName]; ok {
 		return schema, nil
 	}
-	schema, err := b.client.Plugins.GetFullSchema(b.ctx, &pluginName)
+
+	exists, err := utils.WorkspaceExists(b.ctx, b.client)
+	if err != nil {
+		return nil, fmt.Errorf("getPluginSchema: checking if workspace exists: %w", err)
+	}
+	if !exists {
+		return schema, nil
+	}
+
+	schema, err = b.client.Plugins.GetFullSchema(b.ctx, &pluginName)
 	if err != nil {
 		return schema, err
 	}

--- a/tests/integration/diff_test.go
+++ b/tests/integration/diff_test.go
@@ -1,0 +1,32 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/kong/deck/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Diff_Workspace(t *testing.T) {
+	tests := []struct {
+		name          string
+		stateFile     string
+		expectedState utils.KongRawState
+	}{
+		{
+			name:      "diff with not existent workspace doesn't error out",
+			stateFile: "testdata/diff/001-not-existing-workspace/kong.yaml",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			teardown := setup(t)
+			defer teardown(t)
+
+			err := diff(tc.stateFile)
+			assert.Nil(t, err)
+		})
+	}
+}

--- a/tests/integration/test_utils.go
+++ b/tests/integration/test_utils.go
@@ -100,3 +100,13 @@ func sync(kongFile string, opts ...string) {
 	deckCmd.SetArgs(args)
 	deckCmd.ExecuteContext(context.Background()) //nolint:errcheck
 }
+
+func diff(kongFile string, opts ...string) error {
+	deckCmd := cmd.NewRootCmd()
+	args := []string{"diff", "-s", kongFile}
+	if len(opts) > 0 {
+		args = append(args, opts...)
+	}
+	deckCmd.SetArgs(args)
+	return deckCmd.ExecuteContext(context.Background())
+}

--- a/tests/integration/testdata/diff/001-not-existing-workspace/kong.yaml
+++ b/tests/integration/testdata/diff/001-not-existing-workspace/kong.yaml
@@ -1,0 +1,4 @@
+_workspace: test
+services:
+- name: svc1
+  host: mockbin.org

--- a/utils/defaulter.go
+++ b/utils/defaulter.go
@@ -225,7 +225,11 @@ func getKongDefaulterWithClient(ctx context.Context, opts DefaulterOpts) (*Defau
 // 3. schema defaults coming from Admin API (excluded Konnect)
 // 4. hardcoded defaults under utils/constants.go (Konnect-only)
 func GetDefaulter(ctx context.Context, opts DefaulterOpts) (*Defaulter, error) {
-	if opts.Client != nil && !opts.DisableDynamicDefaults {
+	exists, err := WorkspaceExists(ctx, opts.Client)
+	if err != nil {
+		return nil, fmt.Errorf("defaulter: checking if workspace exists: %w", err)
+	}
+	if opts.Client != nil && !opts.DisableDynamicDefaults && exists {
 		return getKongDefaulterWithClient(ctx, opts)
 	}
 	opts.DisableDynamicDefaults = true

--- a/utils/defaulter.go
+++ b/utils/defaulter.go
@@ -227,7 +227,7 @@ func getKongDefaulterWithClient(ctx context.Context, opts DefaulterOpts) (*Defau
 func GetDefaulter(ctx context.Context, opts DefaulterOpts) (*Defaulter, error) {
 	exists, err := WorkspaceExists(ctx, opts.Client)
 	if err != nil {
-		return nil, fmt.Errorf("defaulter: checking if workspace exists: %w", err)
+		return nil, fmt.Errorf("ensure workspace exists: %w", err)
 	}
 	if opts.Client != nil && !opts.DisableDynamicDefaults && exists {
 		return getKongDefaulterWithClient(ctx, opts)

--- a/utils/types.go
+++ b/utils/types.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -168,9 +167,6 @@ func GetKongClient(opt KongClientConfig) (*kong.Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse kong address: %w", err)
 	}
-	if opt.Workspace != "" {
-		url.Path = path.Join(url.Path, opt.Workspace)
-	}
 	// Add Session Cookie support if required
 	if opt.CookieJarPath != "" {
 		jar, err := cookiejarparser.LoadCookieJarFile(opt.CookieJarPath)
@@ -187,6 +183,9 @@ func GetKongClient(opt KongClientConfig) (*kong.Client, error) {
 	if opt.Debug {
 		kongClient.SetDebugMode(true)
 		kongClient.SetLogger(os.Stderr)
+	}
+	if opt.Workspace != "" {
+		kongClient.SetWorkspace(opt.Workspace)
 	}
 	return kongClient, nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -8,6 +9,8 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+
+	"github.com/kong/go-kong/kong"
 )
 
 var kongVersionRegex = regexp.MustCompile(`^\d+\.\d+`)
@@ -86,4 +89,15 @@ func RemoveDuplicates(slice *[]string) {
 		newSlice = append(newSlice, s)
 	}
 	*slice = newSlice
+}
+
+func WorkspaceExists(ctx context.Context, client *kong.Client) (bool, error) {
+	if client == nil {
+		return false, nil
+	}
+	workspace := client.Workspace()
+	if workspace == "" {
+		return true, nil
+	}
+	return client.Workspaces.Exists(ctx, &workspace)
 }


### PR DESCRIPTION
The new defaulter interacts with Kong API to retrieve
entities schemas. Doing such query against a not existing
workspace returns an error, blocking the diff operation in decK.

This makes sure decK can run 'diff' regardless of the workspace
by simply not retrieving entities schemas from Kong when the
workspace doesn't exist yet.

Solves https://github.com/Kong/deck/issues/601#issuecomment-1057647420