### PR TITLE
feat: Add indent function to support multi-line content

### DIFF
--- a/file/readfile.go
+++ b/file/readfile.go
@@ -158,12 +158,18 @@ func toFloat(key string) (float64, error) {
 	return strconv.ParseFloat(key, 64)
 }
 
+func indent(spaces int, v string) string {
+	pad := strings.Repeat(" ", spaces)
+	return strings.Replace(v, "\n", "\n"+pad, -1)
+}
+
 func renderTemplate(content string) (string, error) {
 	t := template.New("state").Funcs(template.FuncMap{
 		"env":     getPrefixedEnvVar,
 		"toBool":  toBool,
 		"toInt":   toInt,
 		"toFloat": toFloat,
+		"indent":  indent,
 	}).Delims("${{", "}}")
 	t, err := t.Parse(content)
 	if err != nil {

--- a/file/readfile_test.go
+++ b/file/readfile_test.go
@@ -172,6 +172,17 @@ func Test_getContent(t *testing.T) {
 			args: args{[]string{"testdata/file.yaml"}},
 			envVars: map[string]string{
 				"DECK_SVC2_HOST": "2.example.com",
+				"DECK_FILE_LOG_FUNCTION": `
+function parse_traceid(str)str = string.sub(str,1,8)
+  local uint = 0
+  for i = 1, #str do
+    uint = uint + str:byte(i) * 0x100^(i-1)
+  end
+  return string.format("%.0f", uint)
+end
+
+kong.log.set_serialize_value("trace_id", parse_traceid(ngx.ctx.KONG_SPANS[1].trace_id))
+kong.log.set_serialize_value("span_id", parse_traceid(ngx.ctx.KONG_SPANS[1].span_id))`,
 			},
 			want: &Content{
 				Services: []FService{
@@ -195,6 +206,25 @@ func Test_getContent(t *testing.T) {
 					{
 						Plugin: kong.Plugin{
 							Name: kong.String("prometheus"),
+						},
+					},
+					{
+						Plugin: kong.Plugin{
+							Name: kong.String("pre-function"),
+							Config: kong.Configuration{
+								"log": `
+function parse_traceid(str)str = string.sub(str,1,8)
+  local uint = 0
+  for i = 1, #str do
+    uint = uint + str:byte(i) * 0x100^(i-1)
+  end
+  return string.format("%.0f", uint)
+end
+
+kong.log.set_serialize_value("trace_id", parse_traceid(ngx.ctx.KONG_SPANS[1].trace_id))
+kong.log.set_serialize_value("span_id", parse_traceid(ngx.ctx.KONG_SPANS[1].span_id))
+`,
+							},
 						},
 					},
 				},
@@ -220,7 +250,8 @@ func Test_getContent(t *testing.T) {
 			name: "multiple files",
 			args: args{[]string{"testdata/file.yaml", "testdata/file.json"}},
 			envVars: map[string]string{
-				"DECK_SVC2_HOST": "2.example.com",
+				"DECK_SVC2_HOST":         "2.example.com",
+				"DECK_FILE_LOG_FUNCTION": "kong.log.set_serialize_value('trace_id', 1))",
 			},
 			want: &Content{
 				Services: []FService{
@@ -244,6 +275,14 @@ func Test_getContent(t *testing.T) {
 					{
 						Plugin: kong.Plugin{
 							Name: kong.String("prometheus"),
+						},
+					},
+					{
+						Plugin: kong.Plugin{
+							Name: kong.String("pre-function"),
+							Config: kong.Configuration{
+								"log": "kong.log.set_serialize_value('trace_id', 1))\n",
+							},
 						},
 					},
 				},

--- a/file/testdata/file.yaml
+++ b/file/testdata/file.yaml
@@ -9,3 +9,7 @@ services:
     - '<' # verifies that the templating engine does not perform character escaping
 plugins:
 - name: prometheus
+- name: pre-function
+  config:
+    log: |
+      ${{ env "DECK_FILE_LOG_FUNCTION" | indent 8 }}


### PR DESCRIPTION
We want to extract Lua code from `kong.yaml` file for two reasons:
1. Better syntax highlight in the IDE for .lua files
2. Write unit tests for the functions

So, we would like to have a setup like that:

**kong.yaml**
```yaml
---
_format_version: "3.0"
plugins:
  - name: pre-function
    config:
      log: |
        ${{ env "DECK_FILE_LOG_FUNCTION" | indent 8 }}
```

**file_log.lua**
```lua
function parse_traceid(str)str = string.sub(str,1,8)
  local uint = 0
  for i = 1, #str do
    uint = uint + str:byte(i) * 0x100^(i-1)
  end
  return string.format("%.0f", uint)
end

kong.log.set_serialize_value("trace_id", parse_traceid(ngx.ctx.KONG_SPANS[1].trace_id))
kong.log.set_serialize_value("span_id", parse_traceid(ngx.ctx.KONG_SPANS[1].span_id))
```

However, without the `indent` function, it is not possible to convert the yaml to json. It fails due indentation required by yaml. This issue https://github.com/Kong/deck/issues/616 worked around this problem, replacing yaml with json, where you have better control of quotes.

But we would like consistency in the setup; it means using yaml everywhere. Inspired by `k8s helm`, where function indent is available https://helm.sh/docs/chart_template_guide/function_list/#indent to deal with multi-line block, I added the indent function to deck.
