### PR TITLE
fix: set default strip_path to true

### DIFF
--- a/convert/testdata/5/output-expected.yaml
+++ b/convert/testdata/5/output-expected.yaml
@@ -22,7 +22,7 @@ services:
     - http
     - https
     regex_priority: 0
-    strip_path: false
+    strip_path: true
   tags:
   - team-svc1
   write_timeout: 60000
@@ -41,7 +41,7 @@ services:
     - http
     - https
     regex_priority: 0
-    strip_path: false
+    strip_path: true
   write_timeout: 60000
 - connect_timeout: 60000
   host: mockbin.org
@@ -61,5 +61,5 @@ services:
     - http
     - https
     regex_priority: 0
-    strip_path: false
+    strip_path: true
   write_timeout: 60000

--- a/convert/testdata/6/output-expected.yaml
+++ b/convert/testdata/6/output-expected.yaml
@@ -21,7 +21,7 @@ services:
     protocols:
     - https
     regex_priority: 0
-    strip_path: false
+    strip_path: true
   tags:
   - team-svc1
   write_timeout: 30000
@@ -39,7 +39,7 @@ services:
     protocols:
     - https
     regex_priority: 0
-    strip_path: false
+    strip_path: true
   write_timeout: 30000
 - connect_timeout: 30000
   host: mockbin.org
@@ -58,5 +58,5 @@ services:
     protocols:
     - https
     regex_priority: 0
-    strip_path: false
+    strip_path: true
   write_timeout: 30000

--- a/convert/testdata/7/output-expected.yaml
+++ b/convert/testdata/7/output-expected.yaml
@@ -22,7 +22,7 @@ services:
     - http
     - https
     regex_priority: 0
-    strip_path: false
+    strip_path: true
   tags:
   - team-svc1
   write_timeout: 60000
@@ -41,7 +41,7 @@ services:
     - http
     - https
     regex_priority: 0
-    strip_path: false
+    strip_path: true
   write_timeout: 60000
 - connect_timeout: 60000
   host: mockbin.org
@@ -61,5 +61,5 @@ services:
     - http
     - https
     regex_priority: 0
-    strip_path: false
+    strip_path: true
   write_timeout: 60000

--- a/utils/constants.go
+++ b/utils/constants.go
@@ -21,7 +21,7 @@ var (
 	routeDefaults = kong.Route{
 		PreserveHost:  kong.Bool(false),
 		RegexPriority: kong.Int(0),
-		StripPath:     kong.Bool(false),
+		StripPath:     kong.Bool(true),
 		Protocols:     kong.StringSlice("http", "https"),
 	}
 	targetDefaults = kong.Target{

--- a/utils/defaulter_test.go
+++ b/utils/defaulter_test.go
@@ -180,7 +180,7 @@ func TestRouteSetTest(t *testing.T) {
 			want: &kong.Route{
 				PreserveHost:  kong.Bool(true),
 				RegexPriority: kong.Int(0),
-				StripPath:     kong.Bool(false),
+				StripPath:     kong.Bool(true),
 				Protocols:     kong.StringSlice("http", "https"),
 			},
 		},
@@ -192,7 +192,7 @@ func TestRouteSetTest(t *testing.T) {
 			want: &kong.Route{
 				PreserveHost:  kong.Bool(false),
 				RegexPriority: kong.Int(0),
-				StripPath:     kong.Bool(false),
+				StripPath:     kong.Bool(true),
 				Protocols:     kong.StringSlice("http", "tls"),
 			},
 		},
@@ -202,7 +202,7 @@ func TestRouteSetTest(t *testing.T) {
 				Name:      kong.String("foo"),
 				Hosts:     kong.StringSlice("1.example.com", "2.example.com"),
 				Methods:   kong.StringSlice("GET", "POST"),
-				StripPath: kong.Bool(false),
+				StripPath: kong.Bool(true),
 			},
 			want: &kong.Route{
 				Name:          kong.String("foo"),
@@ -210,7 +210,7 @@ func TestRouteSetTest(t *testing.T) {
 				Methods:       kong.StringSlice("GET", "POST"),
 				PreserveHost:  kong.Bool(false),
 				RegexPriority: kong.Int(0),
-				StripPath:     kong.Bool(false),
+				StripPath:     kong.Bool(true),
 				Protocols:     kong.StringSlice("http", "https"),
 			},
 		},


### PR DESCRIPTION
In the past decK had to set the default value of the `strip_path` field to [false](https://github.com/Kong/deck/blob/v1.26.0/utils/constants.go#L22) because of some limitation in the library used for defaults injection: this was a workaround to allow this field to be set to `false`. Then, if the field was not set in the configuration, the field was then turned into `true` at runtime via inspection of the Kong Admin API.

This commit changes the decK default for the `strip_path` field to `true`, since now the underlying library has fixed the issue that triggered this workaround in the first place.