### PR TITLE
chore: mark file/kong_json_schema.json as generated code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+file/kong_json_schema.json linguist-generated=true


### PR DESCRIPTION
Prevent showing diffs of `file/kong_json_schema.json` since it contains generated.