### PR TITLE
fix: upstreams changes should be pushed after certs ones

### DIFF
--- a/diff/order.go
+++ b/diff/order.go
@@ -32,16 +32,15 @@ var dependencyOrder = [][]types.EntityType{
 	{
 		types.ServicePackage,
 		types.RBACRole,
-		types.Upstream,
 		types.Certificate,
 		types.CACertificate,
 		types.Consumer,
 	},
 	{
 		types.RBACEndpointPermission,
-		types.Target,
 		types.SNI,
 		types.Service,
+		types.Upstream,
 
 		types.KeyAuth, types.HMACAuth, types.JWTAuth,
 		types.BasicAuth, types.OAuth2Cred, types.ACLGroup,
@@ -50,6 +49,7 @@ var dependencyOrder = [][]types.EntityType{
 	{
 		types.ServiceVersion,
 		types.Route,
+		types.Target,
 	},
 	{
 		types.Plugin,


### PR DESCRIPTION
Right now, `Upstream` entities are computed concurrently with
`Certificates`. This may lead to ordering errors because an `Upstream`
can reference `Certificates` objects in the 'client_certificate' field.

This PR makes sure Upstreams changes are pushed after Certificates.