### PR TITLE
fix(cli): move deprecation warnings to stderr

### DIFF
--- a/cmd/file_convert.go
+++ b/cmd/file_convert.go
@@ -77,8 +77,8 @@ func executeConvert(_ *cobra.Command, _ []string) error {
 		}
 	}
 	if convertCmdDestinationFormat == "konnect" {
-		cprint.UpdatePrintf("Warning: konnect format type was deprecated in v1.12 and it will be removed\n" +
-			"in a future version. Please use your Kong configuration files with deck <cmd>.\n" +
+		fmt.Fprintf(os.Stderr, "Warning: konnect format type was deprecated in v1.12 and it will be removed\n"+
+			"in a future version. Please use your Kong configuration files with deck <cmd>.\n"+
 			"Please see https://docs.konghq.com/konnect/getting-started/import/.\n")
 	}
 	return nil

--- a/cmd/gateway_diff.go
+++ b/cmd/gateway_diff.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
-	"github.com/kong/deck/cprint"
 	"github.com/spf13/cobra"
 )
 
@@ -38,7 +38,7 @@ func newDiffCmd(deprecated bool) *cobra.Command {
 		use = "diff"
 		short = "[deprecated] use 'gateway diff' instead"
 		execute = func(cmd *cobra.Command, args []string) error {
-			cprint.UpdatePrintf("Warning: 'deck diff' is DEPRECATED and will be removed in a future version. " +
+			fmt.Fprintf(os.Stderr, "Warning: 'deck diff' is DEPRECATED and will be removed in a future version. "+
 				"Use 'deck gateway diff' instead.\n")
 			return executeDiff(cmd, args)
 		}

--- a/cmd/gateway_dump.go
+++ b/cmd/gateway_dump.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
-	"github.com/kong/deck/cprint"
 	"github.com/kong/deck/dump"
 	"github.com/kong/deck/file"
 	"github.com/kong/deck/state"
@@ -151,7 +151,7 @@ func newDumpCmd(deprecated bool) *cobra.Command {
 		short = "[deprecated] use 'gateway dump' instead"
 		execute = func(cmd *cobra.Command, args []string) error {
 			dumpCmdKongStateFile = dumpCmdKongStateFileDeprecated
-			cprint.UpdatePrintf("Warning: 'deck dump' is DEPRECATED and will be removed in a future version. " +
+			fmt.Fprintf(os.Stderr, "Warning: 'deck dump' is DEPRECATED and will be removed in a future version. "+
 				"Use 'deck gateway dump' instead.\n")
 			return executeDump(cmd, args)
 		}

--- a/cmd/gateway_ping.go
+++ b/cmd/gateway_ping.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 
-	"github.com/kong/deck/cprint"
 	"github.com/kong/deck/utils"
 	"github.com/spf13/cobra"
 )
@@ -27,7 +27,7 @@ func newPingCmd(deprecated bool) *cobra.Command {
 	if deprecated {
 		short = "[deprecated] use 'gateway ping' instead"
 		execute = func(cmd *cobra.Command, args []string) error {
-			cprint.UpdatePrintf("Warning: 'deck ping' is DEPRECATED and will be removed in a future version. " +
+			fmt.Fprintf(os.Stderr, "Warning: 'deck ping' is DEPRECATED and will be removed in a future version. "+
 				"Use 'deck gateway ping' instead.\n")
 			return executePing(cmd, args)
 		}

--- a/cmd/gateway_reset.go
+++ b/cmd/gateway_reset.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
-	"github.com/kong/deck/cprint"
 	"github.com/kong/deck/state"
 	"github.com/kong/deck/utils"
 	"github.com/spf13/cobra"
@@ -112,7 +112,7 @@ func newResetCmd(deprecated bool) *cobra.Command {
 	if deprecated {
 		short = "[deprecated] use 'gateway reset' instead"
 		execute = func(cmd *cobra.Command, args []string) error {
-			cprint.UpdatePrintf("Warning: 'deck reset' is DEPRECATED and will be removed in a future version. " +
+			fmt.Fprintf(os.Stderr, "Warning: 'deck reset' is DEPRECATED and will be removed in a future version. "+
 				"Use 'deck gateway reset' instead.\n")
 			return executeReset(cmd, args)
 		}

--- a/cmd/gateway_sync.go
+++ b/cmd/gateway_sync.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
-	"github.com/kong/deck/cprint"
 	"github.com/spf13/cobra"
 )
 
@@ -39,7 +39,7 @@ func newSyncCmd(deprecated bool) *cobra.Command {
 		use = "sync"
 		short = "[deprecated] use 'gateway sync' instead"
 		execute = func(cmd *cobra.Command, args []string) error {
-			cprint.UpdatePrintf("Warning: 'deck sync' is DEPRECATED and will be removed in a future version. " +
+			fmt.Fprintf(os.Stderr, "Warning: 'deck sync' is DEPRECATED and will be removed in a future version. "+
 				"Use 'deck gateway sync' instead.\n")
 			return executeSync(cmd, args)
 		}

--- a/cmd/gateway_validate.go
+++ b/cmd/gateway_validate.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 
-	"github.com/kong/deck/cprint"
 	"github.com/kong/deck/dump"
 	"github.com/kong/deck/file"
 	"github.com/kong/deck/state"
@@ -105,7 +105,7 @@ this command unless --online flag is used.
 `
 
 		execute = func(cmd *cobra.Command, args []string) error {
-			cprint.UpdatePrintf("Warning: 'deck validate' is DEPRECATED and will be removed in a future version. " +
+			fmt.Fprintf(os.Stderr, "Warning: 'deck validate' is DEPRECATED and will be removed in a future version. "+
 				"Use 'deck gateway validate' instead.\n")
 			return executeValidate(cmd, args)
 		}

--- a/tests/integration/diff_test.go
+++ b/tests/integration/diff_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 var (
-	expectedOutputMasked = `Warning: 'deck diff' is DEPRECATED and will be removed in a future version. Use 'deck gateway diff' instead.
-updating service svc1  {
+	expectedOutputMasked = `updating service svc1  {
    "connect_timeout": 60000,
    "enabled": true,
    "host": "[masked]",
@@ -38,8 +37,7 @@ Summary:
   Deleted: 0
 `
 
-	expectedOutputUnMasked = `Warning: 'deck diff' is DEPRECATED and will be removed in a future version. Use 'deck gateway diff' instead.
-updating service svc1  {
+	expectedOutputUnMasked = `updating service svc1  {
    "connect_timeout": 60000,
    "enabled": true,
    "host": "mockbin.org",
@@ -70,8 +68,7 @@ Summary:
 		"DECK_FOO":           "foo_test", // unused, partial match
 	}
 
-	expectedOutputUnMaskedJSON = `Warning: 'deck diff' is DEPRECATED and will be removed in a future version. Use 'deck gateway diff' instead.
-{
+	expectedOutputUnMaskedJSON = `{
 	"changes": {
 		"creating": [
 			{
@@ -167,8 +164,7 @@ Summary:
 
 `
 
-	expectedOutputMaskedJSON = `Warning: 'deck diff' is DEPRECATED and will be removed in a future version. Use 'deck gateway diff' instead.
-{
+	expectedOutputMaskedJSON = `{
 	"changes": {
 		"creating": [
 			{
@@ -268,8 +264,7 @@ Summary:
 
 `
 
-	expectedOutputUnMaskedJSON30x = `Warning: 'deck diff' is DEPRECATED and will be removed in a future version. Use 'deck gateway diff' instead.
-{
+	expectedOutputUnMaskedJSON30x = `{
 	"changes": {
 		"creating": [
 			{
@@ -363,8 +358,7 @@ Summary:
 
 `
 
-	expectedOutputMaskedJSON30x = `Warning: 'deck diff' is DEPRECATED and will be removed in a future version. Use 'deck gateway diff' instead.
-{
+	expectedOutputMaskedJSON30x = `{
 	"changes": {
 		"creating": [
 			{


### PR DESCRIPTION
This is ugly and inconsistent, but not breaking.

