### PR TITLE
[WIP] Single sourcing syntax

### DIFF
--- a/docs/generate-docs.go
+++ b/docs/generate-docs.go
@@ -35,14 +35,14 @@ func genVer() (cleanVersion string) {
 	for scanner.Scan() {
 		if lineNum == 2 {
 			ver = scanner.Text()
-			cleanVersion = string(ver[4 : len(ver)-10])
+			cleanVersion = (ver[4 : len(ver)-10])
 		}
 		lineNum++
 	}
 	if err := scanner.Err(); err != nil {
 		log.Fatalln(err)
 	}
-	return string(cleanVersion)
+	return (cleanVersion)
 }
 
 func genMarkdownTreeCustom(cmd *cobra.Command, dir string, filePrepender, linkHandler func(string) string) error {
@@ -164,7 +164,7 @@ func genMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 	name := cmd.CommandPath()
 
 	buf.WriteString(fmt.Sprintf("---\ntitle: %s\nsource_url: https://github.com/Kong/deck/tree/main/cmd\n---\n\n", name))
-	buf.WriteString("{% if_version gte:" + string(genVer()) + "x %}" + "\n\n")
+	buf.WriteString("{% if_version gte:" + (genVer()) + "x %}" + "\n\n")
 	buf.WriteString(cmd.Long + "\n\n")
 
 	if cmd.Runnable() {

--- a/docs/generate-docs.go
+++ b/docs/generate-docs.go
@@ -141,6 +141,7 @@ func genMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 	name := cmd.CommandPath()
 
 	buf.WriteString(fmt.Sprintf("---\ntitle: %s\nsource_url: https://github.com/Kong/deck/tree/main/cmd\n---\n\n", name))
+	buf.WriteString("{% if_version gte:1.13.x %}" + "\n\n")
 	buf.WriteString(cmd.Long + "\n\n")
 
 	if cmd.Runnable() {
@@ -158,6 +159,8 @@ func genMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 	if err := printFlags(buf, cmd); err != nil {
 		return err
 	}
+
+	buf.WriteString("{% endif_version %}" + "\n\n")
 
 	if hasSeeAlso(cmd) {
 		buf.WriteString("## See also\n\n")


### PR DESCRIPTION
This PR wraps the existing documentation generation script in tags that allow for [single sourcing](https://github.com/Kong/docs.konghq.com/pull/3765)

Depends on [#3974](https://github.com/Kong/docs.konghq.com/pull/3974)
## todo
- [x] pull version number by reading from changelog.md and automatically populate the if_version version. Unless there is a better way to do this. 