### PR TITLE
fix: correctly set select_tags when dumping from Konnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [v1.12.4](#v1124)
 - [v1.12.3](#v1123)
 - [v1.12.2](#v1122)
 - [v1.12.1](#v1121)
@@ -39,6 +40,16 @@
 - [v0.3.0](#v030)
 - [v0.2.0](#v020)
 - [v0.1.0](#v010)
+
+## [v1.12.4]
+
+> Release date: 2022/07/07
+
+### Fixes
+
+- Make sure decK correctly includes select_tags when dumping
+  from Konnect.
+  [#711](https://github.com/Kong/deck/pull/711)
 
 ## [v1.12.3]
 
@@ -957,6 +968,7 @@ No breaking changes have been introduced in this release.
 
 Debut release of decK
 
+[v1.12.4]: https://github.com/kong/deck/compare/v1.12.3...v1.12.4
 [v1.12.3]: https://github.com/kong/deck/compare/v1.12.2...v1.12.3
 [v1.12.2]: https://github.com/kong/deck/compare/v1.12.1...v1.12.2
 [v1.12.1]: https://github.com/kong/deck/compare/v1.12.0...v1.12.1

--- a/cmd/common_konnect.go
+++ b/cmd/common_konnect.go
@@ -143,6 +143,7 @@ func dumpKonnectV2(ctx context.Context) error {
 		return fmt.Errorf("building state: %w", err)
 	}
 	return file.KongStateToFile(ks, file.WriteConfig{
+		SelectTags:       dumpConfig.SelectorTags,
 		Filename:         dumpCmdKongStateFile,
 		FileFormat:       file.Format(strings.ToUpper(konnectDumpCmdStateFormat)),
 		WithID:           dumpWithID,


### PR DESCRIPTION
Before:

```
  $ deck dump --yes --select-tag team-svc1
  $ cat kong.yaml # missing select_tags
  _format_version: "1.1"
  _info:
    defaults: {}
  _konnect:
    runtime_group_name: default
  services:
  - connect_timeout: 60000
    enabled: true
    host: mockbin.org
    name: svc1
    port: 80
    protocol: http
    read_timeout: 60000
    retries: 5
    tags:
    - team-svc1
    write_timeout: 60000
```

After:

```
  $ deck dump --yes --select-tag team-svc1
  $ cat kong.yaml # included select_tags
  _format_version: "1.1"
  _info:
    defaults: {}
    select_tags:
    - team-svc1
  _konnect:
    runtime_group_name: default
  services:
  - connect_timeout: 60000
    enabled: true
    host: mockbin.org
    name: svc1
    port: 80
    protocol: http
    read_timeout: 60000
    retries: 5
    tags:
    - team-svc1
    write_timeout: 60000
```