### PR TITLE
feat(patch): allow arrays to be specified on the CLI

### DIFF
--- a/cmd/file_patch.go
+++ b/cmd/file_patch.go
@@ -32,7 +32,7 @@ func executePatch(cmd *cobra.Command, args []string) error {
 	{
 		var err error
 		valuesPatch.SelectorSources = cmdPatchSelectors
-		valuesPatch.ObjValues, valuesPatch.Remove, err = patch.ValidateValuesFlags(cmdPatchValues)
+		valuesPatch.ObjValues, valuesPatch.Remove, valuesPatch.ArrValues, err = patch.ValidateValuesFlags(cmdPatchValues)
 		if err != nil {
 			return fmt.Errorf("failed parsing '--value' entry; %w", err)
 		}
@@ -120,20 +120,29 @@ to the output file. The patches can be specified by a '--selector' and one or mo
 '--value' tags, or via patch files.
 
 When using '--selector' and '--values', the items are selected by the 'selector', 
-which is a JSONpath query. From the array of nodes found, only the objects are updated.
-The 'values' are applied on each of the JSONObjects returned by the 'selector'.
+which is a JSONpath query. The 'field values' (in '<key:value>' format) are applied on 
+each of the JSONObjects returned by the 'selector'. The 'array values' (in 
+'[val1, val2]' format) are appended to each of the JSONArrays returned by the 'selector'.
 
-Objects:
-
-The value must be a valid JSON snippet, so use single/double quotes
+The field values must be a valid JSON snippet, so use single/double quotes
 appropriately. If the value is empty, the field is removed from the object.
 
 Examples of valid values:
 
+  # set field "read_timeout" to a numeric value of 10000
 	--selector="$..services[*]" --value="read_timeout:10000"
+
+	# set field "_comment" to a string value
 	--selector="$..services[*]" --value='_comment:"comment injected by patching"'
+
+	# set field "_ignore" to an array of strings
 	--selector="$..services[*]" --value='_ignore:["ignore1","ignore2"]'
+
+	# remove fields "_ignore" and "_comment" from the object
 	--selector="$..services[*]" --value='_ignore:' --value='_comment:'
+
+	# append entries to the methods array of all route objects
+	--selector="$..routes[*].methods" --value='["OPTIONS"]'
 
 
 Patch files have the following format (JSON or YAML) and can contain multiple
@@ -152,8 +161,6 @@ patches that are applied in order:
 	    }
 	  ]
 	}
-
-Arrays:
 
 If the 'values' object instead is an array, then any arrays returned by the selectors
 will get the 'values' appended to them.


### PR DESCRIPTION
requires apiops > 0.1.22 for this pr: https://github.com/Kong/go-apiops/pull/100

values were specified on the CLI as `--value 'key:value'`, and arrays could not. But arrays
were possible in the patch file format. This adds the format `--value '[1,2,3]'` to specify the arrays on the CLI as well.