### PR TITLE
feat: add toBool function for template

### DIFF
--- a/file/readfile.go
+++ b/file/readfile.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -145,9 +146,14 @@ func getPrefixedEnvVar(key string) (string, error) {
 	return value, nil
 }
 
+func toBool(key string) (bool, error) {
+	return strconv.ParseBool(key)
+}
+
 func renderTemplate(content string) (string, error) {
 	t := template.New("state").Funcs(template.FuncMap{
-		"env": getPrefixedEnvVar,
+		"env":    getPrefixedEnvVar,
+		"toBool": toBool,
 	}).Delims("${{", "}}")
 	t, err := t.Parse(content)
 	if err != nil {

--- a/file/readfile_test.go
+++ b/file/readfile_test.go
@@ -424,6 +424,33 @@ func Test_getContent(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "file with env var and parse bool",
+			args: args{[]string{"testdata/parsebool/file.yaml"}},
+			envVars: map[string]string{
+				"DECK_MOCKBIN_ENABLED": "true",
+			},
+			want: &Content{
+				Services: []FService{
+					{
+						Service: kong.Service{
+							Name:    kong.String("svc1"),
+							Host:    kong.String("mockbin.org"),
+							Enabled: kong.Bool(true),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "file with env var and parse bool - err on bad value",
+			args: args{[]string{"testdata/parsebool/file.yaml"}},
+			envVars: map[string]string{
+				"DECK_MOCKBIN_ENABLED": "RIP",
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/file/testdata/parsebool/file.yaml
+++ b/file/testdata/parsebool/file.yaml
@@ -1,0 +1,4 @@
+services:
+- name: svc1
+  host: mockbin.org
+  enabled: ${{ env "DECK_MOCKBIN_ENABLED" | toBool }}


### PR DESCRIPTION
Currently Deck parses env variable in templates and renders it only as string, with other types it creates issues like having boolean flags for example. With this PR we can do this:

```yaml
services:
- name: svc1
  host: mockbin.org
  enabled: ${{ env "DECK_MOCKBIN_ENABLED" | toBool }}
```

Also i think we might want to do the same for Int / floats in the future