### PR TITLE
fix(stderr): ensure we output error to stderr, not stdout

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -85,7 +85,7 @@ func getWorkspaceName(workspaceFlag string, targetContent *file.Content,
 		if enableJSONOutput {
 			jsonOutput.Warnings = append(jsonOutput.Warnings, warning)
 		} else {
-			cprint.DeletePrintf("Warning: " + warning + "\n")
+			cprint.DeletePrintf(os.Stderr, "Warning: "+warning+"\n")
 		}
 		return workspaceFlag
 	}
@@ -266,7 +266,7 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 			}
 			jsonOutput.Changes.Creating = append(jsonOutput.Changes.Creating, workspace)
 		} else {
-			cprint.CreatePrintln("Creating workspace", wsConfig.Workspace)
+			cprint.CreatePrintln(os.Stdout, "Creating workspace", wsConfig.Workspace)
 		}
 		if !dry {
 			_, err = rootClient.Workspaces.Create(ctx, &kong.Workspace{Name: &wsConfig.Workspace})
@@ -319,7 +319,7 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 			jsonOutputString = diff.MaskEnvVarValue(jsonOutputString)
 		}
 
-		cprint.BluePrintLn(jsonOutputString + "\n")
+		cprint.BluePrintLn(os.Stdout, jsonOutputString+"\n")
 	}
 	return nil
 }

