### PR TITLE
fix(docs/cmd) Change go-apiops in remove-tags examples to deck file

### DIFF
--- a/cmd/file_removetags.go
+++ b/cmd/file_removetags.go
@@ -87,10 +87,10 @@ The listed tags are removed from all objects that match the selector expressions
 If no selectors are given, all Kong entities are selected.`,
 		RunE: executeRemoveTags,
 		Example: "# clear tags 'tag1' and 'tag2' from all services in file 'kong.yml'\n" +
-			"cat kong.yml | go-apiops remove-tags --selector='services[*]' tag1 tag2\n" +
+			"cat kong.yml | deck file remove-tags --selector='services[*]' tag1 tag2\n" +
 			"\n" +
 			"# clear all tags except 'tag1' and 'tag2' from the file 'kong.yml'\n" +
-			"cat kong.yml | go-apiops remove-tags --keep-only tag1 tag2",
+			"cat kong.yml | deck file remove-tags --keep-only tag1 tag2",
 	}
 
 	removeTagsCmd.Flags().BoolVar(&cmdRemoveTagsKeepEmptyArrays, "keep-empty-array", false,


### PR DESCRIPTION
Parallel to docs PR: https://github.com/Kong/docs.konghq.com/pull/6037

Examples are telling users to run `go-apiops`, which is only supposed to be used for dev/testing. Changing that to the standard `deck file`.