### PR TITLE
chore: add a GitHub action for validating Kong Gateway images

### DIFF
--- a/.github/workflows/validate-kong-release.yaml
+++ b/.github/workflows/validate-kong-release.yaml
@@ -1,0 +1,38 @@
+name: Validate Kong Gateway Release
+concurrency:
+  group: ${{ github.workflow }}
+on:
+  workflow_dispatch:
+    inputs:
+      kong_image:
+        description: 'Kong Gateway Docker Image'
+        required: true
+        default: 'kong/kong-gateway-dev:latest'
+      branch:
+        description: 'decK Branch'
+        required: true
+        default: 'main'
+jobs:
+  integration:
+    name: "Validating Kong Gateway ${{ inputs.kong_image }} against decK branch ${{ inputs.branch }}"
+    env:
+      KONG_ANONYMOUS_REPORTS: "off"
+      KONG_IMAGE: ${{ inputs.kong_image }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Execution Information
+        run: |
+          echo "Kong Gateway Image = ${{ inputs.kong_image }}"
+          echo "decK Branch = ${{ inputs.branch }}"
+      - name: Setup go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '^1.20'
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.branch }}
+      - name: Setup Kong
+        run: make setup-kong
+      - name: Run integration tests
+        run: make test-integration


### PR DESCRIPTION
This commit adds a workflow with two inputs to supply the Kong Gateway image and decK branch to test against.