### PR TITLE
feat(diff) retry on 404s for Konnect delete events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,13 @@
 - [v0.2.0](#v020)
 - [v0.1.0](#v010)
 
+## Unreleased
+
+### Add
+
+- Retry Konnect delete 404s and increase the Konnect retry backoff multiplier.
+  [#894](https://github.com/Kong/deck/pull/894)
+
 ## [v1.19.1]
 
 > Release date: 2023/03/21

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -24,8 +24,8 @@ var errEnqueueFailed = errors.New("failed to queue event")
 func defaultBackOff() backoff.BackOff {
 	// For various reasons, Kong can temporarily fail to process
 	// a valid request (e.g. when the database is under heavy load).
-	// We retry each request up to 3 times on failure, after around
-	// 1 second, 3 seconds, and 9 seconds (randomized exponential backoff).
+	// We retry each request up to 5 times on failure, with a 3x
+	// exponential backoff multiplier
 	exponentialBackoff := backoff.NewExponentialBackOff()
 	exponentialBackoff.InitialInterval = 1 * time.Second
 	exponentialBackoff.Multiplier = 3

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -333,6 +333,14 @@ func (sc *Syncer) handleEvent(ctx context.Context, d Do, event crud.Event) error
 				return err
 			}
 
+			if errors.As(err, &kongAPIError) &&
+				kongAPIError.Code() == http.StatusNotFound &&
+				sc.konnectClient != nil {
+				// Konnect may take some time to completely persist a resource. When tests rapidly create and then
+				// delete a resource, the delete will encounter a 404 if the resource hasn't fully persisted
+				return err
+			}
+
 			// Do not retry on other status codes
 			return backoff.Permanent(err)
 		}


### PR DESCRIPTION
Retry on 404s if running against Konnect, and increase the backoff multiplier for Konnect requests.

Konnect tests flake because many tests rapidly create and then delete resources. Konnect may have a persistence delay that exceeds the time between the test requests. If the delay is that long, the second request will encounter a 404, failing the test.

This issue likely will not appear during normal user workflows. I would not expect typical usage in the wild to rapidly create and then delete the same resource. If that is indeed the case, this only affects tests.

This only applies to deletes, as creates are only idempotent when the target state provides an ID. Deletes are definitely idempotent and should be sufficient to address the test problem. Updates sometimes use GET+PUT and sometimes use PATCH., and enumerating the safe types would be quite messy.

CI runs indicated there were still some flakes even with the retry. AFAICT these are from failing past the final retry, so I've furthermore increased the Konnect backoff multiplier. https://github.com/Kong/deck/actions/runs/4725109488 with that succeeded on all three tries, and the flake was previously quite common.

Edit: the final changelog update hit the flake again, so this isn't perfect. It does subjectively make the issue less common, but doesn't avoid it completely.