### PR TITLE
fix: add -w shorthand flag support to sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@
 
 ### Fixes
 
+- Add `-w` shorthand flag support to `sync`.
+  [#765](https://github.com/Kong/deck/pull/765)
 - Handle correctly encoded whitespaces into services' `url`
   [#755](https://github.com/Kong/deck/pull/755)
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -39,7 +39,7 @@ to get Kong's state in sync with the input state.`,
 		"state", "s", []string{"kong.yaml"}, "file(s) containing Kong's configuration.\n"+
 			"This flag can be specified multiple times for multiple files.\n"+
 			"Use `-` to read from stdin.")
-	syncCmd.Flags().StringVar(&syncWorkspace, "workspace", "",
+	syncCmd.Flags().StringVarP(&syncWorkspace, "workspace", "w", "",
 		"Sync configuration to a specific workspace "+
 			"(Kong Enterprise only).\n"+
 			"This takes precedence over _workspace fields in state files.")


### PR DESCRIPTION
Right now `dump` supports both `--workspace` and `-w`, while `sync` only supports `--workspace`.