### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/diff/diff_helpers_test.go
+++ b/diff/diff_helpers_test.go
@@ -1,7 +1,6 @@
 package diff
 
 import (
-	"os"
 	"testing"
 
 	"github.com/kong/deck/konnect"
@@ -167,10 +166,7 @@ func Test_MaskEnvVarsValues(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for k, v := range tt.envVars {
-				os.Setenv(k, v)
-				defer func(k string) {
-					os.Unsetenv(k)
-				}(k)
+				t.Setenv(k, v)
 			}
 			if got := maskEnvVarValue(tt.args); got != tt.want {
 				t.Errorf("maskEnvVarValue() = %v\nwant %v", got, tt.want)

--- a/file/readfile_test.go
+++ b/file/readfile_test.go
@@ -377,10 +377,7 @@ func Test_getContent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for k, v := range tt.envVars {
-				os.Setenv(k, v)
-				defer func(k string) {
-					os.Unsetenv(k)
-				}(k)
+				t.Setenv(k, v)
 			}
 			got, err := getContent(tt.args.filenames)
 			if (err != nil) != tt.wantErr {

--- a/tests/integration/diff_test.go
+++ b/tests/integration/diff_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"os"
 	"testing"
 
 	"github.com/kong/deck/utils"
@@ -141,10 +140,7 @@ func Test_Diff_Masked_OlderThan3x(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			for k, v := range tc.envVars {
-				os.Setenv(k, v)
-				defer func(k string) {
-					os.Unsetenv(k)
-				}(k)
+				t.Setenv(k, v)
 			}
 			runWhen(t, "kong", "==2.8.0")
 			teardown := setup(t)
@@ -180,10 +176,7 @@ func Test_Diff_Masked_NewerThan3x(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			for k, v := range tc.envVars {
-				os.Setenv(k, v)
-				defer func(k string) {
-					os.Unsetenv(k)
-				}(k)
+				t.Setenv(k, v)
 			}
 			runWhen(t, "kong", ">=3.0.0")
 			teardown := setup(t)
@@ -219,10 +212,7 @@ func Test_Diff_Unasked_OlderThan3x(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			for k, v := range tc.envVars {
-				os.Setenv(k, v)
-				defer func(k string) {
-					os.Unsetenv(k)
-				}(k)
+				t.Setenv(k, v)
 			}
 			runWhen(t, "kong", "==2.8.0")
 			teardown := setup(t)
@@ -258,10 +248,7 @@ func Test_Diff_Unasked_NewerThan3x(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			for k, v := range tc.envVars {
-				os.Setenv(k, v)
-				defer func(k string) {
-					os.Unsetenv(k)
-				}(k)
+				t.Setenv(k, v)
 			}
 			runWhen(t, "kong", ">=3.0.0")
 			teardown := setup(t)


### PR DESCRIPTION
A testing cleanup.

This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.Setenv