### PR TITLE
chore(file) refactor target config cert omission

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -73,9 +73,6 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 	if dumpConfig.SkipConsumers {
 		targetContent.Consumers = []file.FConsumer{}
 	}
-	if dumpConfig.SkipCACerts {
-		targetContent.CACertificates = []file.FCACertificate{}
-	}
 
 	rootClient, err := utils.GetKongClient(rootConfig)
 	if err != nil {

--- a/file/builder.go
+++ b/file/builder.go
@@ -20,6 +20,7 @@ type stateBuilder struct {
 	kongVersion     semver.Version
 
 	selectTags   []string
+	skipCACerts  bool
 	intermediate *state.KongState
 
 	client *kong.Client
@@ -61,7 +62,9 @@ func (b *stateBuilder) build() (*utils.KongRawState, *utils.KonnectRawState, err
 
 	// build
 	b.certificates()
-	b.caCertificates()
+	if !b.skipCACerts {
+		b.caCertificates()
+	}
 	b.services()
 	b.routes()
 	b.upstreams()

--- a/file/reader.go
+++ b/file/reader.go
@@ -77,6 +77,7 @@ func Get(ctx context.Context, fileContent *Content, opt RenderConfig, dumpConfig
 	builder.kongVersion = opt.KongVersion
 	builder.client = wsClient
 	builder.ctx = ctx
+	builder.skipCACerts = dumpConfig.SkipCACerts
 	if len(dumpConfig.SelectorTags) > 0 {
 		builder.selectTags = dumpConfig.SelectorTags
 	}


### PR DESCRIPTION
Refactor the target config side of the --skip-ca-certificates implementation to use the dumpConfig setting inside file.Get() rather than stripping CA Certificates from target configuration afterwards.

As-is we'd need to duplicate the logic to strip certificates out of target config downstream (see https://github.com/Kong/kubernetes-ingress-controller/pull/2341/commits/3b926bd7493cc4636d984c7a4274e403fb465909#diff-d8590e8687e7807da0cf97910b88e0ddbfc670866e0973a15c56597b99df9244R209-R214) which we don't want--it's simple, but it could potentially diverge. This allows us to use a single implementation internal to deck.