### PR TITLE
fix: make Oauth2Credential's redirect_uris field not required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [v1.13.0](#v1130)
 - [v1.12.1](#v1121)
 - [v1.12.0](#v1120)
 - [v1.11.0](#v1110)
@@ -37,6 +38,16 @@
 - [v0.3.0](#v030)
 - [v0.2.0](#v020)
 - [v0.1.0](#v010)
+
+## [v1.13.0]
+
+> Release date: unreleased/TBD
+
+### Fixes
+
+- Make Oauth2Credential's `redirect_uris` field not required as it's been so
+  since Kong `1.4.0`.
+  [#688](https://github.com/Kong/deck/pull/688)
 
 ## [v1.12.1]
 
@@ -934,6 +945,7 @@ No breaking changes have been introduced in this release.
 
 Debut release of decK
 
+[v1.13.0]: https://github.com/kong/deck/compare/v1.12.1...v1.13.0
 [v1.12.1]: https://github.com/kong/deck/compare/v1.12.0...v1.12.1
 [v1.12.0]: https://github.com/kong/deck/compare/v1.11.0...v1.12.0
 [v1.11.0]: https://github.com/kong/deck/compare/v1.10.0...v1.11.0

--- a/file/codegen/main.go
+++ b/file/codegen/main.go
@@ -84,7 +84,7 @@ func main() {
 	schema.Definitions["KeyAuth"].Required = []string{"key"}
 	schema.Definitions["Oauth2Credential"].Required = []string{
 		"name",
-		"client_id", "redirect_uris", "client_secret",
+		"client_id", "client_secret",
 	}
 	schema.Definitions["MTLSAuth"].Required = []string{"id", "subject_name"}
 

--- a/file/kong_json_schema.json
+++ b/file/kong_json_schema.json
@@ -1171,7 +1171,6 @@
       "required": [
         "name",
         "client_id",
-        "redirect_uris",
         "client_secret"
       ],
       "properties": {


### PR DESCRIPTION
Fixes: https://github.com/Kong/deck/issues/684

decK expects to be required, but it's not been so for a long time:
https://github.com/Kong/kong/commit/f4b89383faca5dea04f0019ce4f59f37aa85901b