### PR TITLE
fix: ping fails with Konnect when using PAT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,16 @@
 - [v0.2.0](#v020)
 - [v0.1.0](#v010)
 
+## [v1.16.1]
+
+> Release date: 2022/11/09
+
+### Fixes
+
+- Fix issue with `ping` when running against Konnect
+  using a PAT.
+  [#790](https://github.com/Kong/deck/pull/790)
+
 ## [v1.16.0]
 
 > Release date: 2022/11/09

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -123,7 +123,7 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 			}
 			konnectRuntimeGroup = targetContent.Konnect.RuntimeGroupName
 		}
-		kongClient, err = GetKongClientForKonnectMode(ctx, konnectConfig)
+		kongClient, err = GetKongClientForKonnectMode(ctx, &konnectConfig)
 		if err != nil {
 			return err
 		}

--- a/cmd/common_konnect.go
+++ b/cmd/common_konnect.go
@@ -46,7 +46,7 @@ func authenticate(
 // a session with Konnect, making the different cloud environments completely
 // transparent to users.
 func GetKongClientForKonnectMode(
-	ctx context.Context, konnectConfig utils.KonnectConfig,
+	ctx context.Context, konnectConfig *utils.KonnectConfig,
 ) (*kong.Client, error) {
 	httpClient := utils.HTTPClient()
 	if konnectConfig.Address != defaultKonnectURL {
@@ -67,7 +67,7 @@ func GetKongClientForKonnectMode(
 	for _, address := range addresses {
 		// get Konnect client
 		konnectConfig.Address = address
-		konnectClient, err = utils.GetKonnectClient(httpClient, konnectConfig)
+		konnectClient, err = utils.GetKonnectClient(httpClient, *konnectConfig)
 		if err != nil {
 			return nil, err
 		}
@@ -75,7 +75,7 @@ func GetKongClientForKonnectMode(
 		if err != nil {
 			return nil, fmt.Errorf("parsing %s address: %v", address, err)
 		}
-		_, err = authenticate(ctx, konnectClient, parsedAddress.Host, konnectConfig)
+		_, err = authenticate(ctx, konnectClient, parsedAddress.Host, *konnectConfig)
 		if err == nil {
 			break
 		}
@@ -124,7 +124,7 @@ func GetKongClientForKonnectMode(
 }
 
 func resetKonnectV2(ctx context.Context) error {
-	client, err := GetKongClientForKonnectMode(ctx, konnectConfig)
+	client, err := GetKongClientForKonnectMode(ctx, &konnectConfig)
 	if err != nil {
 		return err
 	}
@@ -144,7 +144,7 @@ func resetKonnectV2(ctx context.Context) error {
 }
 
 func dumpKonnectV2(ctx context.Context) error {
-	client, err := GetKongClientForKonnectMode(ctx, konnectConfig)
+	client, err := GetKongClientForKonnectMode(ctx, &konnectConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -39,7 +39,7 @@ can connect to Kong's Admin API.`,
 func pingKonnect(ctx context.Context) error {
 	// get Konnect client
 	httpClient := utils.HTTPClient()
-	_, err := GetKongClientForKonnectMode(ctx, konnectConfig)
+	_, err := GetKongClientForKonnectMode(ctx, &konnectConfig)
 	if err != nil {
 		return err
 	}

--- a/tests/integration/test_utils.go
+++ b/tests/integration/test_utils.go
@@ -32,7 +32,7 @@ func getTestClient() (*kong.Client, error) {
 		Password: os.Getenv("DECK_KONNECT_PASSWORD"),
 	}
 	if konnectConfig.Email != "" && konnectConfig.Password != "" {
-		return cmd.GetKongClientForKonnectMode(ctx, konnectConfig)
+		return cmd.GetKongClientForKonnectMode(ctx, &konnectConfig)
 	}
 	return utils.GetKongClient(utils.KongClientConfig{
 		Address: getKongAddress(),


### PR DESCRIPTION
The konnectConfig object gets modified along the way in the process of building a Konnect client.
In order for this to work with the existing 'ping' logic, konnectConfig should be passed as a pointer