### PR TITLE
docs(apiops): Clean up command text for new file commands

### DIFF
--- a/cmd/file.go
+++ b/cmd/file.go
@@ -16,8 +16,8 @@ import (
 func newAddFileCmd() *cobra.Command {
 	addFileCmd := &cobra.Command{
 		Use:   "file [sub-command]...",
-		Short: "Sub-command to host the decK file manipulation operations",
-		Long:  `Sub-command to host the decK file manipulation operations`,
+		Short: "Subcommand to host the decK file manipulation operations",
+		Long:  `Subcommand to host the decK file manipulation operations.`,
 	}
 
 	return addFileCmd

--- a/cmd/file_addplugins.go
+++ b/cmd/file_addplugins.go
@@ -112,10 +112,10 @@ func newAddPluginsCmd() *cobra.Command {
 		Long: `Add plugins to objects in a decK file.
 
 The plugins are added to all objects that match the selector expressions. If no
-selectors are given, they will be added to the top-level 'plugins' array.
+selectors are given, the plugins are added to the top-level 'plugins' array.
 
-The plugin-files have the following format (JSON or YAML) and are applied in the
-order they are given;
+The plugin files have the following format (JSON or YAML) and are applied in the
+order they are given:
 
 	{ "_format_version": "1.0",
 		"add-plugins": [
@@ -139,20 +139,20 @@ order they are given;
 	}
 
 	addPluginsCmd.Flags().StringVarP(&cmdAddPluginsInputFilename, "state", "s", "-",
-		"decK file to process. Use - to read from stdin")
+		"decK file to process. Use - to read from stdin.")
 	addPluginsCmd.Flags().StringArrayVar(&cmdAddPluginsSelectors, "selector", []string{},
-		"JSON path expression to select plugin-owning objects to add plugins to,\n"+
-			"defaults to the top-level (selector '$'). Repeat for multiple selectors.")
+		"JSON path expression to select plugin-owning objects to add plugins to.\n"+
+			"Defaults to the top-level (selector '$'). Repeat for multiple selectors.")
 	addPluginsCmd.Flags().StringArrayVar(&cmdAddPluginsStrConfigs, "config", []string{},
 		"JSON snippet containing the plugin configuration to add. Repeat to add\n"+
 			"multiple plugins.")
 	addPluginsCmd.Flags().BoolVar(&cmdAddPluginsOverwrite, "overwrite", false,
-		"specifying this flag will overwrite plugins by the same name if they already\n"+
-			"exist in an array. The default is to skip existing plugins.")
+		"Specify this flag to overwrite plugins by the same name if they already\n"+
+			"exist in an array. The default behavior is to skip existing plugins.")
 	addPluginsCmd.Flags().StringVarP(&cmdAddPluginOutputFilename, "output-file", "o", "-",
-		"output file to write. Use - to write to stdout")
+		"Output file to write to. Use - to write to stdout.")
 	addPluginsCmd.Flags().StringVarP(&cmdAddPluginOutputFormat, "format", "", filebasics.OutputFormatYaml,
-		"output format: "+filebasics.OutputFormatJSON+" or "+filebasics.OutputFormatYaml)
+		"Output format: "+filebasics.OutputFormatJSON+" or "+filebasics.OutputFormatYaml)
 
 	return addPluginsCmd
 }

--- a/cmd/file_addtags.go
+++ b/cmd/file_addtags.go
@@ -76,14 +76,14 @@ selectors are given, all Kong entities are tagged.`,
 	}
 
 	addTagsCmd.Flags().StringVarP(&cmdAddTagsInputFilename, "state", "s", "-",
-		"decK file to process. Use - to read from stdin")
+		"decK file to process. Use - to read from stdin.")
 	addTagsCmd.Flags().StringArrayVar(&cmdAddTagsSelectors, "selector", []string{},
-		"JSON path expression to select objects to add tags to,\n"+
-			"defaults to all Kong entities (repeat for multiple selectors)")
+		"JSON path expression to select objects to add tags to.\n"+
+			"Defaults to all Kong entities. Repeat for multiple selectors.")
 	addTagsCmd.Flags().StringVarP(&cmdAddTagsOutputFilename, "output-file", "o", "-",
-		"output file to write. Use - to write to stdout")
+		"Output file to write to. Use - to write to stdout.")
 	addTagsCmd.Flags().StringVarP(&cmdAddTagsOutputFormat, "format", "", filebasics.OutputFormatYaml,
-		"output format: "+filebasics.OutputFormatJSON+" or "+filebasics.OutputFormatYaml)
+		"Output format: "+filebasics.OutputFormatJSON+" or "+filebasics.OutputFormatYaml)
 
 	return addTagsCmd
 }

