### PR TITLE
fix(docs) Remove errant comma from CLI example

### DIFF
--- a/cmd/file_addplugins.go
+++ b/cmd/file_addplugins.go
@@ -132,7 +132,7 @@ order they are given:
 	            "my-property": "value"
 	          }
 	        }
-	      ],
+	      ]
 	    }
 	  ]
 	}


### PR DESCRIPTION
Someone filed a PR to fix this in the docs, but the source is here. Fixing source so that we don't pull it in again.

https://github.com/Kong/docs.konghq.com/pull/5940