### PR TITLE
fix: correct inconsistency for multiple consumers with custom_id fields

### DIFF
--- a/state/consumer.go
+++ b/state/consumer.go
@@ -62,19 +62,19 @@ func (k *ConsumersCollection) Add(consumer Consumer) error {
 	// custom_id, we may get a false positive.
 	_, err := getConsumer(txn, []string{"Username", "id"}, searchBy...)
 	if err == nil {
-		return fmt.Errorf("inserting consumer %v: %w", consumer.Console(), ErrAlreadyExists)
+		return fmt.Errorf("inserting consumer by username %v: %w", consumer.Console(), ErrAlreadyExists)
 	} else if !errors.Is(err, ErrNotFound) {
 		return err
 	}
 
 	if !utils.Empty(consumer.CustomID) {
 		searchBy = []string{*consumer.CustomID}
-	}
-	_, err = getConsumer(txn, []string{"CustomID"}, searchBy...)
-	if err == nil {
-		return fmt.Errorf("inserting consumer %v: %w", consumer.Console(), ErrAlreadyExists)
-	} else if !errors.Is(err, ErrNotFound) {
-		return err
+		_, err = getConsumer(txn, []string{"CustomID"}, searchBy...)
+		if err == nil {
+			return fmt.Errorf("inserting consumer by custom_id %v: %w", consumer.Console(), ErrAlreadyExists)
+		} else if !errors.Is(err, ErrNotFound) {
+			return err
+		}
 	}
 
 	err = txn.Insert(consumerTableName, &consumer)

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -4171,6 +4171,21 @@ func Test_Sync_ConsumersWithCustomIDAndOrUsername(t *testing.T) {
 			},
 		},
 	}, nil)
+
+	err = sync("testdata/sync/024-consumers-with-custom_id-and-username/kong3x-reverse-order.yaml")
+	require.NoError(t, err)
+
+	testKongState(t, client, false, utils.KongRawState{
+		Consumers: []*kong.Consumer{
+			{
+				Username: kong.String("TestUser"),
+			},
+			{
+				Username: kong.String("OtherUser"),
+				CustomID: kong.String("TestUser"),
+			},
+		},
+	}, nil)
 }
 
 // This test has 2 goals:

--- a/tests/integration/testdata/sync/024-consumers-with-custom_id-and-username/kong3x-reverse-order.yaml
+++ b/tests/integration/testdata/sync/024-consumers-with-custom_id-and-username/kong3x-reverse-order.yaml
@@ -1,0 +1,5 @@
+_format_version: "3.0"
+consumers:
+- username: OtherUser
+  custom_id: TestUser
+- username: TestUser


### PR DESCRIPTION
This commit corrects a bug preventing consumers with equal `Username` and `CustomID` to always be correctly handled by decK.

For example, syncing the following state file works as expected:

```
$ cat kong.yaml
_format_version: "3.0"
consumers:
- username: TestUser
- username: OtherUser
  custom_id: TestUser
```

```
$ deck sync
creating consumer OtherUser
creating consumer TestUser
Summary:
  Created: 2
  Updated: 0
  Deleted: 0
```

But syncing the following state file (same content as the first one, but with consumers in reverse order) doesn't work:

```
_format_version: "3.0"
consumers:
- username: OtherUser
  custom_id: TestUser
- username: TestUser
```

```
$ deck sync
Error: building state: inserting consumer TestUser: entity already exists
```

This commit is making sure this bogus inconsistency is corrected.