### PR TITLE
chore: refactor the cli command structure

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/kong/deck/convert"
@@ -18,61 +19,73 @@ var (
 	convertCmdAssumeYes         bool
 )
 
+func executeConvert(_ *cobra.Command, _ []string) error {
+	sourceFormat, err := convert.ParseFormat(convertCmdSourceFormat)
+	if err != nil {
+		return err
+	}
+	destinationFormat, err := convert.ParseFormat(convertCmdDestinationFormat)
+	if err != nil {
+		return err
+	}
+
+	if convertCmdInputFile != "" {
+		if yes, err := utils.ConfirmFileOverwrite(
+			convertCmdOutputFile, "", convertCmdAssumeYes,
+		); err != nil {
+			return err
+		} else if !yes {
+			return nil
+		}
+
+		err = convert.Convert(convertCmdInputFile, convertCmdOutputFile, sourceFormat, destinationFormat)
+		if err != nil {
+			return fmt.Errorf("converting file: %w", err)
+		}
+	} else if is2xTo3xConversion() {
+		path, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("getting current working directory: %w", err)
+		}
+		files, err := utils.ConfigFilesInDir(path)
+		if err != nil {
+			return fmt.Errorf("getting files from directory: %w", err)
+		}
+		for _, filename := range files {
+			err = convert.Convert(filename, filename, sourceFormat, destinationFormat)
+			if err != nil {
+				return fmt.Errorf("converting '%s' file: %w", filename, err)
+			}
+		}
+	}
+	if convertCmdDestinationFormat == "konnect" {
+		cprint.UpdatePrintf("Warning: konnect format type was deprecated in v1.12 and it will be removed\n" +
+			"in a future version. Please use your Kong configuration files with deck <cmd>.\n" +
+			"Please see https://docs.konghq.com/konnect/getting-started/import/.\n")
+	}
+	return nil
+}
+
 // newConvertCmd represents the convert command
