### PR TITLE
fix: remove all selected tags when using dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@
 
 ### Fixes
 
+- Remove selected tags information from entities level when
+  using `dump`.
+  [#766](https://github.com/Kong/deck/pull/766)
 - Use `kong.yaml` as default value with `convert` subcommand
   when no `--output-file` is provided.
   [#775](https://github.com/Kong/deck/pull/775)

--- a/file/writer.go
+++ b/file/writer.go
@@ -320,6 +320,7 @@ func fetchService(id string, kongState *state.KongState, config WriteConfig) (*F
 	})
 	utils.ZeroOutID(&s, s.Name, config.WithID)
 	utils.ZeroOutTimestamps(&s)
+	utils.MustRemoveTags(&s, config.SelectTags)
 	return &s, nil
 }
 
@@ -567,6 +568,7 @@ func populateConsumers(kongState *state.KongState, file *Content,
 		for _, k := range keyAuths {
 			utils.ZeroOutID(k, k.Key, config.WithID)
 			utils.ZeroOutTimestamps(k)
+			utils.MustRemoveTags(k, config.SelectTags)
 			k.Consumer = nil
 			c.KeyAuths = append(c.KeyAuths, &k.KeyAuth)
 		}
@@ -578,6 +580,7 @@ func populateConsumers(kongState *state.KongState, file *Content,
 			k.Consumer = nil
 			utils.ZeroOutID(k, k.Username, config.WithID)
 			utils.ZeroOutTimestamps(k)
+			utils.MustRemoveTags(k, config.SelectTags)
 			c.HMACAuths = append(c.HMACAuths, &k.HMACAuth)
 		}
 		jwtSecrets, err := kongState.JWTAuths.GetAllByConsumerID(*c.ID)
@@ -588,6 +591,7 @@ func populateConsumers(kongState *state.KongState, file *Content,
 			k.Consumer = nil
 			utils.ZeroOutID(k, k.Key, config.WithID)
 			utils.ZeroOutTimestamps(k)
+			utils.MustRemoveTags(k, config.SelectTags)
 			c.JWTAuths = append(c.JWTAuths, &k.JWTAuth)
 		}
 		basicAuths, err := kongState.BasicAuths.GetAllByConsumerID(*c.ID)
@@ -598,6 +602,7 @@ func populateConsumers(kongState *state.KongState, file *Content,
 			k.Consumer = nil
 			utils.ZeroOutID(k, k.Username, config.WithID)
 			utils.ZeroOutTimestamps(k)
+			utils.MustRemoveTags(k, config.SelectTags)
 			c.BasicAuths = append(c.BasicAuths, &k.BasicAuth)
 		}
 		oauth2Creds, err := kongState.Oauth2Creds.GetAllByConsumerID(*c.ID)
@@ -608,6 +613,7 @@ func populateConsumers(kongState *state.KongState, file *Content,
 			k.Consumer = nil
 			utils.ZeroOutID(k, k.ClientID, config.WithID)
 			utils.ZeroOutTimestamps(k)
+			utils.MustRemoveTags(k, config.SelectTags)
 			c.Oauth2Creds = append(c.Oauth2Creds, &k.Oauth2Credential)
 		}
 		aclGroups, err := kongState.ACLGroups.GetAllByConsumerID(*c.ID)
@@ -618,6 +624,7 @@ func populateConsumers(kongState *state.KongState, file *Content,
 			k.Consumer = nil
 			utils.ZeroOutID(k, k.Group, config.WithID)
 			utils.ZeroOutTimestamps(k)
+			utils.MustRemoveTags(k, config.SelectTags)
 			c.ACLGroups = append(c.ACLGroups, &k.ACLGroup)
 		}
 		mtlsAuths, err := kongState.MTLSAuths.GetAllByConsumerID(*c.ID)
@@ -626,6 +633,7 @@ func populateConsumers(kongState *state.KongState, file *Content,
 		}
 		for _, k := range mtlsAuths {
 			utils.ZeroOutTimestamps(k)
+			utils.MustRemoveTags(k, config.SelectTags)
 			k.Consumer = nil
 			c.MTLSAuths = append(c.MTLSAuths, &k.MTLSAuth)
 		}

--- a/tests/integration/dump_test.go
+++ b/tests/integration/dump_test.go
@@ -1,0 +1,43 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Dump_SelectTags(t *testing.T) {
+	tests := []struct {
+		name         string
+		stateFile    string
+		expectedFile string
+	}{
+		{
+			name:         "dump with select-tags",
+			stateFile:    "testdata/dump/001-entities-with-tags/kong.yaml",
+			expectedFile: "testdata/dump/001-entities-with-tags/expected.yaml",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runWhen(t, "kong", ">=3.0.0")
+			teardown := setup(t)
+			defer teardown(t)
+
+			assert.NoError(t, sync(tc.stateFile))
+
+			output, err := dump(
+				"--select-tag", "managed-by-deck",
+				"--select-tag", "org-unit-42",
+				"-o", "-",
+			)
+			assert.NoError(t, err)
+
+			expected, err := readFile(tc.expectedFile)
+			assert.NoError(t, err)
+			assert.Equal(t, output, expected)
+		})
+	}
+}

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -2220,7 +2220,7 @@ func Test_Sync_UpdateUsernameInConsumerWithCustomID(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			kong.RunWhenKong(t, ">=2.8.0 <3.0.0")
+			runWhen(t, "kong", ">=2.8.0 <3.0.0")
 			teardown := setup(t)
 			defer teardown(t)
 
@@ -2265,7 +2265,7 @@ func Test_Sync_UpdateConsumerWithCustomID(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			kong.RunWhenKong(t, ">=2.8.0 <3.0.0")
+			runWhen(t, "kong", ">=2.8.0 <3.0.0")
 			teardown := setup(t)
 			defer teardown(t)
 
@@ -2310,7 +2310,7 @@ func Test_Sync_UpdateUsernameInConsumerWithCustomID_3x(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			kong.RunWhenKong(t, ">=3.0.0")
+			runWhen(t, "kong", ">=3.0.0")
 			teardown := setup(t)
 			defer teardown(t)
 
@@ -2355,7 +2355,7 @@ func Test_Sync_UpdateConsumerWithCustomID_3x(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			kong.RunWhenKong(t, ">=3.0.0")
+			runWhen(t, "kong", ">=3.0.0")
 			teardown := setup(t)
 			defer teardown(t)
 

--- a/tests/integration/testdata/dump/001-entities-with-tags/expected.yaml
+++ b/tests/integration/testdata/dump/001-entities-with-tags/expected.yaml
@@ -1,0 +1,266 @@
+_format_version: "3.0"
+_info:
+  defaults: {}
+  select_tags:
+  - managed-by-deck
+  - org-unit-42
+certificates:
+- cert: |
+    -----BEGIN CERTIFICATE-----
+    MIIC1jCCAb4CCQCt23nwvxSCvjANBgkqhkiG9w0BAQsFADAtMRYwFAYDVQQDDA0q
+    LmV4YW1wbGUuY29tMRMwEQYDVQQKDAprb25naHEub3JnMB4XDTE4MTIzMTIwMTkw
+    MVoXDTE5MTIzMTIwMTkwMVowLTEWMBQGA1UEAwwNKi5leGFtcGxlLmNvbTETMBEG
+    A1UECgwKa29uZ2hxLm9yZzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+    AKj/2r1AXo9x+2Csrd0SHbpnzuW+xYqgsd+YA9ZrZNV7SZGSbaZymsRMz8wg5OIU
+    iUik2GM1749/lYvojLFStBPy9UY/gd++5f3wLp4xHiI+IU2XQ97otXKGfyh36RmN
+    dKDqPLN8BG3R346s/y1GOulFvLthYmZVYF9ufHiqimfEDSbTt79P5C3X0Rw/afK1
+    GjHEJPCB/XkZ6lkcEyL6LqZI5oBigDqa9hI/nWLxEzfm8pgosiS38p9TAijlOkpm
+    tX2p2b1pktlNIy3rxsqj6IynN9Wc7FpV1N4HoPKV7vQQ08hjwW6WfanVthaaJosj
+    Vr2TBCJ1ltAmsb+5B2VPYVkCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAnByTyQfV
+    3LkwuoWS57CWcqbNw/cHnv/ChzmIv+6mIXvDBSvCgrPZIWCpaCfYRG6R51E44fr/
+    8V1AKT0Zt15DjrXEEcIGQgsIDO91/wlL091fTAUzSbL0yt7HTlm8sX6xndPNAZrq
+    cfcIPVMxknfqPy2VqS4IrNC03pHkDKtokphBjVUlkiWsdcq+fHYbS2xL2d1Da/uN
+    hX/iwgo+v5gOF5xtaXx7D7L3Cf+MHb/MOXWPfYXNiTpSBVX8/Kx5RP+QLI16nWvw
+    lrijTlXZFR8NIZBrCo/QZ2cNbUAbN3R0n+/kMFubxBL8WEm6Qhi9jBjbJeDMspd8
+    C+/TZJQMpx5vyA==
+    -----END CERTIFICATE-----
+  id: 13c562a1-191c-4464-9b18-e5222b46035b
+  key: |
+    -----BEGIN PRIVATE KEY-----
+    MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCo/9q9QF6Pcftg
+    rK3dEh26Z87lvsWKoLHfmAPWa2TVe0mRkm2mcprETM/MIOTiFIlIpNhjNe+Pf5WL
+    6IyxUrQT8vVGP4HfvuX98C6eMR4iPiFNl0Pe6LVyhn8od+kZjXSg6jyzfARt0d+O
+    rP8tRjrpRby7YWJmVWBfbnx4qopnxA0m07e/T+Qt19EcP2nytRoxxCTwgf15GepZ
+    HBMi+i6mSOaAYoA6mvYSP51i8RM35vKYKLIkt/KfUwIo5TpKZrV9qdm9aZLZTSMt
+    68bKo+iMpzfVnOxaVdTeB6Dyle70ENPIY8Fuln2p1bYWmiaLI1a9kwQidZbQJrG/
+    uQdlT2FZAgMBAAECggEAVnyRcda2Tcy0K7ZTR9aUlie370VhDN/OB7JhDGNreAEf
+    FjuMl+kAoUL5+OpAmB6QXzfVcXhRv+s4GiCJl9nORINK2Id5rIqiYwF+qgBS/o0z
+    N+UYm8QVz6Va/9fV1/jXXd5h8Cygi58jPH32HTJaxbSlsHNXCy3YIx6E3q/QIueR
+    6ZdSXPqMEqxEU19M9jW8UeiRFrpmcyYxVpfxYIY/+O9lYjSpaeLs7hZeCP9PqWXA
+    Sxz2CnHZ8BcsDxAyuoHoVw+kjMpUMvA3sD4lwkV8BAYzfLmQf6PR83SFNsrE8XYu
+    /8WnQuCuytcl8Zg55R6tGCvf6Wyyf+MDRPwv/43QMQKBgQDbqK9Dq54k+EHgSNnP
+    K6AhNjFd6aqcNC1kom/sSlWBnuA/BEqJMECr8S2dYvzONUPPfX5NNUjB4Vw3Qw7a
+    pUgKuCQoVpzpZs5m1bk78itWDtA84LjkXfdejnUXVw/aVxLCM5QV9aEkm/dEWWMI
+    P1WTYVoWoZCLlEE08q0AvZQcdQKBgQDE9ZCmc6ncmhnQftuRj5PnXG2a79MLCT61
+    sCEBDVvkcUJVqbzwGRLwRkdIzLgvmiuP+SukHgyfr8/RXG99xEW/q7NDrtEcqfXP
+    19QXwOIp5NwDnOXyAlXiyZ50fCE2tSo2wP485+NIhmKj5Zt6y/DL6Qbc5k73XmK4
+    KX5Ej15k1QKBgQCc6KeiIFLMt+Ze78tfORue/dZP7p3oDUGr1Hk9AnCIMlSfz1Hr
+    I+Per17VQaOzLcttyYhSYNDDZld4RlezCkQnHBkAE7bs53pjbSJv1vLr+5L3GdQZ
+    laIiEoNEE/YIExEcVrne4eKlgyAj2/JpLszThcRTzD+z5UibKQs6LzJBDQKBgDVa
+    dAGzCUt57w48nwvyQdWFgydaWef+bB9Zg8c+MCtUxuxfm4/Kqwetcff1hNtYPv60
+    N68weKj1Pi1vhcAi3+YJA/mMrJbAL5dK1uhMVreUiEjuQpfpLAzQIv1Y9sJUFwhY
+    BUbIZhgqVyQguZptDmCeUj6aoL9/sOxESTEXSTG1AoGBAMQ5iJZMsdLCERv0+6Y1
+    F/t/YSW8cugB3vdV9jHZuosoprz48p92pYP8OdQc70H5hZt53hoYNgYFSd+MU6H1
+    hJCaXTsiP4IUmBjiwzSp3o1ctP8lWvnyJpAadYdDhaDaAAoaMjCo9cm5OMwc8t8x
+    hwAPXV2cgWH8fPcT9NLAcwWk
+    -----END PRIVATE KEY-----
+  snis:
+  - name: demo1.example.com
+  - name: demo2.example.com
+  - name: demo3.example.com
+  tags:
+  - cloudops-managed
+consumers:
+- acls:
+  - group: foo-group
+  hmacauth_credentials:
+  - secret: yeNZBeqCuk0D3H85VX77Umacf91MwqRo
+    username: hmac-user
+  jwt_secrets:
+  - algorithm: HS256
+    key: MKWeR0nu9OAUR9HrjpUG82Hbfz7ZXsIw
+    secret: 6gkrxTKAraykMSpmnLNEGiEE3Yz8XL6U
+  keyauth_credentials:
+  - key: iwb6Djkk4HhUlOCmLilDIKh6nZrn90ts
+  username: harry
+- plugins:
+  - config:
+      day: null
+      fault_tolerant: true
+      header_name: null
+      hide_client_headers: false
+      hour: null
+      limit_by: consumer
+      minute: 10
+      month: null
+      path: null
+      policy: redis
+      redis_database: 0
+      redis_host: redis.common.svc
+      redis_password: null
+      redis_port: 6379
+      redis_server_name: null
+      redis_ssl: false
+      redis_ssl_verify: false
+      redis_timeout: 2000
+      redis_username: null
+      second: null
+      year: null
+    enabled: true
+    name: rate-limiting
+    protocols:
+    - http
+    - https
+  tags:
+  - internal-user
+  username: yolo
+plugins:
+- config:
+    bandwidth_metrics: false
+    latency_metrics: false
+    per_consumer: false
+    status_code_metrics: false
+    upstream_health_metrics: false
+  enabled: true
+  name: prometheus
+  protocols:
+  - http
+  - https
+services:
+- connect_timeout: 60000
+  enabled: true
+  host: mockbin.org
+  name: svc1
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 301
+    name: r1
+    path_handling: v0
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  tags:
+  - team-svc1
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: mockbin.org
+  name: svc2
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 301
+    name: r2
+    path_handling: v0
+    paths:
+    - /r2
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: mockbin.org
+  name: svc3
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 301
+    methods:
+    - GET
+    name: r3
+    path_handling: v0
+    paths:
+    - /r3
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+upstreams:
+- algorithm: round-robin
+  hash_fallback: none
+  hash_on: none
+  hash_on_cookie_path: /
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      timeout: 1
+      type: http
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        interval: 0
+        tcp_failures: 0
+        timeouts: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      type: http
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+    threshold: 0
+  name: upstream1
+  slots: 10000
+  targets:
+  - target: 198.51.100.11:80
+    weight: 100
+  - target: 198.51.100.12:80
+    weight: 100
+  - target: 198.51.100.13:80
+    weight: 100

--- a/tests/integration/testdata/dump/001-entities-with-tags/kong.yaml
+++ b/tests/integration/testdata/dump/001-entities-with-tags/kong.yaml
@@ -1,0 +1,324 @@
+_format_version: "3.0"
+certificates:
+- cert: |
+    -----BEGIN CERTIFICATE-----
+    MIIC1jCCAb4CCQCt23nwvxSCvjANBgkqhkiG9w0BAQsFADAtMRYwFAYDVQQDDA0q
+    LmV4YW1wbGUuY29tMRMwEQYDVQQKDAprb25naHEub3JnMB4XDTE4MTIzMTIwMTkw
+    MVoXDTE5MTIzMTIwMTkwMVowLTEWMBQGA1UEAwwNKi5leGFtcGxlLmNvbTETMBEG
+    A1UECgwKa29uZ2hxLm9yZzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+    AKj/2r1AXo9x+2Csrd0SHbpnzuW+xYqgsd+YA9ZrZNV7SZGSbaZymsRMz8wg5OIU
+    iUik2GM1749/lYvojLFStBPy9UY/gd++5f3wLp4xHiI+IU2XQ97otXKGfyh36RmN
+    dKDqPLN8BG3R346s/y1GOulFvLthYmZVYF9ufHiqimfEDSbTt79P5C3X0Rw/afK1
+    GjHEJPCB/XkZ6lkcEyL6LqZI5oBigDqa9hI/nWLxEzfm8pgosiS38p9TAijlOkpm
+    tX2p2b1pktlNIy3rxsqj6IynN9Wc7FpV1N4HoPKV7vQQ08hjwW6WfanVthaaJosj
+    Vr2TBCJ1ltAmsb+5B2VPYVkCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAnByTyQfV
+    3LkwuoWS57CWcqbNw/cHnv/ChzmIv+6mIXvDBSvCgrPZIWCpaCfYRG6R51E44fr/
+    8V1AKT0Zt15DjrXEEcIGQgsIDO91/wlL091fTAUzSbL0yt7HTlm8sX6xndPNAZrq
+    cfcIPVMxknfqPy2VqS4IrNC03pHkDKtokphBjVUlkiWsdcq+fHYbS2xL2d1Da/uN
+    hX/iwgo+v5gOF5xtaXx7D7L3Cf+MHb/MOXWPfYXNiTpSBVX8/Kx5RP+QLI16nWvw
+    lrijTlXZFR8NIZBrCo/QZ2cNbUAbN3R0n+/kMFubxBL8WEm6Qhi9jBjbJeDMspd8
+    C+/TZJQMpx5vyA==
+    -----END CERTIFICATE-----
+  id: 13c562a1-191c-4464-9b18-e5222b46035b
+  key: |
+    -----BEGIN PRIVATE KEY-----
+    MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCo/9q9QF6Pcftg
+    rK3dEh26Z87lvsWKoLHfmAPWa2TVe0mRkm2mcprETM/MIOTiFIlIpNhjNe+Pf5WL
+    6IyxUrQT8vVGP4HfvuX98C6eMR4iPiFNl0Pe6LVyhn8od+kZjXSg6jyzfARt0d+O
+    rP8tRjrpRby7YWJmVWBfbnx4qopnxA0m07e/T+Qt19EcP2nytRoxxCTwgf15GepZ
+    HBMi+i6mSOaAYoA6mvYSP51i8RM35vKYKLIkt/KfUwIo5TpKZrV9qdm9aZLZTSMt
+    68bKo+iMpzfVnOxaVdTeB6Dyle70ENPIY8Fuln2p1bYWmiaLI1a9kwQidZbQJrG/
+    uQdlT2FZAgMBAAECggEAVnyRcda2Tcy0K7ZTR9aUlie370VhDN/OB7JhDGNreAEf
+    FjuMl+kAoUL5+OpAmB6QXzfVcXhRv+s4GiCJl9nORINK2Id5rIqiYwF+qgBS/o0z
+    N+UYm8QVz6Va/9fV1/jXXd5h8Cygi58jPH32HTJaxbSlsHNXCy3YIx6E3q/QIueR
+    6ZdSXPqMEqxEU19M9jW8UeiRFrpmcyYxVpfxYIY/+O9lYjSpaeLs7hZeCP9PqWXA
+    Sxz2CnHZ8BcsDxAyuoHoVw+kjMpUMvA3sD4lwkV8BAYzfLmQf6PR83SFNsrE8XYu
+    /8WnQuCuytcl8Zg55R6tGCvf6Wyyf+MDRPwv/43QMQKBgQDbqK9Dq54k+EHgSNnP
+    K6AhNjFd6aqcNC1kom/sSlWBnuA/BEqJMECr8S2dYvzONUPPfX5NNUjB4Vw3Qw7a
+    pUgKuCQoVpzpZs5m1bk78itWDtA84LjkXfdejnUXVw/aVxLCM5QV9aEkm/dEWWMI
+    P1WTYVoWoZCLlEE08q0AvZQcdQKBgQDE9ZCmc6ncmhnQftuRj5PnXG2a79MLCT61
+    sCEBDVvkcUJVqbzwGRLwRkdIzLgvmiuP+SukHgyfr8/RXG99xEW/q7NDrtEcqfXP
+    19QXwOIp5NwDnOXyAlXiyZ50fCE2tSo2wP485+NIhmKj5Zt6y/DL6Qbc5k73XmK4
+    KX5Ej15k1QKBgQCc6KeiIFLMt+Ze78tfORue/dZP7p3oDUGr1Hk9AnCIMlSfz1Hr
+    I+Per17VQaOzLcttyYhSYNDDZld4RlezCkQnHBkAE7bs53pjbSJv1vLr+5L3GdQZ
+    laIiEoNEE/YIExEcVrne4eKlgyAj2/JpLszThcRTzD+z5UibKQs6LzJBDQKBgDVa
+    dAGzCUt57w48nwvyQdWFgydaWef+bB9Zg8c+MCtUxuxfm4/Kqwetcff1hNtYPv60
+    N68weKj1Pi1vhcAi3+YJA/mMrJbAL5dK1uhMVreUiEjuQpfpLAzQIv1Y9sJUFwhY
+    BUbIZhgqVyQguZptDmCeUj6aoL9/sOxESTEXSTG1AoGBAMQ5iJZMsdLCERv0+6Y1
+    F/t/YSW8cugB3vdV9jHZuosoprz48p92pYP8OdQc70H5hZt53hoYNgYFSd+MU6H1
+    hJCaXTsiP4IUmBjiwzSp3o1ctP8lWvnyJpAadYdDhaDaAAoaMjCo9cm5OMwc8t8x
+    hwAPXV2cgWH8fPcT9NLAcwWk
+    -----END PRIVATE KEY-----
+  snis:
+  - name: demo1.example.com
+    tags:
+    - managed-by-deck
+    - org-unit-42
+  - name: demo2.example.com
+    tags:
+    - managed-by-deck
+    - org-unit-42
+  - name: demo3.example.com
+    tags:
+    - managed-by-deck
+    - org-unit-42
+  tags:
+  - cloudops-managed
+  - managed-by-deck
+  - org-unit-42
+consumers:
+- acls:
+  - group: foo-group
+    tags:
+    - managed-by-deck
+    - org-unit-42
+  hmacauth_credentials:
+  - secret: yeNZBeqCuk0D3H85VX77Umacf91MwqRo
+    tags:
+    - managed-by-deck
+    - org-unit-42
+    username: hmac-user
+  jwt_secrets:
+  - algorithm: HS256
+    key: MKWeR0nu9OAUR9HrjpUG82Hbfz7ZXsIw
+    secret: 6gkrxTKAraykMSpmnLNEGiEE3Yz8XL6U
+    tags:
+    - managed-by-deck
+    - org-unit-42
+  keyauth_credentials:
+  - key: iwb6Djkk4HhUlOCmLilDIKh6nZrn90ts
+    tags:
+    - managed-by-deck
+    - org-unit-42
+  tags:
+  - managed-by-deck
+  - org-unit-42
+  username: harry
+- plugins:
+  - config:
+      day: null
+      fault_tolerant: true
+      header_name: null
+      hide_client_headers: false
+      hour: null
+      limit_by: consumer
+      minute: 10
+      month: null
+      path: null
+      policy: redis
+      redis_database: 0
+      redis_host: redis.common.svc
+      redis_password: null
+      redis_port: 6379
+      redis_server_name: null
+      redis_ssl: false
+      redis_ssl_verify: false
+      redis_timeout: 2000
+      redis_username: null
+      second: null
+      year: null
+    enabled: true
+    name: rate-limiting
+    protocols:
+    - http
+    - https
+    tags:
+    - managed-by-deck
+    - org-unit-42
+  tags:
+  - internal-user
+  - managed-by-deck
+  - org-unit-42
+  username: yolo
+plugins:
+- config:
+    bandwidth_metrics: false
+    latency_metrics: false
+    per_consumer: false
+    status_code_metrics: false
+    upstream_health_metrics: false
+  enabled: true
+  name: prometheus
+  protocols:
+  - http
+  - https
+  tags:
+  - managed-by-deck
+  - org-unit-42
+services:
+- connect_timeout: 60000
+  enabled: true
+  host: mockbin.org
+  name: svc1
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 301
+    name: r1
+    path_handling: v0
+    paths:
+    - /r1
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+    tags:
+    - managed-by-deck
+    - org-unit-42
+  tags:
+  - team-svc1
+  - managed-by-deck
+  - org-unit-42
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: mockbin.org
+  name: svc2
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 301
+    name: r2
+    path_handling: v0
+    paths:
+    - /r2
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+    tags:
+    - managed-by-deck
+    - org-unit-42
+  tags:
+  - managed-by-deck
+  - org-unit-42
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: mockbin.org
+  name: svc3
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 301
+    methods:
+    - GET
+    name: r3
+    path_handling: v0
+    paths:
+    - /r3
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+    tags:
+    - managed-by-deck
+    - org-unit-42
+  tags:
+  - managed-by-deck
+  - org-unit-42
+  write_timeout: 60000
+upstreams:
+- algorithm: round-robin
+  hash_fallback: none
+  hash_on: none
+  hash_on_cookie_path: /
+  healthchecks:
+    active:
+      concurrency: 10
+      healthy:
+        http_statuses:
+        - 200
+        - 302
+        interval: 0
+        successes: 0
+      http_path: /
+      https_verify_certificate: true
+      timeout: 1
+      type: http
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 404
+        - 500
+        - 501
+        - 502
+        - 503
+        - 504
+        - 505
+        interval: 0
+        tcp_failures: 0
+        timeouts: 0
+    passive:
+      healthy:
+        http_statuses:
+        - 200
+        - 201
+        - 202
+        - 203
+        - 204
+        - 205
+        - 206
+        - 207
+        - 208
+        - 226
+        - 300
+        - 301
+        - 302
+        - 303
+        - 304
+        - 305
+        - 306
+        - 307
+        - 308
+        successes: 0
+      type: http
+      unhealthy:
+        http_failures: 0
+        http_statuses:
+        - 429
+        - 500
+        - 503
+        tcp_failures: 0
+        timeouts: 0
+    threshold: 0
+  name: upstream1
+  slots: 10000
+  tags:
+  - managed-by-deck
+  - org-unit-42
+  targets:
+  - tags:
+    - managed-by-deck
+    - org-unit-42
+    target: 198.51.100.11:80
+    weight: 100
+  - tags:
+    - managed-by-deck
+    - org-unit-42
+    target: 198.51.100.12:80
+    weight: 100
+  - tags:
+    - managed-by-deck
+    - org-unit-42
+    target: 198.51.100.13:80
+    weight: 100


### PR DESCRIPTION
The expected behaviour for `deck dump` when using `--select-tag` is the following:
1. selected tags information should be summarized at the top of the configuration file inside the `_info` structure
2. selected tags must be removed from entity-level tags

Right now decK doesn't perform (2) consistently, stripping out selected tags from some entities, but not from some others. For example:

```
$ deck dump --select-tag test-tag --yes

$ cat kong.yaml
_format_version: "3.0"
_info:
  defaults: {}
  select_tags:
  - test-tag
services:
- connect_timeout: 60000
  enabled: true
  host: mockbin.org
  name: svc1
  port: 80
  protocol: http
  read_timeout: 60000
  retries: 5
  routes:
  - https_redirect_status_code: 301
    name: r1
    path_handling: v0
    paths:
    - /r1
    preserve_host: false
    protocols:
    - http
    - https
    regex_priority: 0
    request_buffering: true
    response_buffering: true
    strip_path: true
    tags:
    - another-test-tag
  tags:
  - test-tag
  write_timeout: 60000
```

Here, `test-tag` is correctly stripped out from the route entity, which now has only the `another-test-tag` tag, but the `test-tag` is still included in the service entity.

This PR makes sure that selected tags are removed from all entities, so that this information will only be included in the `_info` structure.