### PR TITLE
chore(ci): update deprecated flag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload assets


### PR DESCRIPTION
fixes this warning: https://github.com/Kong/deck/actions/runs/4232904021/jobs/7353197221#step:4:20

docs: https://goreleaser.com/deprecations/#-rm-dist