### PR TITLE
fix: remove old konnect authentication fallback

### DIFF
--- a/cmd/common_konnect.go
+++ b/cmd/common_konnect.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 
@@ -18,27 +17,12 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const (
-	defaultLegacyKonnectURL = "https://konnect.konghq.com"
-
-	defaultRuntimeGroupName        = "default"
-	konnectWithRuntimeGroupsDomain = "api.konghq"
-)
-
-var addresses = []string{
-	defaultKonnectURL,
-	defaultLegacyKonnectURL,
-}
+const defaultRuntimeGroupName = "default"
 
 func authenticate(
-	ctx context.Context, client *konnect.Client, host string, konnectConfig utils.KonnectConfig,
+	ctx context.Context, client *konnect.Client, konnectConfig utils.KonnectConfig,
 ) (konnect.AuthResponse, error) {
-	if strings.Contains(host, konnectWithRuntimeGroupsDomain) {
-		return client.Auth.LoginV2(ctx, konnectConfig.Email,
-			konnectConfig.Password, konnectConfig.Token)
-	}
-	return client.Auth.Login(ctx, konnectConfig.Email,
-		konnectConfig.Password)
+	return client.Auth.LoginV2(ctx, konnectConfig.Email, konnectConfig.Password, konnectConfig.Token)
 }
 
 // GetKongClientForKonnectMode abstracts the different cloud environments users