-func newConvertCmd() *cobra.Command {
+func newConvertCmd(deprecated bool) *cobra.Command {
+	short := "Convert files from one format into another format"
+	execute := executeConvert
+	if deprecated {
+		short = "[deprecated] use 'file convert' instead"
+		execute = func(cmd *cobra.Command, args []string) error {
+			log.Println("Warning: the 'deck convert' command was deprecated and moved to 'deck file convert'")
+			return executeConvert(cmd, args)
+		}
+	}
+
 	convertCmd := &cobra.Command{
 		Use:   "convert",
-		Short: "Convert files from one format into another format",
+		Short: short,
 		Long: `The convert command changes configuration files from one format
 into another compatible format. For example, a configuration for 'kong-gateway-2.x'
 can be converted into a 'kong-gateway-3.x' configuration file.`,
 		Args: validateNoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			sourceFormat, err := convert.ParseFormat(convertCmdSourceFormat)
-			if err != nil {
-				return err
-			}
-			destinationFormat, err := convert.ParseFormat(convertCmdDestinationFormat)
-			if err != nil {
-				return err
-			}
-
-			if convertCmdInputFile != "" {
-				if yes, err := utils.ConfirmFileOverwrite(
-					convertCmdOutputFile, "", convertCmdAssumeYes,
-				); err != nil {
-					return err
-				} else if !yes {
-					return nil
-				}
-
-				err = convert.Convert(convertCmdInputFile, convertCmdOutputFile, sourceFormat, destinationFormat)
-				if err != nil {
-					return fmt.Errorf("converting file: %w", err)
-				}
-			} else if is2xTo3xConversion() {
-				path, err := os.Getwd()
-				if err != nil {
-					return fmt.Errorf("getting current working directory: %w", err)
-				}
-				files, err := utils.ConfigFilesInDir(path)
-				if err != nil {
-					return fmt.Errorf("getting files from directory: %w", err)
-				}
-				for _, filename := range files {
-					err = convert.Convert(filename, filename, sourceFormat, destinationFormat)
-					if err != nil {
-						return fmt.Errorf("converting '%s' file: %w", filename, err)
-					}
-				}
-			}
-			if convertCmdDestinationFormat == "konnect" {
-				cprint.UpdatePrintf("Warning: konnect format type was deprecated in v1.12 and it will be removed\n" +
-					"in a future version. Please use your Kong configuration files with deck <cmd>.\n" +
-					"Please see https://docs.konghq.com/konnect/getting-started/import/.\n")
-			}
-			return nil
-		},
+		RunE: execute,
 	}
 
 	sourceFormats := []convert.Format{convert.FormatKongGateway, convert.FormatKongGateway2x}

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -1,0 +1,24 @@
+/*
+Copyright © 2023 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+//
+//
+// Define the CLI data for the file sub-command
+//
+//
+
+func newAddFileCmd() *cobra.Command {
+	addFileCmd := &cobra.Command{
+		Use:   "file [sub-command]...",
+		Short: "Sub-command to host the decK file manipulation operations",
+		Long:  `Sub-command to host the decK file manipulation operations`,
+	}
+
+	return addFileCmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -211,12 +211,11 @@ It can be used to export, import, or sync entities to Kong.`,
 	rootCmd.AddCommand(newPingCmd())
 	rootCmd.AddCommand(newDumpCmd())
 	rootCmd.AddCommand(newDiffCmd())
-	rootCmd.AddCommand(newConvertCmd())
+	rootCmd.AddCommand(newConvertCmd(true)) // deprecated, to be removed
 	rootCmd.AddCommand(newCompletionCmd())
 	rootCmd.AddCommand(newKonnectCmd())
-	// commands from go-apiops library:
-	fileCmd := newAddFileCmd()
 	{
+		fileCmd := newAddFileCmd()
 		rootCmd.AddCommand(fileCmd)
 		fileCmd.AddCommand(newAddPluginsCmd())
 		fileCmd.AddCommand(newAddTagsCmd())
@@ -225,6 +224,8 @@ It can be used to export, import, or sync entities to Kong.`,
 		fileCmd.AddCommand(newMergeCmd())
 		fileCmd.AddCommand(newPatchCmd())
 		fileCmd.AddCommand(newOpenapi2KongCmd())
+		fileCmd.AddCommand(newConvertCmd(false))
+		fileCmd.AddCommand(newValidateCmd()) // alias; since this does both file+online
 	}
 	return rootCmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -215,13 +215,17 @@ It can be used to export, import, or sync entities to Kong.`,
 	rootCmd.AddCommand(newCompletionCmd())
 	rootCmd.AddCommand(newKonnectCmd())
 	// commands from go-apiops library:
-	rootCmd.AddCommand(newAddPluginsCmd())
-	rootCmd.AddCommand(newAddTagsCmd())
-	rootCmd.AddCommand(newListTagsCmd())
-	rootCmd.AddCommand(newRemoveTagsCmd())
-	rootCmd.AddCommand(newMergeCmd())
-	rootCmd.AddCommand(newPatchCmd())
-	rootCmd.AddCommand(newOpenapi2KongCmd())
+	fileCmd := newAddFileCmd()
+	{
+		rootCmd.AddCommand(fileCmd)
+		fileCmd.AddCommand(newAddPluginsCmd())
+		fileCmd.AddCommand(newAddTagsCmd())
+		fileCmd.AddCommand(newListTagsCmd())
+		fileCmd.AddCommand(newRemoveTagsCmd())
+		fileCmd.AddCommand(newMergeCmd())
+		fileCmd.AddCommand(newPatchCmd())
+		fileCmd.AddCommand(newOpenapi2KongCmd())
+	}
 	return rootCmd
 }
 


### PR DESCRIPTION
desired structure:
```
- version     Print the decK version
- completion  Generate completion script
- help        Help about any command
​
- file        decK file operations
  - add-tags     Adds tags to objects in a decK file
  - list-tags    Lists current tags to objects in a decK file
  - merge        Merges multiple decK files into one
  - openapi2kong Convert OpenAPI files to Kong's decK format
  - patch        Applies patches on top of a decK file
  - remove-tags  Removes tags from objects in a decK file
  - convert      Convert files from one format into another format
  - render       renders a final decK file as it would be synced (for local diffs)
  - validate     ==> alias for usability, since it does both file+online
- kong        online operations
  - diff         Diff the current entities in Kong with the one on disks
  - dump         Export Kong configuration to a file
  - ping         Verify connectivity with Kong
  - reset        Reset deletes all entities in Kong
  - sync         Sync performs operations to get Kong's configuration to match the state file
  - validate     Validate the state file
- diff        ==> alias for backward compatibilty
- dump        ==> alias for backward compatibilty
- ping        ==> alias for backward compatibilty
- reset       ==> alias for backward compatibilty
- sync        ==> alias for backward compatibilty
- validate    ==> alias for backward compatibilty
- convert     ==> alias for backward compatibilty
```

Todo:

- [x] create "file" subcommand
- [x] move apiops commands under "file"
- [ ] create "kong" subcommand, moved to #962 
- [ ] move kong commands under "kong", moved to #962 
- [ ] move relevant globals flags to the "kong" subcommand, moved to #962 