### PR TITLE
fix: workspaces validation with multiple files

### DIFF
--- a/file/readfile.go
+++ b/file/readfile.go
@@ -34,7 +34,9 @@ func getContent(filenames []string) (*Content, error) {
 		if err != nil {
 			return nil, fmt.Errorf("reading file: %w", err)
 		}
-		workspaces = append(workspaces, content.Workspace)
+		if content.Workspace != "" {
+			workspaces = append(workspaces, content.Workspace)
+		}
 		err = mergo.Merge(&res, content, mergo.WithAppendSlice)
 		if err != nil {
 			return nil, fmt.Errorf("merging file contents: %w", err)

--- a/file/readfile_test.go
+++ b/file/readfile_test.go
@@ -398,6 +398,32 @@ func Test_getContent(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "shared workspace",
+			args: args{[]string{"testdata/sharedworkspace"}},
+			want: &Content{
+				FormatVersion: *kong.String("1.1"),
+				Workspace:     *kong.String("bar"),
+				Services: []FService{
+					{
+						Service: kong.Service{
+							Name: kong.String("svc1"),
+							Host: kong.String("1.example.com"),
+							Tags: kong.StringSlice("team-svc1"),
+						},
+						Routes: []*FRoute{
+							{
+								Route: kong.Route{
+									Name:  kong.String("r1"),
+									Paths: kong.StringSlice("/r1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/file/testdata/sharedworkspace/foo.yaml
+++ b/file/testdata/sharedworkspace/foo.yaml
@@ -1,0 +1,9 @@
+services:
+- name: svc1
+  host: 1.example.com
+  tags:
+  - team-svc1
+  routes:
+  - name: r1
+    paths:
+    - /r1

--- a/file/testdata/sharedworkspace/meta.yaml
+++ b/file/testdata/sharedworkspace/meta.yaml
@@ -1,0 +1,2 @@
+_format_version: "1.1"
+_workspace: bar


### PR DESCRIPTION
When running `deck sync` with multiple state files, either by passing multiple `-s` flags
(e.g. `-s foo.yaml -s bar.yaml`) or by passing a folder (e.g. `-s ./statefiles`), decK merges the whole configuration from all files and it fails the content validation if different `_workspace` entries are found. While this is good and expected by design, decK also fails in the following case:

```
$ cat foo.yaml

services:
- name: svc1
  host: 1.example.com
  tags:
  - team-svc1
  routes:
  - name: r1
    paths:
    - /r1

$ cat meta.yaml

_format_version: "1.1"
_workspace: bar
```

The error from decK would be the following:

```
$ deck sync -s meta.yaml -s foo.yaml

Error: it seems like you are trying to sync multiple workspaces at the same time ([ bar]).
decK doesn't support syncing multiple workspaces at the same time, please sync one workspace at a time
```

The reason why decK is failing is because it's adding an empty workspace to the array used for validation because the `foo.yaml` state file is missing the `_workspace` entry.

This commit makes sure that the "emtpy workspace" is not considered at workspace validation time.