@@ -50,9 +34,6 @@ func GetKongClientForKonnectMode(
 	ctx context.Context, konnectConfig *utils.KonnectConfig,
 ) (*kong.Client, error) {
 	httpClient := utils.HTTPClient()
-	if konnectConfig.Address != defaultKonnectURL {
-		addresses = []string{konnectConfig.Address}
-	}
 
 	if konnectConfig.Token != "" {
 		konnectConfig.Headers = append(
@@ -63,56 +44,24 @@ func GetKongClientForKonnectMode(
 	// authenticate with konnect
 	var err error
 	var konnectClient *konnect.Client
-	var parsedAddress *url.URL
 	var konnectAddress string
-	for _, address := range addresses {
-		// get Konnect client
-		konnectConfig.Address = address
-		konnectClient, err = utils.GetKonnectClient(httpClient, *konnectConfig)
-		if err != nil {
-			return nil, err
-		}
-		parsedAddress, err = url.Parse(address)
-		if err != nil {
-			return nil, fmt.Errorf("parsing %s address: %w", address, err)
-		}
-		_, err = authenticate(ctx, konnectClient, parsedAddress.Host, *konnectConfig)
-		if err == nil {
-			break
-		}
-		// Personal Access Token authentication is not supported with the
-		// legacy Konnect, so we don't need to fallback in case of 401s.
-		if konnect.IsUnauthorizedErr(err) && konnectConfig.Token != "" {
-			return nil, fmt.Errorf("authenticating with Konnect: %w", err)
-		}
-		if konnect.IsUnauthorizedErr(err) {
-			continue
-		}
+	// get Konnect client
+	konnectClient, err = utils.GetKonnectClient(httpClient, *konnectConfig)
+	if err != nil {
+		return nil, err
 	}
+	_, err = authenticate(ctx, konnectClient, *konnectConfig)
 	if err != nil {
 		return nil, fmt.Errorf("authenticating with Konnect: %w", err)
 	}
-	if strings.Contains(parsedAddress.Host, konnectWithRuntimeGroupsDomain) {
-		// get kong runtime group ID
-		kongRGID, err := fetchKongRuntimeGroupID(ctx, konnectClient)
-		if err != nil {
-			return nil, err
-		}
-
-		// set the kong runtime group ID in the client
-		konnectClient.SetRuntimeGroupID(kongRGID)
-		konnectAddress = konnectConfig.Address + "/konnect-api/api/runtime_groups/" + kongRGID
-	} else {
-		// get kong control plane ID
-		kongCPID, err := fetchKongControlPlaneID(ctx, konnectClient)
-		if err != nil {
-			return nil, err
-		}
-
-		// set the kong control plane ID in the client
-		konnectClient.SetControlPlaneID(kongCPID)
-		konnectAddress = konnectConfig.Address + "/api/control_planes/" + kongCPID
+	kongRGID, err := fetchKongRuntimeGroupID(ctx, konnectClient)
+	if err != nil {
+		return nil, err
 	}
+
+	// set the kong runtime group ID in the client
+	konnectClient.SetRuntimeGroupID(kongRGID)
+	konnectAddress = konnectConfig.Address + "/konnect-api/api/runtime_groups/" + kongRGID
 
 	// initialize kong client
 	return utils.GetKongClient(utils.KongClientConfig{

--- a/cmd/konnect_diff.go
+++ b/cmd/konnect_diff.go
@@ -23,9 +23,6 @@ func newKonnectDiffCmd() *cobra.Command {
 		Args: validateNoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			_ = sendAnalytics("konnect-diff", "", modeKonnect)
-			if konnectConfig.Address == defaultKonnectURL {
-				konnectConfig.Address = defaultLegacyKonnectURL
-			}
 			return syncKonnect(cmd.Context(), konnectDiffCmdKongStateFile, true,
 				konnectDiffCmdParallelism)
 		},

--- a/cmd/konnect_dump.go
+++ b/cmd/konnect_dump.go
@@ -38,9 +38,6 @@ func newKonnectDumpCmd() *cobra.Command {
 			}
 
 			// get Konnect client
-			if konnectConfig.Address == defaultKonnectURL {
-				konnectConfig.Address = defaultLegacyKonnectURL
-			}
 			konnectClient, err := utils.GetKonnectClient(httpClient, konnectConfig)
 			if err != nil {
 				return err

--- a/cmd/konnect_ping.go
+++ b/cmd/konnect_ping.go
@@ -18,9 +18,6 @@ credentials.` + konnectAlphaState,
 		Args: validateNoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			_ = sendAnalytics("konnect-ping", "", modeKonnect)
-			if konnectConfig.Address == defaultKonnectURL {
-				konnectConfig.Address = defaultLegacyKonnectURL
-			}
 			client, err := utils.GetKonnectClient(nil, konnectConfig)
 			if err != nil {
 				return err

--- a/cmd/konnect_sync.go
+++ b/cmd/konnect_sync.go
@@ -15,9 +15,6 @@ to get Konnect's state in sync with the input state.` + konnectAlphaState,
 		Args: validateNoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			_ = sendAnalytics("konnect-sync", "", modeKonnect)
-			if konnectConfig.Address == defaultKonnectURL {
-				konnectConfig.Address = defaultLegacyKonnectURL
-			}
 			return syncKonnect(cmd.Context(), konnectDiffCmdKongStateFile, false,
 				konnectDiffCmdParallelism)
 		},

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"net/url"
 
 	"github.com/kong/deck/utils"
 	"github.com/spf13/cobra"
@@ -47,9 +46,8 @@ func pingKonnect(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	u, _ := url.Parse(konnectConfig.Address)
 	// authenticate with konnect
-	res, err := authenticate(ctx, konnectClient, u.Host, konnectConfig)
+	res, err := authenticate(ctx, konnectClient, konnectConfig)
 	if err != nil {
 		return fmt.Errorf("authenticating with Konnect: %w", err)
 	}

--- a/tests/integration/ping_test.go
+++ b/tests/integration/ping_test.go
@@ -3,14 +3,24 @@
 package integration
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func Test_KonnectPing(t *testing.T) {
-	t.Run("konnect ping", func(t *testing.T) {
+	t.Run("konnect ping - email/password", func(t *testing.T) {
 		runWhen(t, "konnect", "")
-		require.NoError(t, ping())
+		require.NoError(t, ping(
+			"--konnect-email", os.Getenv("DECK_KONNECT_EMAIL"),
+			"--konnect-password", os.Getenv("DECK_KONNECT_PASSWORD"),
+		))
+	})
+	t.Run("konnect ping - token", func(t *testing.T) {
+		runWhen(t, "konnect", "")
+		require.NoError(t, ping(
+			"--konnect-token", os.Getenv("DECK_KONNECT_TOKEN"),
+		))
 	})
 }


### PR DESCRIPTION
decK used to require to work with both "old" and "new" Konnect. This requirement is now obsolete, since the "old" Konnect doesn't exist anymore, so it is the need of this fallback mechanism.

This commit removes such mechanism.