--- a/cmd/file_listtags.go
+++ b/cmd/file_listtags.go
@@ -70,21 +70,21 @@ func newListTagsCmd() *cobra.Command {
 		Short: "List current tags from objects in a decK file",
 		Long: `List current tags from objects in a decK file.
 
-The tags will be collected from all objects that match the selector expressions. If no
+The tags are collected from all objects that match the selector expressions. If no
 selectors are given, all Kong entities will be scanned.`,
 		RunE: executeListTags,
 		Args: cobra.NoArgs,
 	}
 
 	ListTagsCmd.Flags().StringVarP(&cmdListTagsInputFilename, "state", "s", "-",
-		"decK file to process. Use - to read from stdin")
+		"decK file to process. Use - to read from stdin.")
 	ListTagsCmd.Flags().StringArrayVar(&cmdListTagsSelectors, "selector", []string{},
-		"JSON path expression to select objects to scan for tags,\n"+
-			"defaults to all Kong entities (repeat for multiple selectors)")
+		"JSON path expression to select objects to scan for tags.\n"+
+			"Defaults to all Kong entities. Repeat for multiple selectors.")
 	ListTagsCmd.Flags().StringVarP(&cmdListTagsOutputFilename, "output-file", "o", "-",
-		"output file to write. Use - to write to stdout")
+		"Output file to write to. Use - to write to stdout.")
 	ListTagsCmd.Flags().StringVarP(&cmdListTagsOutputFormat, "format", "", PlainOutputFormat,
-		"output format: "+filebasics.OutputFormatJSON+", "+filebasics.OutputFormatYaml+", or "+PlainOutputFormat)
+		"Output format: "+filebasics.OutputFormatJSON+", "+filebasics.OutputFormatYaml+", or "+PlainOutputFormat)
 
 	return ListTagsCmd
 }

--- a/cmd/file_merge.go
+++ b/cmd/file_merge.go
@@ -47,18 +47,20 @@ func newMergeCmd() *cobra.Command {
 		Short: "Merge multiple decK files into one",
 		Long: `Merge multiple decK files into one.
 
-The files can be either json or yaml format. Will merge all top-level arrays by simply
-concatenating them. Any other keys will be copied. The files will be processed in the order
-provided. No checks on content will be done, eg. duplicates, nor any validations.
+The files can be in either JSON or YAML format. Merges all top-level arrays by
+concatenating them. Any other keys are copied. The files are processed in the order
+provided. 
 
-If the input files are not compatible an error will be returned. Compatibility is
+Doesn't perform any checks on content, e.g. duplicates, or any validations.
+
+If the input files are not compatible, returns an error. Compatibility is
 determined by the '_transform' and '_format_version' fields.`,
 		RunE: executeMerge,
 		Args: cobra.MinimumNArgs(1),
 	}
 
 	mergeCmd.Flags().StringVarP(&cmdMergeOutputFilename, "output-file", "o", "-",
-		"output file to write. Use - to write to stdout")
+		"Output file to write to. Use - to write to stdout.")
 	mergeCmd.Flags().StringVarP(&cmdMergeOutputFormat, "format", "", "yaml", "output format: yaml or json")
 
 	return mergeCmd

