### PR TITLE
Add basic validation for restricted fields

### DIFF
--- a/file/builder_test.go
+++ b/file/builder_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 const (
-	defaultPort        = 80
 	defaultTimeout     = 60000
 	defaultSlots       = 10000
 	defaultWeight      = 100
@@ -28,7 +27,6 @@ var kong130Version = semver.MustParse("1.3.0")
 
 var kongDefaults = KongDefaults{
 	Service: &kong.Service{
-		Port:           kong.Int(defaultPort),
 		Protocol:       kong.String("http"),
 		ConnectTimeout: kong.Int(defaultTimeout),
 		WriteTimeout:   kong.Int(defaultTimeout),
@@ -402,7 +400,6 @@ func Test_stateBuilder_services(t *testing.T) {
 					{
 						ID:             kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						Name:           kong.String("foo"),
-						Port:           kong.Int(80),
 						Protocol:       kong.String("http"),
 						ConnectTimeout: kong.Int(60000),
 						WriteTimeout:   kong.Int(60000),
@@ -434,7 +431,6 @@ func Test_stateBuilder_services(t *testing.T) {
 					{
 						ID:             kong.String("538c7f96-b164-4f1b-97bb-9f4bb472e89f"),
 						Name:           kong.String("foo"),
-						Port:           kong.Int(80),
 						Protocol:       kong.String("http"),
 						ConnectTimeout: kong.Int(60000),
 						WriteTimeout:   kong.Int(60000),
@@ -2028,7 +2024,6 @@ func Test_stateBuilder(t *testing.T) {
 					{
 						ID:             kong.String("538c7f96-b164-4f1b-97bb-9f4bb472e89f"),
 						Name:           kong.String("foo-service"),
-						Port:           kong.Int(80),
 						Protocol:       kong.String("http"),
 						ConnectTimeout: kong.Int(60000),
 						WriteTimeout:   kong.Int(60000),
@@ -2037,7 +2032,6 @@ func Test_stateBuilder(t *testing.T) {
 					{
 						ID:             kong.String("dfd79b4d-7642-4b61-ba0c-9f9f0d3ba55b"),
 						Name:           kong.String("bar-service"),
-						Port:           kong.Int(80),
 						Protocol:       kong.String("http"),
 						ConnectTimeout: kong.Int(60000),
 						WriteTimeout:   kong.Int(60000),
@@ -2046,7 +2040,6 @@ func Test_stateBuilder(t *testing.T) {
 					{
 						ID:             kong.String("9e6f82e5-4e74-4e81-a79e-4bbd6fe34cdc"),
 						Name:           kong.String("large-payload-service"),
-						Port:           kong.Int(80),
 						Protocol:       kong.String("http"),
 						ConnectTimeout: kong.Int(60000),
 						WriteTimeout:   kong.Int(60000),
@@ -2188,7 +2181,6 @@ func Test_stateBuilder(t *testing.T) {
 								RequestBuffering: kong.Bool(false),
 							},
 							Service: &kong.Service{
-								Port:           kong.Int(443),
 								Protocol:       kong.String("https"),
 								ConnectTimeout: kong.Int(5000),
 								WriteTimeout:   kong.Int(5000),
@@ -2312,7 +2304,6 @@ func Test_stateBuilder(t *testing.T) {
 					{
 						ID:             kong.String("538c7f96-b164-4f1b-97bb-9f4bb472e89f"),
 						Name:           kong.String("foo-service"),
-						Port:           kong.Int(443),
 						Protocol:       kong.String("https"),
 						ConnectTimeout: kong.Int(5000),
 						WriteTimeout:   kong.Int(5000),
@@ -2321,7 +2312,6 @@ func Test_stateBuilder(t *testing.T) {
 					{
 						ID:             kong.String("dfd79b4d-7642-4b61-ba0c-9f9f0d3ba55b"),
 						Name:           kong.String("bar-service"),
-						Port:           kong.Int(443),
 						Protocol:       kong.String("https"),
 						ConnectTimeout: kong.Int(5000),
 						WriteTimeout:   kong.Int(5000),
@@ -2330,7 +2320,6 @@ func Test_stateBuilder(t *testing.T) {
 					{
 						ID:             kong.String("9e6f82e5-4e74-4e81-a79e-4bbd6fe34cdc"),
 						Name:           kong.String("large-payload-service"),
-						Port:           kong.Int(443),
 						Protocol:       kong.String("https"),
 						ConnectTimeout: kong.Int(5000),
 						WriteTimeout:   kong.Int(5000),

--- a/utils/constants.go
+++ b/utils/constants.go
@@ -5,7 +5,6 @@ import (
 )
 
 const (
-//	defaultPort        = 80
 	defaultTimeout     = 60000
 	defaultSlots       = 10000
 	defaultWeight      = 100
@@ -71,10 +70,10 @@ var (
 		HashOnCookiePath: kong.String("/"),
 	}
 	defaultsRestrictedFields = map[string][]string{
-		"service": {"ID", "Host", "Name", "Port"},
-		"route": {"ID", "Name"},
-		"target": {"ID"}, // TODO check what is target4..
-		"upstream": {"ID", "Name"},
+		"Service":  {"ID", "Host", "Name", "Port"},
+		"Route":    {"ID", "Name"},
+		"Target":   {"ID", "Target"},
+		"Upstream": {"ID", "Name"},
 	}
 )
 

--- a/utils/constants.go
+++ b/utils/constants.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	defaultPort        = 80
+//	defaultPort        = 80
 	defaultTimeout     = 60000
 	defaultSlots       = 10000
 	defaultWeight      = 100
@@ -14,7 +14,6 @@ const (
 
 var (
 	serviceDefaults = kong.Service{
-		Port:           kong.Int(defaultPort),
 		Protocol:       kong.String("http"),
 		ConnectTimeout: kong.Int(defaultTimeout),
 		WriteTimeout:   kong.Int(defaultTimeout),
@@ -70,6 +69,12 @@ var (
 		HashOn:           kong.String("none"),
 		HashFallback:     kong.String("none"),
 		HashOnCookiePath: kong.String("/"),
+	}
+	defaultsRestrictedFields = map[string][]string{
+		"service": {"ID", "Host", "Name", "Port"},
+		"route": {"ID", "Name"},
+		"target": {"ID"}, // TODO check what is target4..
+		"upstream": {"ID", "Name"},
 	}
 )
 

--- a/utils/defaulter.go
+++ b/utils/defaulter.go
@@ -258,7 +258,7 @@ func GetDefaulter(ctx context.Context, opts DefaulterOpts) (*Defaulter, error) {
 func (d *Defaulter) populateDefaultsFromInput(defaults interface{}) error {
 	err := validateKongDefaults(defaults)
 	if err != nil {
-		return fmt.Errorf("%w", err)
+		return fmt.Errorf("validating defaults: %w", err)
 	}
 
 	r := reflect.ValueOf(defaults)

--- a/utils/defaulter_test.go
+++ b/utils/defaulter_test.go
@@ -529,7 +529,7 @@ func TestGetDefaulter_Konnect(t *testing.T) {
 				KongDefaults: &kongDefaultForTesting{
 					Service: &kong.Service{
 						Path:           kong.String("/v1"),
-					  Protocol:       kong.String("http"),
+						Protocol:       kong.String("http"),
 						ConnectTimeout: kong.Int(defaultTimeout),
 						WriteTimeout:   kong.Int(defaultTimeout),
 						ReadTimeout:    kong.Int(defaultTimeout),
@@ -574,42 +574,41 @@ func TestGetDefaulter_Konnect(t *testing.T) {
 	}
 }
 
-
 func TestCheckRestrictedFields(t *testing.T) {
 	assert := assert.New(t)
 
 	testCases := []struct {
-		desc string
-		entity *kong.Service
+		desc             string
+		entity           *kong.Service
 		restrictedFields []string
-		invalidFields []string
+		invalidFields    []string
 	}{
 		{
 			desc: "no restricted fields",
-			entity:  &kong.Service{
-				ID: kong.String("testID"),
+			entity: &kong.Service{
+				ID:   kong.String("testID"),
 				Name: kong.String("testName"),
 			},
 			restrictedFields: []string{},
 		},
 		{
 			desc: "one restricted fields",
-			entity:  &kong.Service{
-				ID: kong.String("testID"),
+			entity: &kong.Service{
+				ID:   kong.String("testID"),
 				Name: kong.String("testName"),
 			},
 			restrictedFields: []string{"ID"},
-			invalidFields: []string{"ID"},
+			invalidFields:    []string{"ID"},
 		},
 		{
 			desc: "multiple restricted fields",
-			entity:  &kong.Service{
-				ID: kong.String("testID"),
+			entity: &kong.Service{
+				ID:   kong.String("testID"),
 				Name: kong.String("testName"),
 				Port: kong.Int(80),
 			},
 			restrictedFields: []string{"ID", "Name", "Port"},
-			invalidFields: []string{"ID", "Name", "Port"},
+			invalidFields:    []string{"ID", "Name", "Port"},
 		},
 	}
 
@@ -618,7 +617,7 @@ func TestCheckRestrictedFields(t *testing.T) {
 			err := checkEntityDefaults(tC.entity, tC.restrictedFields)
 			if len(tC.invalidFields) > 0 {
 				assert.NotNil(err)
-				assert.Contains(err.Error(), strings.Join(tC.invalidFields, ", "))
+				assert.Contains(err.Error(), strings.ToLower(strings.Join(tC.invalidFields, ", ")))
 			} else {
 				assert.Nil(err)
 			}
@@ -631,99 +630,99 @@ func TestKongDefaultsRestrictedFields(t *testing.T) {
 	ctx := context.Background()
 
 	testCases := []struct {
-		desc string
+		desc          string
 		kongDefaults  *kongDefaultForTesting
 		invalidFields []string
 	}{
 		{
 			desc: "service no restricted fields",
-			kongDefaults:  &kongDefaultForTesting{
-				Service:  &kong.Service{
+			kongDefaults: &kongDefaultForTesting{
+				Service: &kong.Service{
 					Path: kong.String("/v1"),
 				},
 			},
 		},
 		{
 			desc: "route no restricted fields",
-			kongDefaults:  &kongDefaultForTesting{
-				Route:  &kong.Route{
+			kongDefaults: &kongDefaultForTesting{
+				Route: &kong.Route{
 					StripPath: kong.Bool(false),
 				},
 			},
 		},
 		{
 			desc: "target no restricted fields",
-			kongDefaults:  &kongDefaultForTesting{
-				Target:  &kong.Target{
-					Target: kong.String("testTarget"),
+			kongDefaults: &kongDefaultForTesting{
+				Target: &kong.Target{
+					Weight: kong.Int(42),
 				},
 			},
 		},
 		{
 			desc: "upstream no restricted fields",
-			kongDefaults:  &kongDefaultForTesting{
-				Upstream:  &kong.Upstream{
+			kongDefaults: &kongDefaultForTesting{
+				Upstream: &kong.Upstream{
 					HostHeader: kong.String("testHostHeader"),
 				},
 			},
 		},
 		{
 			desc: "service restricted fields",
-			kongDefaults:  &kongDefaultForTesting{
-				Service:  &kong.Service{
-					ID: kong.String("testID"),
+			kongDefaults: &kongDefaultForTesting{
+				Service: &kong.Service{
+					ID:   kong.String("testID"),
 					Name: kong.String("testName"),
 					Port: kong.Int(80),
 					Host: kong.String("testHost"),
 					Path: kong.String("/v1"),
 				},
 			},
-			invalidFields: defaultsRestrictedFields["service"],
+			invalidFields: defaultsRestrictedFields["Service"],
 		},
 		{
 			desc: "route restricted fields",
-			kongDefaults:  &kongDefaultForTesting{
-				Route:  &kong.Route{
-					ID: kong.String("testID"),
-					Name: kong.String("testName"),
+			kongDefaults: &kongDefaultForTesting{
+				Route: &kong.Route{
+					ID:        kong.String("testID"),
+					Name:      kong.String("testName"),
 					StripPath: kong.Bool(false),
 				},
 			},
-			invalidFields: defaultsRestrictedFields["route"],
+			invalidFields: defaultsRestrictedFields["Route"],
 		},
 		{
 			desc: "target restricted fields",
-			kongDefaults:  &kongDefaultForTesting{
-				Target:  &kong.Target{
-					ID: kong.String("testID"),
+			kongDefaults: &kongDefaultForTesting{
+				Target: &kong.Target{
+					ID:     kong.String("testID"),
 					Target: kong.String("testTarget"),
 				},
 			},
-			invalidFields: defaultsRestrictedFields["target"],
+			invalidFields: defaultsRestrictedFields["Target"],
 		},
 		{
 			desc: "upstream restricted fields",
-			kongDefaults:  &kongDefaultForTesting{
-				Upstream:  &kong.Upstream{
-					ID: kong.String("testID"),
-					Name: kong.String("testName"),
+			kongDefaults: &kongDefaultForTesting{
+				Upstream: &kong.Upstream{
+					ID:         kong.String("testID"),
+					Name:       kong.String("testName"),
 					HostHeader: kong.String("testHostHeader"),
 				},
 			},
-			invalidFields: defaultsRestrictedFields["upstream"],
+			invalidFields: defaultsRestrictedFields["Upstream"],
 		},
 	}
 
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
 			opts := DefaulterOpts{
-				KongDefaults:	tC.kongDefaults,
+				KongDefaults: tC.kongDefaults,
 			}
 			d, err := GetDefaulter(ctx, opts)
 			if len(tC.invalidFields) > 0 {
 				assert.Nil(d)
 				assert.NotNil(err)
-				assert.Contains(err.Error(), strings.Join(tC.invalidFields, ", "))
+				assert.Contains(err.Error(), strings.ToLower(strings.Join(tC.invalidFields, ", ")))
 			} else {
 				assert.NotNil(d)
 				assert.Nil(err)


### PR DESCRIPTION
I spend some time yesterday to implement a validation for #421. It could have been simpler by just checking the object fields directly with if statements, but I was interested to learn a bit about the **reflect** module.

To check; this implementation do the validation *after* the user input injection, which mean that the defaults in `constants.go` can still be applied without validation. 

```shell
$ ./deck validate
Error: building state: creating defaulter: 3 errors occurred:
        service defaults cannot have these restricted fields set: id, name
        route defaults cannot have these restricted fields set: id, name
        upstream defaults cannot have these restricted fields set: id
        ...
```


TODO:

- [ ] I think the CI failure is because my branch is in my personal fork