### PR TITLE
docs(cli): Add a long description for file render

### DIFF
--- a/cmd/file_render.go
+++ b/cmd/file_render.go
@@ -27,8 +27,19 @@ func executeFileRenderCmd(_ *cobra.Command, _ []string) error {
 func newFileRenderCmd() *cobra.Command {
 	renderCmd := &cobra.Command{
 		Use:   "render",
-		Short: "Render the configuration as Kong declarative config",
-		Long:  ``,
+		Short: "Combines multiple complete configuration files into one Kong declarative config file.",
+		Long:  `Combines multiple complete configuration files into one Kong
+	declarative config file.
+
+ This command can render the output in JSON or YAML format. Unlike 
+ "deck file merge", the render command accepts complete configuration files, 
+ while "deck file merge" only combines partial file snippets.
+
+ For example, the following command takes two input files and renders them as one 
+ combined JSON file:
+
+   deck file render kong1.yml kong2.yml -o kong3 --format json
+	`,
 		Args:  cobra.ArbitraryArgs,
 		RunE:  executeFileRenderCmd,
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/file_render.go
+++ b/cmd/file_render.go
@@ -28,24 +28,24 @@ func newFileRenderCmd() *cobra.Command {
 	renderCmd := &cobra.Command{
 		Use:   "render",
 		Short: "Combines multiple complete configuration files and renders them as one Kong declarative config file.",
-		Long:  `Combines multiple complete configuration files and renders them as one Kong
-	declarative config file.
+		Long: `Combines multiple complete configuration files and renders them as one Kong
+declarative config file.
 
- This command renders a full declarative configuration in JSON or YAML format by assembling 
- multiple files and populating defaults and environment substitutions. 
- This command is useful to observe what configuration would be sent prior to synchronizing to 
- the gateway.
+This command renders a full declarative configuration in JSON or YAML format by assembling 
+multiple files and populating defaults and environment substitutions. 
+This command is useful to observe what configuration would be sent prior to synchronizing to 
+the gateway.
  
- In comparison to the "deck file merge" command, the render command accepts 
- complete configuration files, while "deck file merge" can operate on partial files.
+In comparison to the "deck file merge" command, the render command accepts 
+complete configuration files, while "deck file merge" can operate on partial files.
 
- For example, the following command takes two input files and renders them as one 
- combined JSON file:
+For example, the following command takes two input files and renders them as one 
+combined JSON file:
 
-   deck file render kong1.yml kong2.yml -o kong3 --format json
-	`,
-		Args:  cobra.ArbitraryArgs,
-		RunE:  executeFileRenderCmd,
+  deck file render kong1.yml kong2.yml -o kong3 --format json
+`,
+		Args: cobra.ArbitraryArgs,
+		RunE: executeFileRenderCmd,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			fileRenderCmdKongStateFile = args
 			if len(fileRenderCmdKongStateFile) == 0 {

--- a/cmd/file_render.go
+++ b/cmd/file_render.go
@@ -27,14 +27,17 @@ func executeFileRenderCmd(_ *cobra.Command, _ []string) error {
 func newFileRenderCmd() *cobra.Command {
 	renderCmd := &cobra.Command{
 		Use:   "render",
-		Short: "Combines multiple complete configuration files into one Kong declarative config file.",
-		Long:  `Combines multiple complete configuration files into one Kong
+		Short: "Combines multiple complete configuration files and renders them as one Kong declarative config file.",
+		Long:  `Combines multiple complete configuration files and renders them as one Kong
 	declarative config file.
 
- This command renders a full declarative configuration in JSON or YAML format by assembling multiple files and populating defaults and environment substitutions. This command is useful to observe what configuration would be sent prior to synchronizing to the gateway.
+ This command renders a full declarative configuration in JSON or YAML format by assembling 
+ multiple files and populating defaults and environment substitutions. 
+ This command is useful to observe what configuration would be sent prior to synchronizing to 
+ the gateway.
  
-In comparison to the "deck file merge" command, the render command accepts complete configuration files, 
- while "deck file merge" can operate on partial files.
+ In comparison to the "deck file merge" command, the render command accepts 
+ complete configuration files, while "deck file merge" can operate on partial files.
 
  For example, the following command takes two input files and renders them as one 
  combined JSON file:

--- a/cmd/file_render.go
+++ b/cmd/file_render.go
@@ -31,9 +31,10 @@ func newFileRenderCmd() *cobra.Command {
 		Long:  `Combines multiple complete configuration files into one Kong
 	declarative config file.
 
- This command can render the output in JSON or YAML format. Unlike 
- "deck file merge", the render command accepts complete configuration files, 
- while "deck file merge" only combines partial file snippets.
+ This command renders a full declarative configuration in JSON or YAML format by assembling multiple files and populating defaults and environment substitutions. This command is useful to observe what configuration would be sent prior to synchronizing to the gateway.
+ 
+In comparison to the "deck file merge" command, the render command accepts complete configuration files, 
+ while "deck file merge" can operate on partial files.
 
  For example, the following command takes two input files and renders them as one 
  combined JSON file:


### PR DESCRIPTION
The existing description for `deck file render` doesn't currently provide any detail on what the command does or how to use it. 
I was trying to test it out and couldn't even figure out how it was supposed to work, since there's no input file flag or example. 

Found the info I needed on Slack here, and based the update on that: https://kongstrong.slack.com/archives/C04349E4KRC/p1690921140291889

❗ I did run into one potential issue while testing: this command doesn't warn you when overwriting existing files, like `deck dump` or others do. Is that intentional?
