### PR TITLE
feat: enhance error messages during dump for plugins

### DIFF
--- a/file/writer.go
+++ b/file/writer.go
@@ -378,7 +378,7 @@ func populatePlugins(kongState *state.KongState, file *Content,
 			cID := *p.Consumer.ID
 			consumer, err := kongState.Consumers.Get(cID)
 			if err != nil {
-				return err
+				return fmt.Errorf("unable to get consumer %s for plugin %s [%s]: %w", cID, *p.Name, *p.ID, err)
 			}
 			if !utils.Empty(consumer.Username) {
 				cID = *consumer.Username
@@ -390,7 +390,7 @@ func populatePlugins(kongState *state.KongState, file *Content,
 			sID := *p.Service.ID
 			service, err := kongState.Services.Get(sID)
 			if err != nil {
-				return err
+				return fmt.Errorf("unable to get service %s for plugin %s [%s]: %w", sID, *p.Name, *p.ID, err)
 			}
 			if !utils.Empty(service.Name) {
 				sID = *service.Name
@@ -402,7 +402,7 @@ func populatePlugins(kongState *state.KongState, file *Content,
 			rID := *p.Route.ID
 			route, err := kongState.Routes.Get(rID)
 			if err != nil {
-				return err
+				return fmt.Errorf("unable to get route %s for plugin %s [%s]: %w", rID, *p.Name, *p.ID, err)
 			}
 			if !utils.Empty(route.Name) {
 				rID = *route.Name


### PR DESCRIPTION
This update adds additional information if a failure occurs when gathering referenced (or parent) resources; consumer, service, and route. The error message will contain the ID of the referenced resource that failed to be retrieved and include the plugin ID and name for easily identifying where the missing resource is referenced.