--- a/cmd/file_convert.go
+++ b/cmd/file_convert.go
@@ -77,8 +77,8 @@ func executeConvert(_ *cobra.Command, _ []string) error {
 		}
 	}
 	if convertCmdDestinationFormat == "konnect" {
-		cprint.UpdatePrintf("Warning: konnect format type was deprecated in v1.12 and it will be removed\n" +
-			"in a future version. Please use your Kong configuration files with deck <cmd>.\n" +
+		cprint.UpdatePrintf(os.Stderr, "Warning: konnect format type was deprecated in v1.12 and it will be removed\n"+
+			"in a future version. Please use your Kong configuration files with deck <cmd>.\n"+
 			"Please see https://docs.konghq.com/konnect/getting-started/import/.\n")
 	}
 	return nil
@@ -95,7 +95,7 @@ func newConvertCmd(deprecated bool) *cobra.Command {
 		execute = func(cmd *cobra.Command, args []string) error {
 			convertCmdInputFile = convertCmdInputFileDeprecated
 			convertCmdOutputFile = convertCmdOutputFileDeprecated
-			cprint.UpdatePrintf("Warning: 'deck convert' is DEPRECATED and will be removed in a future version. " +
+			cprint.UpdatePrintf(os.Stderr, "Warning: 'deck convert' is DEPRECATED and will be removed in a future version. "+
 				"Use 'deck file convert' instead.\n")
 			return executeConvert(cmd, args)
 		}

--- a/cmd/gateway_diff.go
+++ b/cmd/gateway_diff.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/kong/deck/cprint"
 	"github.com/spf13/cobra"
@@ -38,7 +39,7 @@ func newDiffCmd(deprecated bool) *cobra.Command {
 		use = "diff"
 		short = "[deprecated] use 'gateway diff' instead"
 		execute = func(cmd *cobra.Command, args []string) error {
-			cprint.UpdatePrintf("Warning: 'deck diff' is DEPRECATED and will be removed in a future version. " +
+			cprint.UpdatePrintf(os.Stderr, "Warning: 'deck diff' is DEPRECATED and will be removed in a future version. "+
 				"Use 'deck gateway diff' instead.\n")
 			return executeDiff(cmd, args)
 		}

--- a/cmd/gateway_dump.go
+++ b/cmd/gateway_dump.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/kong/deck/cprint"
@@ -151,7 +152,7 @@ func newDumpCmd(deprecated bool) *cobra.Command {
 		short = "[deprecated] use 'gateway dump' instead"
 		execute = func(cmd *cobra.Command, args []string) error {
 			dumpCmdKongStateFile = dumpCmdKongStateFileDeprecated
-			cprint.UpdatePrintf("Warning: 'deck dump' is DEPRECATED and will be removed in a future version. " +
+			cprint.UpdatePrintf(os.Stderr, "Warning: 'deck dump' is DEPRECATED and will be removed in a future version. "+
 				"Use 'deck gateway dump' instead.\n")
 			return executeDump(cmd, args)
 		}

--- a/cmd/gateway_ping.go
+++ b/cmd/gateway_ping.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/kong/deck/cprint"
 	"github.com/kong/deck/utils"
@@ -27,7 +28,7 @@ func newPingCmd(deprecated bool) *cobra.Command {
 	if deprecated {
 		short = "[deprecated] use 'gateway ping' instead"
 		execute = func(cmd *cobra.Command, args []string) error {
-			cprint.UpdatePrintf("Warning: 'deck ping' is DEPRECATED and will be removed in a future version. " +
+			cprint.UpdatePrintf(os.Stderr, "Warning: 'deck ping' is DEPRECATED and will be removed in a future version. "+
 				"Use 'deck gateway ping' instead.\n")
 			return executePing(cmd, args)
 		}

--- a/cmd/gateway_reset.go
+++ b/cmd/gateway_reset.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/kong/deck/cprint"
 	"github.com/kong/deck/state"
@@ -112,7 +113,7 @@ func newResetCmd(deprecated bool) *cobra.Command {
 	if deprecated {
 		short = "[deprecated] use 'gateway reset' instead"
 		execute = func(cmd *cobra.Command, args []string) error {
-			cprint.UpdatePrintf("Warning: 'deck reset' is DEPRECATED and will be removed in a future version. " +
+			cprint.UpdatePrintf(os.Stderr, "Warning: 'deck reset' is DEPRECATED and will be removed in a future version. "+
 				"Use 'deck gateway reset' instead.\n")
 			return executeReset(cmd, args)
 		}

--- a/cmd/gateway_sync.go
+++ b/cmd/gateway_sync.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/kong/deck/cprint"
 	"github.com/spf13/cobra"
@@ -39,7 +40,7 @@ func newSyncCmd(deprecated bool) *cobra.Command {
 		use = "sync"
 		short = "[deprecated] use 'gateway sync' instead"
 		execute = func(cmd *cobra.Command, args []string) error {
-			cprint.UpdatePrintf("Warning: 'deck sync' is DEPRECATED and will be removed in a future version. " +
+			cprint.UpdatePrintf(os.Stderr, "Warning: 'deck sync' is DEPRECATED and will be removed in a future version. "+
 				"Use 'deck gateway sync' instead.\n")
 			return executeSync(cmd, args)
 		}

--- a/cmd/gateway_validate.go
+++ b/cmd/gateway_validate.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/kong/deck/cprint"
 	"github.com/kong/deck/dump"
@@ -105,7 +106,7 @@ this command unless --online flag is used.
 `
 
 		execute = func(cmd *cobra.Command, args []string) error {
-			cprint.UpdatePrintf("Warning: 'deck validate' is DEPRECATED and will be removed in a future version. " +
+			cprint.UpdatePrintf(os.Stderr, "Warning: 'deck validate' is DEPRECATED and will be removed in a future version. "+
 				"Use 'deck gateway validate' instead.\n")
 			return executeValidate(cmd, args)
 		}

--- a/cmd/konnect.go
+++ b/cmd/konnect.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/kong/deck/cprint"
 	"github.com/spf13/cobra"
 )
@@ -18,8 +20,8 @@ func newKonnectCmd() *cobra.Command {
 		Long: `The konnect command prints subcommands that can be used to
 configure Konnect.` + konnectAlphaState,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			cprint.UpdatePrintf("Notice: The 'deck konnect' command has been deprecated as of v1.12. \n" +
-				"Please use deck <cmd> instead if you would like to declaratively manage your \n" +
+			cprint.UpdatePrintf(os.Stderr, "Notice: The 'deck konnect' command has been deprecated as of v1.12. \n"+
+				"Please use deck <cmd> instead if you would like to declaratively manage your \n"+
 				"Kong gateway config with Konnect.\n")
 		},
 	}

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -3,6 +3,7 @@ package convert
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/blang/semver/v4"
@@ -129,7 +130,7 @@ func convertKongGateway2xTo3x(input *file.Content, filename string) (*file.Conte
 		if changedRoutesLen > 10 {
 			changedRoutes = changedRoutes[:10]
 		}
-		cprint.UpdatePrintf(
+		cprint.UpdatePrintf(os.Stderr,
 			"From the '%s' config file,\n"+
 				"%d unsupported routes' paths format with Kong version 3.0\n"+
 				"or above were detected. Some of these routes are (not an exhaustive list):\n\n"+
@@ -140,7 +141,7 @@ func convertKongGateway2xTo3x(input *file.Content, filename string) (*file.Conte
 			filename, changedRoutesLen, strings.Join(changedRoutes, "\n"))
 	}
 
-	cprint.UpdatePrintf(
+	cprint.UpdatePrintf(os.Stderr,
 		"From the '%s' config file,\n"+
 			"the _format_version field has been migrated from '%s' to '%s'.\n"+
 			"These automatic changes may not be correct or exhaustive enough, please\n"+

--- a/cprint/color.go
+++ b/cprint/color.go
@@ -1,6 +1,7 @@
 package cprint
 
 import (
+	"io"
 	"sync"
 
 	"github.com/fatih/color"
@@ -13,65 +14,65 @@ var (
 	DisableOutput bool
 )
 
-func conditionalPrintf(fn func(string, ...interface{}), format string, a ...interface{}) {
+func conditionalPrintf(w io.Writer, fn func(io.Writer, string, ...interface{}), format string, a ...interface{}) {
 	if DisableOutput {
 		return
 	}
 	mu.Lock()
 	defer mu.Unlock()
-	fn(format, a...)
+	fn(w, format, a...)
 }
 
-func conditionalPrintln(fn func(...interface{}), a ...interface{}) {
+func conditionalPrintln(w io.Writer, fn func(io.Writer, ...interface{}), a ...interface{}) {
 	if DisableOutput {
 		return
 	}
 	mu.Lock()
 	defer mu.Unlock()
-	fn(a...)
+	fn(w, a...)
 }
 
 var (
-	createPrintf = color.New(color.FgGreen).PrintfFunc()
-	deletePrintf = color.New(color.FgRed).PrintfFunc()
-	updatePrintf = color.New(color.FgYellow).PrintfFunc()
+	createPrintf = color.New(color.FgGreen).FprintfFunc()
+	deletePrintf = color.New(color.FgRed).FprintfFunc()
+	updatePrintf = color.New(color.FgYellow).FprintfFunc()
 
 	// CreatePrintf is fmt.Printf with red as foreground color.
-	CreatePrintf = func(format string, a ...interface{}) {
-		conditionalPrintf(createPrintf, format, a...)
+	CreatePrintf = func(w io.Writer, format string, a ...interface{}) {
+		conditionalPrintf(w, createPrintf, format, a...)
 	}
 
 	// DeletePrintf is fmt.Printf with green as foreground color.
-	DeletePrintf = func(format string, a ...interface{}) {
-		conditionalPrintf(deletePrintf, format, a...)
+	DeletePrintf = func(w io.Writer, format string, a ...interface{}) {
+		conditionalPrintf(w, deletePrintf, format, a...)
 	}
 
 	// UpdatePrintf is fmt.Printf with yellow as foreground color.
-	UpdatePrintf = func(format string, a ...interface{}) {
-		conditionalPrintf(updatePrintf, format, a...)
+	UpdatePrintf = func(w io.Writer, format string, a ...interface{}) {
+		conditionalPrintf(w, updatePrintf, format, a...)
 	}
 
-	createPrintln = color.New(color.FgGreen).PrintlnFunc()
-	deletePrintln = color.New(color.FgRed).PrintlnFunc()
-	updatePrintln = color.New(color.FgYellow).PrintlnFunc()
-	bluePrintln   = color.New(color.BgBlue).PrintlnFunc()
+	createPrintln = color.New(color.FgGreen).FprintlnFunc()
+	deletePrintln = color.New(color.FgRed).FprintlnFunc()
+	updatePrintln = color.New(color.FgYellow).FprintlnFunc()
+	bluePrintln   = color.New(color.BgBlue).FprintlnFunc()
 
 	// CreatePrintln is fmt.Println with red as foreground color.
-	CreatePrintln = func(a ...interface{}) {
-		conditionalPrintln(createPrintln, a...)
+	CreatePrintln = func(w io.Writer, a ...interface{}) {
+		conditionalPrintln(w, createPrintln, a...)
 	}
 
 	// DeletePrintln is fmt.Println with green as foreground color.
-	DeletePrintln = func(a ...interface{}) {
-		conditionalPrintln(deletePrintln, a...)
+	DeletePrintln = func(w io.Writer, a ...interface{}) {
+		conditionalPrintln(w, deletePrintln, a...)
 	}
 
 	// UpdatePrintln is fmt.Println with yellow as foreground color.
-	UpdatePrintln = func(a ...interface{}) {
-		conditionalPrintln(updatePrintln, a...)
+	UpdatePrintln = func(w io.Writer, a ...interface{}) {
+		conditionalPrintln(w, updatePrintln, a...)
 	}
 
-	BluePrintLn = func(a ...interface{}) {
-		conditionalPrintln(bluePrintln, a...)
+	BluePrintLn = func(w io.Writer, a ...interface{}) {
+		conditionalPrintln(w, bluePrintln, a...)
 	}
 )

--- a/cprint/color_test.go
+++ b/cprint/color_test.go
@@ -42,9 +42,9 @@ func TestPrint(t *testing.T) {
 			name:          "println prints colored output",
 			DisableOutput: false,
 			Run: func() {
-				CreatePrintln("foo")
-				UpdatePrintln("bar")
-				DeletePrintln("fubaz")
+				CreatePrintln(os.Stdout, "foo")
+				UpdatePrintln(os.Stdout, "bar")
+				DeletePrintln(os.Stdout, "fubaz")
 			},
 			Expected: "\x1b[32mfoo\n\x1b[0m\x1b[33mbar\n\x1b[0m\x1b[31mfubaz\n\x1b[0m",
 		},
@@ -52,9 +52,9 @@ func TestPrint(t *testing.T) {
 			name:          "println doesn't output anything when disabled",
 			DisableOutput: true,
 			Run: func() {
-				CreatePrintln("foo")
-				UpdatePrintln("bar")
-				DeletePrintln("fubaz")
+				CreatePrintln(os.Stdout, "foo")
+				UpdatePrintln(os.Stdout, "bar")
+				DeletePrintln(os.Stdout, "fubaz")
 			},
 			Expected: "",
 		},
@@ -62,9 +62,9 @@ func TestPrint(t *testing.T) {
 			name:          "printf prints colored output",
 			DisableOutput: false,
 			Run: func() {
-				CreatePrintf("%s", "foo")
-				UpdatePrintf("%s", "bar")
-				DeletePrintf("%s", "fubaz")
+				CreatePrintf(os.Stdout, "%s", "foo")
+				UpdatePrintf(os.Stdout, "%s", "bar")
+				DeletePrintf(os.Stdout, "%s", "fubaz")
 			},
 			Expected: "\x1b[32mfoo\x1b[0m\x1b[33mbar\x1b[0m\x1b[31mfubaz\x1b[0m",
 		},
@@ -72,9 +72,9 @@ func TestPrint(t *testing.T) {
 			name:          "printf doesn't output anything when disabled",
 			DisableOutput: true,
 			Run: func() {
-				CreatePrintln("foo")
-				UpdatePrintln("bar")
-				DeletePrintln("fubaz")
+				CreatePrintln(os.Stdout, "foo")
+				UpdatePrintln(os.Stdout, "bar")
+				DeletePrintln(os.Stdout, "fubaz")
 			},
 			Expected: "",
 		},

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -131,13 +132,19 @@ func NewSyncer(opts SyncerOpts) (*Syncer, error) {
 	}
 
 	if s.createPrintln == nil {
-		s.createPrintln = cprint.CreatePrintln
+		s.createPrintln = func(a ...interface{}) {
+			cprint.CreatePrintln(os.Stdout, a...) // TODO: fix to stderr, but would be breaking now
+		}
 	}
 	if s.updatePrintln == nil {
-		s.updatePrintln = cprint.UpdatePrintln
+		s.updatePrintln = func(a ...interface{}) {
+			cprint.UpdatePrintln(os.Stdout, a...) // TODO: fix to stderr, but would be breaking now
+		}
 	}
 	if s.deletePrintln == nil {
-		s.deletePrintln = cprint.DeletePrintln
+		s.deletePrintln = func(a ...interface{}) {
+			cprint.DeletePrintln(os.Stdout, a...) // TODO: fix to stderr, but would be breaking now
+		}
 	}
 
 	err := s.init()

--- a/types/basicauth.go
+++ b/types/basicauth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sync"
 
 	"github.com/kong/deck/cprint"
@@ -105,7 +106,7 @@ func (d *basicAuthDiffer) warnBasicAuth() {
 			"credentials using decK doesn't work due to hashing of passwords in Kong."
 	)
 	d.once.Do(func() {
-		cprint.UpdatePrintln(basicAuthPasswordWarning)
+		cprint.UpdatePrintln(os.Stderr, basicAuthPasswordWarning)
 	})
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -243,7 +243,7 @@ func PrintRouteRegexWarning(unsupportedRoutes []string) {
 	if unsupportedRoutesLen > 10 {
 		unsupportedRoutes = unsupportedRoutes[:10]
 	}
-	cprint.UpdatePrintf(
+	cprint.UpdatePrintf(os.Stderr,
 		"%d unsupported routes' paths format with Kong version 3.0\n"+
 			"or above were detected. Some of these routes are (not an exhaustive list):\n\n"+
 			"%s\n\n"+UpgradeMessage,


### PR DESCRIPTION
This updates the `cprint` package to explicitly specify the output stream.

All occurrences have been updated accordingly, explicit warnings are now going to `stderr`. A few statements remain to stdout.

Is this breaking?
- it changes signatures in the internal helper package `cprint`, is this part of the external API?
- the `Syncer` (see changes in `diff/diff.go`) remains backward compatible, since that is part of the external API.