### PR TITLE
chore: filter test action conditions

### DIFF
--- a/.github/workflows/integration-enterprise-nightly.yaml
+++ b/.github/workflows/integration-enterprise-nightly.yaml
@@ -1,6 +1,10 @@
 name: Enterprise Integration Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - main
+  pull_request: {}
 
 jobs:
   runnable:

--- a/.github/workflows/integration-enterprise.yaml
+++ b/.github/workflows/integration-enterprise.yaml
@@ -1,6 +1,10 @@
 name: Enterprise Integration Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - main
+  pull_request: {}
 
 jobs:
   integration:

--- a/.github/workflows/integration-konnect.yaml
+++ b/.github/workflows/integration-konnect.yaml
@@ -1,6 +1,6 @@
 name: Konnect Integration Test
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   integration:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,6 +1,10 @@
 name: Integration Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - main
+  pull_request: {}
 
 jobs:
   integration:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,10 @@
 name: CI Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - main
+  pull_request: {}
 
 jobs:
   test:


### PR DESCRIPTION
Filter the push test condition to the main branch only, so that pull requests do not run duplicate tests for their pull and their branch push.

https://github.com/rainest/deck/actions/runs/4736968342 is a fork test of the main push condition.

This is an alternative to https://github.com/Kong/deck/pull/894 that does not change deck behavior, on the working hypothesis that there's a race between the two jobs for Konnect interactions.

https://github.com/Kong/deck/actions/runs/4736946073 succeeded on all 5 runs, which is promising.