### PR TITLE
fix: populate missing 'enabled' service field from file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@
 
 ### Fixes
 
+- Service's `enabled` field is now correctly parsed when present in config files.
+  [#677](https://github.com/Kong/deck/pull/677)
 - Route references to services by name are now properly handled when printing
   diffs.
   [#657](https://github.com/Kong/deck/pull/657)

--- a/file/reader_test.go
+++ b/file/reader_test.go
@@ -149,3 +149,21 @@ func TestReadKongStateFromStdin(t *testing.T) {
 	},
 		c.Services[0].Service)
 }
+
+func TestReadKongStateFromFile(t *testing.T) {
+	filenames := []string{"testdata/config.yaml"}
+	assert := assert.New(t)
+	assert.Equal("testdata/config.yaml", filenames[0])
+
+	c, err := GetContentFromFiles(filenames)
+	assert.NotNil(c)
+	assert.Nil(err)
+
+	t.Run("enabled field for service is read", func(t *testing.T) {
+		assert.Equal(kong.Service{
+			Name:    kong.String("svc1"),
+			Host:    kong.String("mockbin.org"),
+			Enabled: kong.Bool(true),
+		}, c.Services[0].Service)
+	})
+}

--- a/file/testdata/config.yaml
+++ b/file/testdata/config.yaml
@@ -1,0 +1,4 @@
+services:
+- name: svc1
+  host: mockbin.org
+  enabled: true

--- a/file/types.go
+++ b/file/types.go
@@ -70,6 +70,7 @@ type service struct {
 	TLSVerify         *bool      `json:"tls_verify,omitempty" yaml:"tls_verify,omitempty"`
 	TLSVerifyDepth    *int       `json:"tls_verify_depth,omitempty" yaml:"tls_verify_depth,omitempty"`
 	CACertificates    []*string  `json:"ca_certificates,omitempty" yaml:"ca_certificates,omitempty"`
+	Enabled           *bool      `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 	Routes            []*FRoute  `json:"routes,omitempty" yaml:",omitempty"`
 	Plugins           []*FPlugin `json:"plugins,omitempty" yaml:",omitempty"`
 
@@ -101,6 +102,7 @@ func copyToService(fService FService) service {
 	s.Tags = fService.Tags
 	s.Routes = fService.Routes
 	s.Plugins = fService.Plugins
+	s.Enabled = fService.Enabled
 
 	return s
 }
@@ -176,6 +178,7 @@ func copyFromService(service service, fService *FService) error {
 	fService.TLSVerifyDepth = service.TLSVerifyDepth
 	fService.Routes = service.Routes
 	fService.Plugins = service.Plugins
+	fService.Enabled = service.Enabled
 	return nil
 }
 


### PR DESCRIPTION
Without this decK is failing at parsing the 'enabled' field
for services entities.