### PR TITLE
fix: handle nil pointer dereference in `Defaulter.getEntitySchema`

### DIFF
--- a/utils/defaulter.go
+++ b/utils/defaulter.go
@@ -215,12 +215,15 @@ func (d *Defaulter) getEntitySchema(entityType string) (map[string]interface{}, 
 		return schema, err
 	}
 	resp, err := d.client.Do(d.ctx, req, &schema)
+	if err != nil {
+		return schema, err
+	}
 	// in case the schema is not found - like in case of EE features,
 	// no error should be returned.
 	if resp.StatusCode == http.StatusNotFound {
 		return schema, nil
 	}
-	return schema, err
+	return schema, nil
 }
 
 func (d *Defaulter) addEntityDefaults(entityType string, entity interface{}) error {


### PR DESCRIPTION
Corrects a nil pointer dereference when `Defaulter.getEntitySchema()` is called & the HTTP request fails.