### PR TITLE
fix: add --db-workspace-update-propagation-delay CLI flag

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"reflect"
 	"sort"
+	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/kong/deck/cprint"
@@ -206,6 +207,8 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 			if err != nil {
 				return err
 			}
+			// make sure the DB is updated and ready to receive new workspace queries.
+			time.Sleep(time.Duration(syncCmdDBWSUpdateDelay) * time.Second)
 		}
 	}
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -7,9 +7,10 @@ import (
 )
 
 var (
-	syncCmdParallelism   int
-	syncCmdDBUpdateDelay int
-	syncWorkspace        string
+	syncCmdParallelism     int
+	syncCmdDBUpdateDelay   int
+	syncCmdDBWSUpdateDelay int
+	syncWorkspace          string
 )
 
 // newSyncCmd represents the sync command
@@ -58,6 +59,9 @@ to get Kong's state in sync with the input state.`,
 		0, "artificial delay (in seconds) that is injected between insert operations \n"+
 			"for related entities (usually for Cassandra deployments).\n"+
 			"See `db_update_propagation` in kong.conf.")
+	syncCmd.Flags().IntVar(&syncCmdDBWSUpdateDelay, "db-workspace-update-propagation-delay",
+		0, "artificial delay (in seconds) that is injected between new workspaces creation \n"+
+			"and all the remaining operations.")
 	syncCmd.Flags().BoolVar(&dumpConfig.SkipCACerts, "skip-ca-certificates",
 		false, "do not sync CA certificates.")
 	addSilenceEventsFlag(syncCmd.Flags())


### PR DESCRIPTION
When some configuration is applied to a non-existent workspace, decK creates the workspace before proceeding with the other queries. In such cases, it may happen that Kong is not "fast" enough to propagate workspace changes, leading to some misleading 404s due to not-existing (not-propagated) workspaces.

This commit is adding a new --db-workspace-update-propagation-delay CLI flag to introduce an artificial delay when a new workspace is created.
This is different from the --db-update-propagation-delay flag, as the latter gets applied to every insert operation and it was initially introduced to address some Cassandra limitation.

Related to https://github.com/Kong/deck/issues/783