### PR TITLE
feat: allow updating entities' IDs while keeping their names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,16 @@
 - [v0.2.0](#v020)
 - [v0.1.0](#v010)
 
+## [v1.21.0]
+
+> Release date: TBD
+
+### Add
+
+- Add support for updating Services, Routes, and Consumers by changing their IDs,
+  but retaining their names.
+  [#918](https://github.com/Kong/deck/pull/918)
+
 ## [v1.20.0]
 
 > Release date: 2023/04/24
@@ -63,7 +73,6 @@
 ### Add
 
 - Add the license type to the file package.
-
 
 ## [v1.19.1]
 

--- a/diff/order_test.go
+++ b/diff/order_test.go
@@ -4,7 +4,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/kong/deck/crud"
 	"github.com/kong/deck/types"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_reverse(t *testing.T) {
@@ -47,4 +49,43 @@ func Test_reverse(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEventsInOrder(t *testing.T) {
+	e := func(entityType types.EntityType) crud.Event {
+		return crud.Event{Kind: crud.Kind(entityType)}
+	}
+
+	eventsOutOfOrder := []crud.Event{
+		e(types.Consumer),
+		e(types.Service),
+		e(types.KeyAuth),
+		e(types.Route),
+		e(types.ServicePackage),
+		e(types.ConsumerGroup),
+		e(types.ServiceVersion),
+		e(types.Plugin),
+	}
+
+	order := reverseOrder()
+	result := eventsInOrder(eventsOutOfOrder, order)
+
+	require.Equal(t, [][]crud.Event{
+		{
+			e(types.Plugin),
+		},
+		{
+			e(types.Route),
+			e(types.ServiceVersion),
+		},
+		{
+			e(types.Service),
+			e(types.KeyAuth),
+			e(types.ConsumerGroup),
+		},
+		{
+			e(types.Consumer),
+			e(types.ServicePackage),
+		},
+	}, result)
 }

--- a/tests/integration/test_utils.go
+++ b/tests/integration/test_utils.go
@@ -10,7 +10,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-
 	"github.com/kong/deck/cmd"
 	deckDump "github.com/kong/deck/dump"
 	"github.com/kong/deck/utils"

--- a/tests/integration/test_utils.go
+++ b/tests/integration/test_utils.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/kong/deck/cmd"
 	deckDump "github.com/kong/deck/dump"
 	"github.com/kong/deck/utils"

--- a/tests/integration/testdata/sync/020-same-names-altered-ids/1-before.yaml
+++ b/tests/integration/testdata/sync/020-same-names-altered-ids/1-before.yaml
@@ -1,0 +1,26 @@
+_format_version: "3.0"
+services:
+  - id: 18076db2-28b6-423b-ba39-a797193017f7     # Changing ID,
+    name: s1                                     # leaving the same name.
+    host: "mockbin.org"
+    routes:
+      - id: 17b6a97e-f3f7-4c47-857a-7464cb9e202b # Changing ID,
+        name: r1                                 # leaving the same name.
+        paths:
+          - /r1
+consumers:
+  - id: 5a1e49a8-2536-41fa-a4e9-605bf218a4fa     # Changing ID,
+    username: c1                                 # leaving the same name.
+plugins:
+  - name: rate-limiting
+    config:
+      second: 1
+    service: s1
+  - name: rate-limiting
+    config:
+      second: 1
+    route: r1
+  - name: rate-limiting
+    config:
+      second: 1
+    consumer: c1

--- a/tests/integration/testdata/sync/020-same-names-altered-ids/2-before.yaml
+++ b/tests/integration/testdata/sync/020-same-names-altered-ids/2-before.yaml
@@ -1,0 +1,26 @@
+_format_version: "3.0"
+services:
+  - id: 18076db2-28b6-423b-ba39-a797193017f7     # Changing ID,
+    name: s1                                     # leaving the same name.
+    host: "mockbin.org"
+    routes:
+      - id: 97b6a97e-f3f7-4c47-857a-7464cb9e202b
+        name: r1
+        paths:
+          - /r1
+consumers:
+  - id: 5a1e49a8-2536-41fa-a4e9-605bf218a4fa     # Changing ID,
+    username: c1                                 # leaving the same name.
+plugins:
+  - name: rate-limiting
+    config:
+      second: 1
+    service: s1
+  - name: rate-limiting
+    config:
+      second: 1
+    route: r1
+  - name: rate-limiting
+    config:
+      second: 1
+    consumer: c1

--- a/tests/integration/testdata/sync/020-same-names-altered-ids/3-before.yaml
+++ b/tests/integration/testdata/sync/020-same-names-altered-ids/3-before.yaml
@@ -1,0 +1,26 @@
+_format_version: "3.0"
+services:
+  - id: 98076db2-28b6-423b-ba39-a797193017f7
+    name: s1
+    host: "mockbin.org"
+    routes:
+      - id: 17b6a97e-f3f7-4c47-857a-7464cb9e202b # Changing ID,
+        name: r1                                 # leaving the same name.
+        paths:
+          - /r1
+consumers:
+  - id: 5a1e49a8-2536-41fa-a4e9-605bf218a4fa     # Changing ID,
+    username: c1                                 # leaving the same name.
+plugins:
+  - name: rate-limiting
+    config:
+      second: 1
+    service: s1
+  - name: rate-limiting
+    config:
+      second: 1
+    route: r1
+  - name: rate-limiting
+    config:
+      second: 1
+    consumer: c1

--- a/tests/integration/testdata/sync/020-same-names-altered-ids/desired.yaml
+++ b/tests/integration/testdata/sync/020-same-names-altered-ids/desired.yaml
@@ -1,0 +1,26 @@
+_format_version: "3.0"
+services:
+  - id: 98076db2-28b6-423b-ba39-a797193017f7
+    name: s1
+    host: "mockbin.org"
+    routes:
+      - id: 97b6a97e-f3f7-4c47-857a-7464cb9e202b
+        name: r1
+        paths:
+          - /r1
+consumers:
+  - id: 9a1e49a8-2536-41fa-a4e9-605bf218a4fa
+    username: c1
+plugins:
+  - name: rate-limiting
+    config:
+      second: 1
+    service: s1
+  - name: rate-limiting
+    config:
+      second: 1
+    route: r1
+  - name: rate-limiting
+    config:
+      second: 1
+    consumer: c1

--- a/tests/integration/testdata/sync/021-update-with-explicit-ids/after.yaml
+++ b/tests/integration/testdata/sync/021-update-with-explicit-ids/after.yaml
@@ -1,0 +1,18 @@
+_format_version: "3.0"
+services:
+  - enabled: true
+    host: mockbin.org
+    id: c75a775b-3a32-4b73-8e05-f68169c23941     # Leaving ID
+    name: s1                                     # and name unchanged.
+    port: 80
+    tags: [after]
+    routes:
+      - id: 97b6a97e-f3f7-4c47-857a-7464cb9e202b # Leaving ID
+        name: r1                                 # and name unchanged.
+        paths:
+          - /r1
+        tags: [after]
+consumers:
+  - id: 9a1e49a8-2536-41fa-a4e9-605bf218a4fa # Leaving ID
+    username: c1                             # and username unchanged.
+    tags: [after]

--- a/tests/integration/testdata/sync/021-update-with-explicit-ids/before.yaml
+++ b/tests/integration/testdata/sync/021-update-with-explicit-ids/before.yaml
@@ -1,0 +1,15 @@
+_format_version: "3.0"
+services:
+  - enabled: true
+    host: mockbin.org
+    id: c75a775b-3a32-4b73-8e05-f68169c23941     # Leaving ID
+    name: s1                                     # and name unchanged.
+    port: 80
+    routes:
+      - id: 97b6a97e-f3f7-4c47-857a-7464cb9e202b # Leaving ID
+        name: r1                                 # and name unchanged.
+        paths:
+          - /r1
+consumers:
+  - id: 9a1e49a8-2536-41fa-a4e9-605bf218a4fa # Leaving ID
+    username: c1                             # and username unchanged.

--- a/types/core.go
+++ b/types/core.go
@@ -14,6 +14,12 @@ type Differ interface {
 	CreateAndUpdates(func(crud.Event) error) error
 }
 
+type DuplicatesDeleter interface {
+	// DuplicatesDeletes returns delete events for entities that have duplicates in the current and target state.
+	// A duplicate is defined as an entity with the same name but different ID.
+	DuplicatesDeletes() ([]crud.Event, error)
+}
+
 type Entity interface {
 	Type() EntityType
 	CRUDActions() crud.Actions

--- a/types/postProcess.go
+++ b/types/postProcess.go
@@ -22,12 +22,12 @@ func (crud *servicePostAction) Delete(_ context.Context, args ...crud.Arg) (crud
 	// Delete all plugins associated with this service as that's the implicit behavior of Kong (cascade delete).
 	plugins, err := crud.currentState.Plugins.GetAllByServiceID(serviceID)
 	if err != nil {
-		return nil, fmt.Errorf("error looking up plugins for service '%v': %v", serviceID, err)
+		return nil, fmt.Errorf("error looking up plugins for service '%v': %w", serviceID, err)
 	}
 	for _, plugin := range plugins {
 		err = crud.currentState.Plugins.Delete(*plugin.ID)
 		if err != nil {
-			return nil, fmt.Errorf("error deleting plugin '%v' for service '%v': %v", *plugin.ID, serviceID, err)
+			return nil, fmt.Errorf("error deleting plugin '%v' for service '%v': %w", *plugin.ID, serviceID, err)
 		}
 	}
 	return nil, crud.currentState.Services.Delete(serviceID)
@@ -51,12 +51,12 @@ func (crud *routePostAction) Delete(_ context.Context, args ...crud.Arg) (crud.A
 	// Delete all plugins associated with this route as that's the implicit behavior of Kong (cascade delete).
 	plugins, err := crud.currentState.Plugins.GetAllByRouteID(routeID)
 	if err != nil {
-		return nil, fmt.Errorf("error looking up plugins for route '%v': %v", routeID, err)
+		return nil, fmt.Errorf("error looking up plugins for route '%v': %w", routeID, err)
 	}
 	for _, plugin := range plugins {
 		err = crud.currentState.Plugins.Delete(*plugin.ID)
 		if err != nil {
-			return nil, fmt.Errorf("error deleting plugin '%v' for route '%v': %v", *plugin.ID, routeID, err)
+			return nil, fmt.Errorf("error deleting plugin '%v' for route '%v': %w", *plugin.ID, routeID, err)
 		}
 	}
 	return nil, crud.currentState.Routes.Delete(routeID)
@@ -178,11 +178,11 @@ func (crud *consumerPostAction) Delete(_ context.Context, args ...crud.Arg) (cru
 	// Delete all plugins associated with this consumer as that's the implicit behavior of Kong (cascade delete).
 	plugins, err := crud.currentState.Plugins.GetAllByConsumerID(consumerID)
 	if err != nil {
-		return nil, fmt.Errorf("error looking up plugins for consumer '%v': %v", consumerID, err)
+		return nil, fmt.Errorf("error looking up plugins for consumer '%v': %w", consumerID, err)
 	}
 	for _, plugin := range plugins {
 		if err := crud.currentState.Plugins.Delete(*plugin.ID); err != nil {
-			return nil, fmt.Errorf("error deleting plugin '%v' for consumer '%v': %v", *plugin.ID, consumerID, err)
+			return nil, fmt.Errorf("error deleting plugin '%v' for consumer '%v': %w", *plugin.ID, consumerID, err)
 		}
 	}
 	return nil, crud.currentState.Consumers.Delete(consumerID)

--- a/types/route.go
+++ b/types/route.go
@@ -165,3 +165,43 @@ func (d *routeDiffer) createUpdateRoute(route *state.Route) (*crud.Event, error)
 	}
 	return nil, nil
 }
+
+func (d *routeDiffer) DuplicatesDeletes() ([]crud.Event, error) {
+	targetRoutes, err := d.targetState.Routes.GetAll()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching routes from state: %w", err)
+	}
+
+	var events []crud.Event
+	for _, route := range targetRoutes {
+		event, err := d.deleteDuplicateRoute(route)
+		if err != nil {
+			return nil, err
+		}
+		if event != nil {
+			events = append(events, *event)
+		}
+	}
+
+	return events, nil
+}
+
+func (d *routeDiffer) deleteDuplicateRoute(targetRoute *state.Route) (*crud.Event, error) {
+	currentRoute, err := d.currentState.Routes.Get(*targetRoute.Name)
+	if err == state.ErrNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("error looking up route %q: %w", *targetRoute.Name, err)
+	}
+
+	if *currentRoute.ID != *targetRoute.ID {
+		return &crud.Event{
+			Op:   crud.Delete,
+			Kind: "route",
+			Obj:  currentRoute,
+		}, nil
+	}
+
+	return nil, nil
+}

--- a/types/service.go
+++ b/types/service.go
@@ -58,7 +58,7 @@ func (s *serviceCRUD) Update(ctx context.Context, arg ...crud.Arg) (crud.Arg, er
 	event := crud.EventFromArg(arg[0])
 	service := serviceFromStruct(event)
 
-	updatedService, err := s.client.Services.Update(ctx, &service.Service)
+	updatedService, err := s.client.Services.Create(ctx, &service.Service)
 	if err != nil {
 		return nil, err
 	}
@@ -116,12 +116,12 @@ func (d *serviceDiffer) CreateAndUpdates(handler func(crud.Event) error) error {
 	}
 
 	for _, service := range targetServices {
-		event, err := d.createUpdateService(service)
+		n, err := d.createUpdateService(service)
 		if err != nil {
 			return err
 		}
-		if event != nil {
-			err = handler(*event)
+		if n != nil {
+			err = handler(*n)
 			if err != nil {
 				return err
 			}

--- a/types/service.go
+++ b/types/service.go
@@ -58,7 +58,7 @@ func (s *serviceCRUD) Update(ctx context.Context, arg ...crud.Arg) (crud.Arg, er
 	event := crud.EventFromArg(arg[0])
 	service := serviceFromStruct(event)
 
-	updatedService, err := s.client.Services.Create(ctx, &service.Service)
+	updatedService, err := s.client.Services.Update(ctx, &service.Service)
 	if err != nil {
 		return nil, err
 	}
@@ -116,12 +116,12 @@ func (d *serviceDiffer) CreateAndUpdates(handler func(crud.Event) error) error {
 	}
 
 	for _, service := range targetServices {
-		n, err := d.createUpdateService(service)
+		event, err := d.createUpdateService(service)
 		if err != nil {
 			return err
 		}
-		if n != nil {
-			err = handler(*n)
+		if event != nil {
+			err = handler(*event)
 			if err != nil {
 				return err
 			}
@@ -155,5 +155,93 @@ func (d *serviceDiffer) createUpdateService(service *state.Service) (*crud.Event
 			OldObj: currentService,
 		}, nil
 	}
+	return nil, nil
+}
+
+func (d *serviceDiffer) DuplicatesDeletes() ([]crud.Event, error) {
+	targetServices, err := d.targetState.Services.GetAll()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching services from state: %w", err)
+	}
+	var events []crud.Event
+	for _, service := range targetServices {
+		serviceEvents, err := d.deleteDuplicateService(service)
+		if err != nil {
+			return nil, err
+		}
+		events = append(events, serviceEvents...)
+	}
+
+	return events, nil
+}
+
+func (d *serviceDiffer) deleteDuplicateService(targetService *state.Service) ([]crud.Event, error) {
+	currentService, err := d.currentState.Services.Get(*targetService.Name)
+	if err == state.ErrNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("error looking up service %q: %w",
+			*targetService.Name, err)
+	}
+
+	if *currentService.ID != *targetService.ID {
+		// Found a duplicate, delete it along with all routes and plugins associated with it.
+		var events []crud.Event
+
+		// We have to delete all routes beforehand as otherwise we will get a foreign key error when deleting the service
+		// as routes are not deleted by the cascading delete of the service.
+		// See https://github.com/Kong/kong/discussions/7314 for more details.
+		routesToDelete, err := d.currentState.Routes.GetAllByServiceID(*currentService.ID)
+		if err != nil {
+			return nil, fmt.Errorf("error looking up routes for service %q: %w",
+				*currentService.Name, err)
+		}
+
+		for _, route := range routesToDelete {
+			// We have to delete all plugins associated with the route to make sure they'll be recreated eventually.
+			// Plugins are deleted by the cascading delete of the route and without us generating a delete event manually,
+			// they could not be later recreated in createUpdates stage of the diff.
+			// By generating a delete event for each plugin, we make sure that the implicit deletion of plugins is handled
+			// in the local state and createUpdate stage can recreate them.
+			pluginsToDelete, err := d.currentState.Plugins.GetAllByRouteID(*route.ID)
+			if err != nil {
+				return nil, fmt.Errorf("error looking up plugins for route %q: %w",
+					*route.Name, err)
+			}
+
+			for _, plugin := range pluginsToDelete {
+				if err := d.currentState.Plugins.Delete(*plugin.ID); err != nil {
+					return nil, fmt.Errorf("error deleting plugin %q for route %q: %w",
+						*route.Name, *plugin.Name, err)
+				}
+				// REVIEW: Should we generate a delete event for the plugin? It will always result in a DELETE
+				// call for this plugin while it could be just a local state change as we already know it's going
+				// to be deleted by the cascading delete of the route.
+				//
+				// It's also problematic when syncing with Konnect as Koko returns 404 when trying to delete a plugin
+				// that doesn't exist. It's not an issue when syncing with Kong as Kong returns 204.
+				//
+				//events = append(events, crud.Event{
+				//	Op:   crud.Delete,
+				//	Kind: "plugin",
+				//	Obj:  plugin,
+				//})
+			}
+
+			events = append(events, crud.Event{
+				Op:   crud.Delete,
+				Kind: "route",
+				Obj:  route,
+			})
+		}
+
+		return append(events, crud.Event{
+			Op:   crud.Delete,
+			Kind: "service",
+			Obj:  currentService,
+		}), nil
+	}
+
 	return nil, nil
 }


### PR DESCRIPTION
This adds an additional step to the `diff.Syncer`'s `diff` producer - `deleteDuplicates`. Its purpose is to clean up the entities in the **current** state that have duplicates with the same names in the **target** state before proceeding with updates/creates and regular deletes. Without that additional step, it's not possible to perform sync in which the IDs of entities are changed while their names are kept between syncs. 

An actual use-case that is the motivation for this change is Kong Ingress Controller where we recently started assigning entities' IDs explicitly. Without this change, existing setups break when KIC is upgraded from the version not setting the IDs to the new one because of breaking the uniqueness constraints of Services, Routes, and Consumers.

The added test cases represent the complete use case with all the affected entities: Services, Routes, and Consumers. We change their IDs, keeping the names and we expect the final state on the Kong side to be using the new IDs. 

The problematic part of the implementation is how Services are handled - we cannot safely delete them as they might be referred by Routes. When they do, deletes fail as there's no cascade delete for them configured and foreign key constraint is violated. Because of that, in the Service's `deleteDuplicateService` implementation, we have to manually generate delete events for the associated Routes and, in consequence, their Plugins. It is to make sure they'll be recreated in the later stage of the diff command - `createUpdate`.

That gives us more headache as that means we generate events that shouldn't be handled in parallel in the case of Service. Because of that, higher level events rearranging needs to happen to make sure they are all handled in the expected `reverseOrder`, just as the regular `delete` events.

It's a prerequisite for solving https://github.com/Kong/kubernetes-ingress-controller/issues/4025. 