### PR TITLE
fix: diff with not-existing WS must not fail due to defaults

### DIFF
--- a/file/builder.go
+++ b/file/builder.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/blang/semver/v4"
@@ -41,6 +42,8 @@ var kong140Version = semver.MustParse("1.4.0")
 var uuid = func() *string {
 	return kong.String(utils.UUID())
 }
+
+var ErrWorkspaceNotFound = fmt.Errorf("workspace not found")
 
 func (b *stateBuilder) build() (*utils.KongRawState, *utils.KonnectRawState, error) {
 	// setup
@@ -825,7 +828,7 @@ func (b *stateBuilder) getPluginSchema(pluginName string) (map[string]interface{
 		return nil, fmt.Errorf("ensure workspace exists: %w", err)
 	}
 	if !exists {
-		return schema, nil
+		return schema, ErrWorkspaceNotFound
 	}
 
 	schema, err = b.client.Plugins.GetFullSchema(b.ctx, &pluginName)
@@ -842,6 +845,9 @@ func (b *stateBuilder) addPluginDefaults(plugin *FPlugin) error {
 	}
 	schema, err := b.getPluginSchema(*plugin.Name)
 	if err != nil {
+		if errors.Is(err, ErrWorkspaceNotFound) {
+			return nil
+		}
 		return fmt.Errorf("retrieve schema for %v from Kong: %v", *plugin.Name, err)
 	}
 	return kong.FillPluginsDefaults(&plugin.Plugin, schema)

--- a/tests/integration/testdata/diff/001-not-existing-workspace/kong.yaml
+++ b/tests/integration/testdata/diff/001-not-existing-workspace/kong.yaml
@@ -2,3 +2,7 @@ _workspace: test
 services:
 - name: svc1
   host: mockbin.org
+plugins:
+  - name: rate-limiting
+    config:
+      minute: 123


### PR DESCRIPTION
decK dynamically discovers entities defaults by interacting
with the Kong Admin API. Queries to retrieve entities schema
for a workspace that doesn't exist yet would fail though.
When running `diff`, in order to prevent a failure, decK simply
skips defaults injection for all entities, but it was still
wrongly running queries for plugins, making the run fail.

This PR makes sure plugins defaults injection is treated the
same as other entities when running `diff` against a
not-existing workspace.

Solves https://github.com/Kong/deck/issues/697