### PR TITLE
fix: handle tags for old consumer-groups implementation

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -248,6 +248,7 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 	// read the current state
 	var currentState *state.KongState
 	if workspaceExists {
+		ctx = context.WithValue(ctx, utils.KongVersionContextKey, parsedKongVersion)
 		currentState, err = fetchCurrentState(ctx, kongClient, dumpConfig)
 		if err != nil {
 			return err

--- a/tests/integration/testdata/sync/028-consumer-groups-tags/no_tags.yaml
+++ b/tests/integration/testdata/sync/028-consumer-groups-tags/no_tags.yaml
@@ -1,0 +1,9 @@
+_format_version: "3.0"
+consumer_groups:
+- name: my-cg
+  consumers:
+  - username: foo
+plugins:
+- name: prometheus
+consumers:
+- username: foo

--- a/tests/integration/testdata/sync/028-consumer-groups-tags/with_tags.yaml
+++ b/tests/integration/testdata/sync/028-consumer-groups-tags/with_tags.yaml
@@ -1,0 +1,15 @@
+_format_version: "3.0"
+_info:
+  defaults: {}
+  select_tags:
+  - foo
+services:
+- connect_timeout: 60000
+  enabled: true
+  host: mockbin.org
+  name: svc1
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -22,8 +22,25 @@ var (
 
 	Kong140Version = semver.MustParse("1.4.0")
 	Kong300Version = semver.MustParse("3.0.0")
+	Kong320Version = semver.MustParse("3.2.0")
 	Kong340Version = semver.MustParse("3.4.0")
 )
+
+type ContextKey int
+
+const (
+	// KongVersionContextKey is the context key used to store the Kong version
+	// in the context.
+	KongVersionContextKey ContextKey = iota
+)
+
+func GetKongVersionFromContext(ctx context.Context) semver.Version {
+	v, ok := ctx.Value(KongVersionContextKey).(semver.Version)
+	if !ok {
+		return semver.Version{}
+	}
+	return v
+}
 
 var ErrorConsumerGroupUpgrade = errors.New(
 	"a rate-limiting-advanced plugin with config.consumer_groups\n" +


### PR DESCRIPTION
Tags support for Consumer Groups was introduced in 3.2. Before that, making a request with a tag would have no effect in the Gateway:

```

$ http :8001/plugins\?tags=foo
HTTP/1.1 200 OK
{
    "data": [],
    "next": null
}

$ http :8001/consumer_groups\?tags=foo
HTTP/1.1 200 OK
{
    "data": [
        {
            "created_at": 1699337744,
            "id": "d241ee7f-875a-41f1-84fb-c509df9e716e",
            "name": "my-cg"
        }
    ],
    "next": null
}
```

For this reason, when a Consumer Group is present and a `sync` with `select_tags` is ran, the existing Consumer Group is wiped out.

This commit introduces a custom way to handle tags for Consumer Groups when the `select_tags` is present in the input. This doesn't mean we are implementing tags support for older versions of the Gateway, but it means that if a Consumer Group (without a tag) exists, it won't be wiped out when a `sync` with `select_tags` is ran.