### PR TITLE
Add 3.x upstream fields

### DIFF
--- a/file/builder_test.go
+++ b/file/builder_test.go
@@ -1839,6 +1839,83 @@ func Test_stateBuilder_upstream(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "upstream with new 3.0 fields",
+			fields: fields{
+				targetContent: &Content{
+					Info: &Info{
+						Defaults: kongDefaults,
+					},
+					Upstreams: []FUpstream{
+						{
+							Upstream: kong.Upstream{
+								Name:  kong.String("foo"),
+								Slots: kong.Int(42),
+								// not actually valid configuration, but this only needs to check that these translate
+								// into the raw state
+								HashOnQueryArg:         kong.String("foo"),
+								HashFallbackQueryArg:   kong.String("foo"),
+								HashOnURICapture:       kong.String("foo"),
+								HashFallbackURICapture: kong.String("foo"),
+							},
+						},
+					},
+				},
+				currentState: existingServiceState(),
+			},
+			want: &utils.KongRawState{
+				Upstreams: []*kong.Upstream{
+					{
+						ID:    kong.String("0cc0d614-4c88-4535-841a-cbe0709b0758"),
+						Name:  kong.String("foo"),
+						Slots: kong.Int(42),
+						Healthchecks: &kong.Healthcheck{
+							Active: &kong.ActiveHealthcheck{
+								Concurrency: kong.Int(10),
+								Healthy: &kong.Healthy{
+									HTTPStatuses: []int{200, 302},
+									Interval:     kong.Int(0),
+									Successes:    kong.Int(0),
+								},
+								HTTPPath: kong.String("/"),
+								Type:     kong.String("http"),
+								Timeout:  kong.Int(1),
+								Unhealthy: &kong.Unhealthy{
+									HTTPFailures: kong.Int(0),
+									TCPFailures:  kong.Int(0),
+									Timeouts:     kong.Int(0),
+									Interval:     kong.Int(0),
+									HTTPStatuses: []int{429, 404, 500, 501, 502, 503, 504, 505},
+								},
+							},
+							Passive: &kong.PassiveHealthcheck{
+								Healthy: &kong.Healthy{
+									HTTPStatuses: []int{
+										200, 201, 202, 203, 204, 205,
+										206, 207, 208, 226, 300, 301, 302, 303, 304, 305,
+										306, 307, 308,
+									},
+									Successes: kong.Int(0),
+								},
+								Unhealthy: &kong.Unhealthy{
+									HTTPFailures: kong.Int(0),
+									TCPFailures:  kong.Int(0),
+									Timeouts:     kong.Int(0),
+									HTTPStatuses: []int{429, 500, 503},
+								},
+							},
+						},
+						HashOn:                 kong.String("none"),
+						HashFallback:           kong.String("none"),
+						HashOnCookiePath:       kong.String("/"),
+						HashOnQueryArg:         kong.String("foo"),
+						HashFallbackQueryArg:   kong.String("foo"),
+						HashOnURICapture:       kong.String("foo"),
+						HashFallbackURICapture: kong.String("foo"),
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/file/kong_json_schema.json
+++ b/file/kong_json_schema.json
@@ -888,6 +888,12 @@
         "hash_fallback_header": {
           "type": "string"
         },
+        "hash_fallback_query_arg": {
+          "type": "string"
+        },
+        "hash_fallback_uri_capture": {
+          "type": "string"
+        },
         "hash_on": {
           "type": "string"
         },
@@ -898,6 +904,12 @@
           "type": "string"
         },
         "hash_on_header": {
+          "type": "string"
+        },
+        "hash_on_query_arg": {
+          "type": "string"
+        },
+        "hash_on_uri_capture": {
           "type": "string"
         },
         "healthchecks": {
@@ -1543,6 +1555,12 @@
         "hash_fallback_header": {
           "type": "string"
         },
+        "hash_fallback_query_arg": {
+          "type": "string"
+        },
+        "hash_fallback_uri_capture": {
+          "type": "string"
+        },
         "hash_on": {
           "type": "string"
         },
@@ -1553,6 +1571,12 @@
           "type": "string"
         },
         "hash_on_header": {
+          "type": "string"
+        },
+        "hash_on_query_arg": {
+          "type": "string"
+        },
+        "hash_on_uri_capture": {
           "type": "string"
         },
         "healthchecks": {

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/imdario/mergo v0.3.12
-	github.com/kong/go-kong v0.30.0
+	github.com/kong/go-kong v0.31.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/shirou/gopsutil/v3 v3.22.6
 	github.com/spf13/cobra v1.5.0
@@ -71,7 +71,7 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/subosito/gotenv v1.3.0 // indirect
-	github.com/tidwall/gjson v1.14.1 // indirect
+	github.com/tidwall/gjson v1.14.2 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.10 // indirect
@@ -87,7 +87,7 @@ require (
 	gopkg.in/ini.v1 v1.66.4 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/gengo v0.0.0-20211129171323-c02415ce4185 // indirect
+	k8s.io/gengo v0.0.0-20220613173612-397b4ae3bce7 // indirect
 	k8s.io/klog/v2 v2.60.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -215,8 +215,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/kong/go-kong v0.30.0 h1:iD13//BnR5rkhJWsl1bA/X3n2dKDBYjXb14M6CYshcA=
-github.com/kong/go-kong v0.30.0/go.mod h1:DREJ1lzBSOV8d7VHhMweTCkZrv4eyx3YgbXQcdOxBvk=
+github.com/kong/go-kong v0.31.0 h1:m+0pMyTbyHPKKIXf7jPz5aqbWvOr9ahsyDtkYh4VGPM=
+github.com/kong/go-kong v0.31.0/go.mod h1:CNUTSvX9mfYVQvb08d+uJfkbjxv7M6RdkLXK8XJ9fL8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -311,8 +311,8 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.3.0 h1:mjC+YW8QpAdXibNi+vNWgzmgBH4+5l5dCXv8cNysBLI=
 github.com/subosito/gotenv v1.3.0/go.mod h1:YzJjq/33h7nrwdY+iHMhEOEEbW0ovIz0tB6t6PwAXzs=
-github.com/tidwall/gjson v1.14.1 h1:iymTbGkQBhveq21bEvAQ81I0LEBork8BFe1CUZXdyuo=
-github.com/tidwall/gjson v1.14.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.14.2 h1:6BBkirS0rAHjumnjHF6qgy5d2YAJ1TLIaFE2lzfOLqo=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
@@ -702,8 +702,9 @@ honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 k8s.io/code-generator v0.24.3 h1:itd1V1ZAYKM+WT+qQDlFKhU1D/Ff5HcEFL/icfClnZA=
 k8s.io/code-generator v0.24.3/go.mod h1:dpVhs00hTuTdTY6jvVxvTFCk6gSMrtfRydbhZwHI15w=
 k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
-k8s.io/gengo v0.0.0-20211129171323-c02415ce4185 h1:TT1WdmqqXareKxZ/oNXEUSwKlLiHzPMyB0t8BaFeBYI=
 k8s.io/gengo v0.0.0-20211129171323-c02415ce4185/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
+k8s.io/gengo v0.0.0-20220613173612-397b4ae3bce7 h1:RGb68G3yotdQggcyenx9y0+lnVJCXXcLa6geXOMlf5o=
+k8s.io/gengo v0.0.0-20220613173612-397b4ae3bce7/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/klog/v2 v2.60.1 h1:VW25q3bZx9uE3vvdL6M8ezOX79vA2Aq1nEWLqNQclHc=

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -236,7 +236,7 @@ var (
 			Enabled: kong.Bool(true),
 			Config: kong.Configuration{
 				"bandwidth_metrics":       false,
-				"lantency_metrics":        false,
+				"latency_metrics":         false,
 				"per_consumer":            false,
 				"status_code_metrics":     false,
 				"upstream_health_metrics": false,
@@ -256,7 +256,7 @@ var (
 			Enabled: kong.Bool(true),
 			Config: kong.Configuration{
 				"bandwidth_metrics":       false,
-				"lantency_metrics":        false,
+				"latency_metrics":         false,
 				"per_consumer":            false,
 				"status_code_metrics":     false,
 				"upstream_health_metrics": false,


### PR DESCRIPTION
Adds new upstream fields for 3.x.

Fix #734.

Requires a new go-kong release that includes https://github.com/Kong/go-kong/pull/200. Currently using a main hash.