### PR TITLE
Apply source_url param to generated docs

### DIFF
--- a/docs/generate-docs.go
+++ b/docs/generate-docs.go
@@ -140,7 +140,7 @@ func genMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 	buf := new(bytes.Buffer)
 	name := cmd.CommandPath()
 
-	buf.WriteString(fmt.Sprintf("---\ntitle: %s\n---\n\n", name))
+	buf.WriteString(fmt.Sprintf("---\ntitle: %s\nsource_url: https://github.com/Kong/deck/tree/main/cmd\n---\n\n", name))
 	buf.WriteString(cmd.Long + "\n\n")
 
 	if cmd.Runnable() {


### PR DESCRIPTION
### Summary 
In the docs repo, changes are often made to autogenerated files instead of the source files, and they aren't always caught. We've just added a check on docs PRs in docs.konqhq.com to catch those instances: https://github.com/Kong/docs.konghq.com/pull/3841

Any generated files now must contain a `source_url` entry in their frontmatter. When a pull request changes a file that contains this entry, a warning will be added as a comment. You can see that in effect here: https://github.com/Kong/docs.konghq.com/pull/3861

Adding the source_url param to all decK CLI generated docs.

### Testing
Tested by running `make generate-cli-docs` from my branch, output looks right:

```
---
title: deck sync
source_url: https://github.com/Kong/deck/tree/main/cmd
---

The sync command reads the state file and performs operation on Kong
to get Kong's state in sync with the input state.
```


