### PR TITLE
feat: add konnect dev mode for koko support

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -399,7 +399,8 @@ func inKonnectMode(targetContent *file.Content) bool {
 		return true
 	} else if rootConfig.Address != defaultKongURL {
 		return false
-	} else if konnectConfig.Email != "" ||
+	} else if konnectConfig.Dev ||
+		konnectConfig.Email != "" ||
 		konnectConfig.Password != "" ||
 		konnectConfig.Token != "" {
 		return true

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -203,6 +203,16 @@ It can be used to export, import, or sync entities to Kong.`,
 	viper.BindPFlag("konnect-runtime-group-name",
 		rootCmd.PersistentFlags().Lookup("konnect-runtime-group-name"))
 
+	// TMP
+	// when using --konnect-dev with dump, diff or sync,
+	// pass --konnect-runtime-group-name <cluster-id>
+	rootCmd.PersistentFlags().Bool("konnect-dev", false,
+		"Enable konnect local development mode.\n"+
+			"Use this mode to communicate with a koko CP.")
+	rootCmd.Flags().MarkHidden("konnect-dev") // TODO make this one work
+	viper.BindPFlag("konnect-dev",
+		rootCmd.PersistentFlags().Lookup("konnect-dev"))
+
 	rootCmd.AddCommand(newSyncCmd())
 	rootCmd.AddCommand(newVersionCmd())
 	rootCmd.AddCommand(newValidateCmd())
@@ -370,6 +380,7 @@ func initKonnectConfig() error {
 	konnectConfig.Debug = (viper.GetInt("verbose") >= 1)
 	konnectConfig.Address = viper.GetString("konnect-addr")
 	konnectConfig.Headers = extendHeaders(viper.GetStringSlice("headers"))
+	konnectConfig.Dev = viper.GetBool("konnect-dev")
 	konnectRuntimeGroup = viper.GetString("konnect-runtime-group-name")
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kong/deck
 go 1.18
 
 replace github.com/yudai/gojsondiff v1.0.0 => github.com/Kong/gojsondiff v1.3.0
+replace github.com/kong/go-kong v0.34.1-0.20221222170410-6c81ce561662 => /home/aboudreault/dev/kong/go-kong
 
 require (
 	github.com/Kong/gojsondiff v1.3.2

--- a/konnect/client.go
+++ b/konnect/client.go
@@ -75,7 +75,7 @@ func (c *Client) SetControlPlaneID(cpID string) {
 	c.common.controlPlaneID = cpID
 }
 
-// SetControlPlaneID sets the konnect runtime-group ID in the client.
+// SetRuntimeGroupID sets the konnect runtime-group ID in the client.
 func (c *Client) SetRuntimeGroupID(rgID string) {
 	c.common.runtimeGroupID = rgID
 }

--- a/utils/types.go
+++ b/utils/types.go
@@ -116,6 +116,7 @@ type KonnectConfig struct {
 	Password string
 	Token    string
 	Debug    bool
+	Dev      bool
 
 	Address string
 
@@ -172,7 +173,7 @@ func retryPolicy(ctx context.Context, resp *http.Response, err error) (bool, err
 	// 429 Too Many Requests is recoverable. Sometimes the server puts
 	// a Retry-After response header to indicate when the server is
 	// available to start processing request from client.
-	if resp.StatusCode == http.StatusTooManyRequests {
+	if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
 		return true, nil
 	}
 	return false, nil


### PR DESCRIPTION
NOT READY FOR REVIEW

Experimental work for koko support

Use Example:
`deck --konnect-addr http://localhost:3000 --konnect-dev --konnect-runtime-group-name 4168295f-015e-4190-837e-0fcc5d72a52f sync -s kong3.yaml`

require: https://github.com/Kong/go-kong/tree/feat/add-global-query-params