### PR TITLE
fix: Typo in global konnect-token-file flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -187,7 +187,7 @@ It can be used to export, import, or sync entities to Kong.`,
 		rootCmd.PersistentFlags().Lookup("konnect-token"))
 
 	rootCmd.PersistentFlags().String("konnect-token-file", "",
-		"File containing the Peronsal Access Token to your Konnect account.")
+		"File containing the Personal Access Token to your Konnect account.")
 	viper.BindPFlag("konnect-token-file",
 		rootCmd.PersistentFlags().Lookup("konnect-token-file"))
 


### PR DESCRIPTION
Fixing a small typo. Since it's a global flag, it shows up in every command.