--- a/cmd/file_openapi2kong.go
+++ b/cmd/file_openapi2kong.go
@@ -66,24 +66,24 @@ func newOpenapi2KongCmd() *cobra.Command {
 		Short: "Convert OpenAPI files to Kong's decK format",
 		Long: `Convert OpenAPI files to Kong's decK format.
 
-The example file has extensive annotations explaining the conversion
-process, as well as all supported custom annotations (x-kong-... directives).
-See: https://github.com/Kong/go-apiops/blob/main/docs/learnservice_oas.yaml`,
+The example file at https://github.com/Kong/go-apiops/blob/main/docs/learnservice_oas.yaml
+has extensive annotations explaining the conversion process, as well as all supported 
+custom annotations (`x-kong-...` directives).`,
 		RunE: executeOpenapi2Kong,
 		Args: cobra.NoArgs,
 	}
 
 	openapi2kongCmd.Flags().StringVarP(&cmdO2KinputFilename, "spec", "s", "-",
-		"OpenAPI spec file to process. Use - to read from stdin")
+		"OpenAPI spec file to process. Use - to read from stdin.")
 	openapi2kongCmd.Flags().StringVarP(&cmdO2KoutputFilename, "output-file", "o", "-",
-		"output file to write. Use - to write to stdout")
+		"Output file to write. Use - to write to stdout.")
 	openapi2kongCmd.Flags().StringVarP(&cmdO2KoutputFormat, "format", "", "yaml", "output format: yaml or json")
 	openapi2kongCmd.Flags().StringVarP(&cmdO2KdocName, "uuid-base", "", "",
-		"the unique base-string for uuid-v5 generation of entity id's (if omitted\n"+
-			"will use the root-level \"x-kong-name\" directive, or fall back to 'info.title')")
+		"The unique base-string for uuid-v5 generation of entity IDs. If omitted,\n"+
+			"uses the root-level \"x-kong-name\" directive, or falls back to 'info.title'.)")
 	openapi2kongCmd.Flags().StringSliceVar(&cmdO2KentityTags, "select-tag", nil,
-		"select tags to apply to all entities (if omitted will use the \"x-kong-tags\"\n"+
-			"directive from the file)")
+		"Select tags to apply to all entities. If omitted, uses the \"x-kong-tags\"\n"+
+			"directive from the file.")
 
 	return openapi2kongCmd
 }

--- a/cmd/file_openapi2kong.go
+++ b/cmd/file_openapi2kong.go
@@ -68,7 +68,7 @@ func newOpenapi2KongCmd() *cobra.Command {
 
 The example file at https://github.com/Kong/go-apiops/blob/main/docs/learnservice_oas.yaml
 has extensive annotations explaining the conversion process, as well as all supported 
-custom annotations (`x-kong-...` directives).`,
+custom annotations (x-kong-... directives).`,
 		RunE: executeOpenapi2Kong,
 		Args: cobra.NoArgs,
 	}

--- a/cmd/file_patch.go
+++ b/cmd/file_patch.go
@@ -112,52 +112,55 @@ func newPatchCmd() *cobra.Command {
 		Short: "Apply patches on top of a decK file",
 		Long: `Apply patches on top of a decK file.
 
-The input file will be read, the patches will be applied, and if successful, written
+The input file is read, the patches are applied, and if successful, written
 to the output file. The patches can be specified by a '--selector' and one or more
-'--value' tags, or via patch-files.
+'--value' tags, or via patch files.
+		
+When using '--selector' and '--values', the items are selected by the 'selector', 
+which is a JSONpath query. From the array of nodes found, only the objects are updated.
+The 'values' are applied on each of the JSONObjects returned by the 'selector'.
 
-When using '--selector' and '--values', the items will be selected by the 'selector' which is
-a JSONpath query. From the array of nodes found, only the objects will be updated.
-The 'values' will be applied on each of the JSONobjects returned by the 'selector'.
+The value must be a valid JSON snippet, so use single/double quotes
+appropriately. If the value is empty, the field is removed from the object.
 
-The value part must be a valid JSON snippet, so make sure to use single/double quotes
-appropriately. If the value is empty, the field will be removed from the object.
-Examples:
-  --selector="$..services[*]" --value="read_timeout:10000"
-  --selector="$..services[*]" --value='_comment:"comment injected by patching"'
-  --selector="$..services[*]" --value='_ignore:["ignore1","ignore2"]'
-  --selector="$..services[*]" --value='_ignore:' --value='_comment:'
+Examples of valid values:
 
-The patch-files have the following format (JSON or Yaml) and can contain multiple
-patches that will be applied in order;
+	--selector="$..services[*]" --value="read_timeout:10000"
+	--selector="$..services[*]" --value='_comment:"comment injected by patching"'
+	--selector="$..services[*]" --value='_ignore:["ignore1","ignore2"]'
+	--selector="$..services[*]" --value='_ignore:' --value='_comment:'
 
-  { "_format_version": "1.0",
-    "patches": [
-      { "selectors": [
-					"$..services[*]"
-				],
-        "values": {
-          "read_timeout": 10000,
-          "_comment": "comment injected by patching"
-        },
-        "remove": [ "_ignore" ]
-      }
-    ]
-  }
+
+Patch files have the following format (JSON or YAML) and can contain multiple
+patches that are applied in order:
+
+	{ "_format_version": "1.0",
+		"patches": [
+		{ "selectors": [
+			"$..services[*]"
+			],
+			"values": {
+			"read_timeout": 10000,
+			"_comment": "comment injected by patching"
+			},
+			"remove": [ "_ignore" ]
+		}
+		]
+	}
 `,
 		RunE: executePatch,
 	}
 
 	patchCmd.Flags().StringVarP(&cmdPatchInputFilename, "state", "s", "-",
-		"decK file to process. Use - to read from stdin")
+		"decK file to process. Use - to read from stdin.")
 	patchCmd.Flags().StringVarP(&cmdPatchOutputFilename, "output-file", "o", "-",
-		"output file to write. Use - to write to stdout")
+		"Output file to write. Use - to write to stdout.")
 	patchCmd.Flags().StringVarP(&cmdPatchOutputFormat, "format", "", "yaml",
-		"output format: yaml or json")
+		"Output format: yaml or json.")
 	patchCmd.Flags().StringArrayVarP(&cmdPatchSelectors, "selector", "", []string{},
-		"json-pointer identifying element to patch (can be specified more than once)")
+		"json-pointer identifying element to patch. Repeat for multiple selectors.)")
 	patchCmd.Flags().StringArrayVarP(&cmdPatchValues, "value", "", []string{},
-		"a value to set in the selected entry in format <key:value> (can be specified more than once)")
+		"A value to set in the selected entry in <key:value> format. Can be specified multiple times.")
 	patchCmd.MarkFlagsRequiredTogether("selector", "value")
 
 	return patchCmd

--- a/cmd/file_removetags.go
+++ b/cmd/file_removetags.go
@@ -81,29 +81,29 @@ func newRemoveTagsCmd() *cobra.Command {
 		Long: `Remove tags from objects in a decK file.
 
 The listed tags are removed from all objects that match the selector expressions.
-If no selectors are given, all Kong entities will be selected.`,
+If no selectors are given, all Kong entities are selected.`,
 		RunE: executeRemoveTags,
-		Example: "  # clear tags 'tag1' and 'tag2' from all services in file 'kong.yml'\n" +
-			"  cat kong.yml | go-apiops remove-tags --selector='services[*]' tag1 tag2\n" +
+		Example: "# clear tags 'tag1' and 'tag2' from all services in file 'kong.yml'\n" +
+			"cat kong.yml | go-apiops remove-tags --selector='services[*]' tag1 tag2\n" +
 			"\n" +
-			"  # clear all tags except 'tag1' and 'tag2' from the file 'kong.yml'\n" +
-			"  cat kong.yml | go-apiops remove-tags --keep-only tag1 tag2",
+			"# clear all tags except 'tag1' and 'tag2' from the file 'kong.yml'\n" +
+			"cat kong.yml | go-apiops remove-tags --keep-only tag1 tag2",
 	}
 
 	removeTagsCmd.Flags().BoolVar(&cmdRemoveTagsKeepEmptyArrays, "keep-empty-array", false,
-		"keep empty tag-arrays in output")
+		"Keep empty tag arrays in output.")
 	removeTagsCmd.Flags().BoolVar(&cmdRemoveTagsKeepOnlyTags, "keep-only", false,
-		"setting this flag will remove all tags except the ones listed\n"+
-			"(if none are listed, all tags will be removed)")
+		"Setting this flag will remove all tags except the ones listed.\n"+
+			"If none are listed, all tags will be removed.")
 	removeTagsCmd.Flags().StringVarP(&cmdRemoveTagsInputFilename, "state", "s", "-",
-		"decK file to process. Use - to read from stdin")
+		"decK file to process. Use - to read from stdin.")
 	removeTagsCmd.Flags().StringArrayVar(&cmdRemoveTagsSelectors, "selector", []string{},
-		"JSON path expression to select objects to remove tags from,\n"+
-			"defaults to all Kong entities (repeat for multiple selectors)")
+		"JSON path expression to select objects to remove tags from.\n"+
+			"Defaults to all Kong entities. Repeat for multiple selectors.")
 	removeTagsCmd.Flags().StringVarP(&cmdRemoveTagsOutputFilename, "output-file", "o", "-",
-		"output file to write. Use - to write to stdout")
+		"Output file to write. Use - to write to stdout.")
 	removeTagsCmd.Flags().StringVarP(&cmdRemoveTagsOutputFormat, "format", "", filebasics.OutputFormatYaml,
-		"output format: "+filebasics.OutputFormatJSON+" or "+filebasics.OutputFormatYaml)
+		"Output format: "+filebasics.OutputFormatJSON+" or "+filebasics.OutputFormatYaml)
 
 	return removeTagsCmd
 }


### PR DESCRIPTION
Follow-up PR to https://github.com/Kong/deck/pull/939. 
Mirrors changes going into the docs in https://github.com/Kong/docs.konghq.com/pull/5819 (minus some formatting so that it doesn't break anything).

Cleaning up new `deck file` commands for readability and consistency, plus better generated output to the doc site.