### PR TITLE
fix: correct order of precedence to gate Konnect mode

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -373,8 +373,11 @@ func sendAnalytics(cmd, kongVersion string, mode mode) error {
 }
 
 func inKonnectMode(targetContent *file.Content) bool {
-	if (targetContent != nil && targetContent.Konnect != nil) ||
-		konnectConfig.Email != "" ||
+	if targetContent != nil && targetContent.Konnect != nil {
+		return true
+	} else if rootConfig.Address != defaultKongURL {
+		return false
+	} else if konnectConfig.Email != "" ||
 		konnectConfig.Password != "" ||
 		konnectConfig.Token != "" {
 		return true

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,7 +15,10 @@ import (
 	"github.com/spf13/viper"
 )
 
-const defaultKonnectURL = "https://us.api.konghq.com"
+const (
+	defaultKongURL    = "http://localhost:8001"
+	defaultKonnectURL = "https://us.api.konghq.com"
+)
 
 var (
 	cfgFile       string
@@ -27,8 +30,9 @@ var (
 	konnectRuntimeGroup string
 )
 
-//nolint:errcheck
 // NewRootCmd represents the base command when called without any subcommands
+//
+//nolint:errcheck
 func NewRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "deck",
@@ -50,7 +54,7 @@ It can be used to export, import, or sync entities to Kong.`,
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "",
 		"Config file (default is $HOME/.deck.yaml).")
 
-	rootCmd.PersistentFlags().String("kong-addr", "http://localhost:8001",
+	rootCmd.PersistentFlags().String("kong-addr", defaultKongURL,
 		"HTTP address of Kong's Admin API.\n"+
 			"This value can also be set using the environment variable DECK_KONG_ADDR\n"+
 			" environment variable.")


### PR DESCRIPTION
Right now decK runs against Konnect if some Konnect
credentials are around, either via command flags or via
environment variables. In the case of having a `kong-addr`
different from the default value and some lingering Konnect
credentials environment variables set, decK would still
decide to run against Konnect instead of Kong.

This PR is reworking the order of precedence gating Konnect:
1. if the config file contains the `_konnect` entry, run
   against Konnect
2. if the `kong-addr` is set to a non-default value, run
   against Kong
3. if some Konnect credentials are set, run against Konnect
4. otherwise run against Kong