### PR TITLE
chore: add nolint directive to make golangci-lint happy

### DIFF
--- a/types/core.go
+++ b/types/core.go
@@ -108,7 +108,7 @@ const (
 	// RBACRole identifies a RBACRole in Kong Enterprise.
 	RBACRole EntityType = "rbac-role"
 	// RBACEndpointPermission identifies a RBACEndpointPermission in Kong Enterprise.
-	RBACEndpointPermission EntityType = "rbac-endpoint-permission"
+	RBACEndpointPermission EntityType = "rbac-endpoint-permission" //nolint:gosec
 
 	// ServicePackage identifies a ServicePackage in Konnect.
 	ServicePackage EntityType = "service-package"


### PR DESCRIPTION
This PR prevents:

```
make lint
golangci-lint run ./...
types/core.go:111:2: G101: Potential hardcoded credentials (gosec)
        RBACEndpointPermission EntityType = "rbac-endpoint-permission"
        ^
```