### PR TITLE
fix: strip references name for plugins and routes

### DIFF
--- a/types/plugin.go
+++ b/types/plugin.go
@@ -14,12 +14,25 @@ type pluginCRUD struct {
 	client *kong.Client
 }
 
+// kong and konnect APIs only require IDs for referenced entities.
+func stripPluginReferencesName(plugin *state.Plugin) {
+	if plugin.Plugin.Service != nil && plugin.Plugin.Service.Name != nil {
+		plugin.Plugin.Service.Name = nil
+	}
+	if plugin.Plugin.Route != nil && plugin.Plugin.Route.Name != nil {
+		plugin.Plugin.Route.Name = nil
+	}
+	if plugin.Plugin.Consumer != nil && plugin.Plugin.Consumer.Username != nil {
+		plugin.Plugin.Consumer.Username = nil
+	}
+}
+
 func pluginFromStruct(arg crud.Event) *state.Plugin {
 	plugin, ok := arg.Obj.(*state.Plugin)
 	if !ok {
 		panic("unexpected type, expected *state.Plugin")
 	}
-
+	stripPluginReferencesName(plugin)
 	return plugin
 }
 

--- a/types/route.go
+++ b/types/route.go
@@ -14,12 +14,19 @@ type routeCRUD struct {
 	client *kong.Client
 }
 
+// kong and konnect APIs only require IDs for referenced entities.
+func stripRouteReferencesName(route *state.Route) {
+	if route.Route.Service != nil && route.Route.Service.Name != nil {
+		route.Route.Service.Name = nil
+	}
+}
+
 func routeFromStruct(arg crud.Event) *state.Route {
 	route, ok := arg.Obj.(*state.Route)
 	if !ok {
 		panic("unexpected type, expected *state.Route")
 	}
-
+	stripRouteReferencesName(route)
 	return route
 }
 


### PR DESCRIPTION
Kong and Konnect APIs only require IDs for referenced entities.
In some cases, injecting the entities name in the requests is
problematic. This makes sure these names are stripped before making
API requests, while preserving the capability of logging user-friendly
messages as added in https://github.com/Kong/deck/pull/662