### PR TITLE
fix: leave previous single arch binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,5 @@
 universal_binaries:
-- replace: true
+- replace: false
 builds:
 - env:
   - CGO_ENABLED=0


### PR DESCRIPTION
I install deck using [asdf](https://github.com/nutellinoit/asdf-deck) and need the previous format of release such as `deck_${version}_darwin_amd64.tar.gz` or `deck_${version}_darwin_arm64.tar.gz`.

Please let me fix it to leave the previous release format.