### PR TITLE
fix(cli): deprecated commands default to kong.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ _testmain.go
 deck
 dist/
 docs/cli-docs/
+
+# vscode editor files
+.vscode/

--- a/cmd/file_convert.go
+++ b/cmd/file_convert.go
@@ -13,12 +13,14 @@ import (
 )
 
 var (
-	convertCmdSourceFormat      string
-	convertCmdDestinationFormat string // konnect/kong-gateway-3.x/etc
-	convertCmdInputFile         string
-	convertCmdOutputFile        string
-	convertCmdAssumeYes         bool
-	convertCmdStateFormat       string // yaml/json output
+	convertCmdSourceFormat         string
+	convertCmdDestinationFormat    string // konnect/kong-gateway-3.x/etc
+	convertCmdInputFile            string
+	convertCmdOutputFile           string
+	convertCmdInputFileDeprecated  string
+	convertCmdOutputFileDeprecated string
+	convertCmdAssumeYes            bool
+	convertCmdStateFormat          string // yaml/json output
 )
 
 func executeConvert(_ *cobra.Command, _ []string) error {
@@ -91,6 +93,8 @@ func newConvertCmd(deprecated bool) *cobra.Command {
 	if deprecated {
 		short = "[deprecated] use 'file convert' instead"
 		execute = func(cmd *cobra.Command, args []string) error {
+			convertCmdInputFile = convertCmdInputFileDeprecated
+			convertCmdOutputFile = convertCmdOutputFileDeprecated
 			cprint.UpdatePrintf("Warning: 'deck convert' is DEPRECATED and will be removed in a future version. " +
 				"Use 'deck file convert' instead.\n")
 			return executeConvert(cmd, args)
@@ -115,10 +119,17 @@ can be converted into a 'kong-gateway-3.x' configuration file.`,
 		fmt.Sprintf("format of the source file, allowed formats: %v", sourceFormats))
 	convertCmd.Flags().StringVar(&convertCmdDestinationFormat, "to", "",
 		fmt.Sprintf("desired format of the output, allowed formats: %v", destinationFormats))
-	convertCmd.Flags().StringVar(&convertCmdInputFile, "input-file", fileInDefault,
-		"configuration file to be converted. Use `-` to read from stdin.")
-	convertCmd.Flags().StringVarP(&convertCmdOutputFile, "output-file", "o", fileOutDefault,
-		"file to write configuration to after conversion. Use `-` to write to stdout.")
+	if deprecated {
+		convertCmd.Flags().StringVar(&convertCmdInputFileDeprecated, "input-file", fileInDefault,
+			"configuration file to be converted. Use `-` to read from stdin.")
+		convertCmd.Flags().StringVarP(&convertCmdOutputFileDeprecated, "output-file", "o", fileOutDefault,
+			"file to write configuration to after conversion. Use `-` to write to stdout.")
+	} else {
+		convertCmd.Flags().StringVar(&convertCmdInputFile, "input-file", fileInDefault,
+			"configuration file to be converted. Use `-` to read from stdin.")
+		convertCmd.Flags().StringVarP(&convertCmdOutputFile, "output-file", "o", fileOutDefault,
+			"file to write configuration to after conversion. Use `-` to write to stdout.")
+	}
 	convertCmd.Flags().BoolVar(&convertCmdAssumeYes, "yes",
 		false, "assume `yes` to prompts and run non-interactively.")
 	convertCmd.Flags().StringVar(&convertCmdStateFormat, "format",

--- a/cmd/gateway_dump.go
+++ b/cmd/gateway_dump.go
@@ -17,11 +17,12 @@ import (
 const defaultFileOutName = "kong"
 
 var (
-	dumpCmdKongStateFile string
-	dumpCmdStateFormat   string
-	dumpWorkspace        string
-	dumpAllWorkspaces    bool
-	dumpWithID           bool
+	dumpCmdKongStateFileDeprecated string
+	dumpCmdKongStateFile           string
+	dumpCmdStateFormat             string
+	dumpWorkspace                  string
+	dumpAllWorkspaces              bool
+	dumpWithID                     bool
 )
 
 func listWorkspaces(ctx context.Context, client *kong.Client) ([]string, error) {
@@ -149,6 +150,7 @@ func newDumpCmd(deprecated bool) *cobra.Command {
 	if deprecated {
 		short = "[deprecated] use 'gateway dump' instead"
 		execute = func(cmd *cobra.Command, args []string) error {
+			dumpCmdKongStateFile = dumpCmdKongStateFileDeprecated
 			cprint.UpdatePrintf("Warning: 'deck dump' is DEPRECATED and will be removed in a future version. " +
 				"Use 'deck gateway dump' instead.\n")
 			return executeDump(cmd, args)
@@ -168,9 +170,15 @@ configure Kong.`,
 		RunE: execute,
 	}
 
-	dumpCmd.Flags().StringVarP(&dumpCmdKongStateFile, "output-file", "o",
-		fileOutDefault, "file to which to write Kong's configuration."+
-			"Use `-` to write to stdout.")
+	if deprecated {
+		dumpCmd.Flags().StringVarP(&dumpCmdKongStateFileDeprecated, "output-file", "o",
+			fileOutDefault, "file to which to write Kong's configuration."+
+				"Use `-` to write to stdout.")
+	} else {
+		dumpCmd.Flags().StringVarP(&dumpCmdKongStateFile, "output-file", "o",
+			fileOutDefault, "file to which to write Kong's configuration."+
+				"Use `-` to write to stdout.")
+	}
 	dumpCmd.Flags().StringVar(&dumpCmdStateFormat, "format",
 		"yaml", "output file format: json or yaml.")
 	dumpCmd.Flags().BoolVar(&dumpWithID, "with-id",


### PR DESCRIPTION
2 Cobra commands were generated; deprecated, and current. Both would point to the same golbal variable.
The bug is that Cobra sets the defaults when CREATING the command not when parsing. This means that the last command created would set the global defaults, and hence overwrite the ones from the other command.

Introduced in #962

Jira: DECK-156