### PR TITLE
fix: use hardcoded Konnect version instead of retrieving it

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -193,10 +193,7 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 	var kongVersion string
 	var parsedKongVersion semver.Version
 	if mode == modeKonnect {
-		kongVersion, err = fetchKonnectKongVersion(ctx, kongClient)
-		if err != nil {
-			return fmt.Errorf("reading Konnect Kong version: %w", err)
-		}
+		kongVersion = fetchKonnectKongVersion()
 	} else {
 		kongVersion, err = fetchKongVersion(ctx, wsConfig)
 		if err != nil {

--- a/cmd/common_konnect.go
+++ b/cmd/common_konnect.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"os"
 	"strings"
 
@@ -118,10 +117,6 @@ func dumpKonnectV2(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	kongVersion, err := fetchKonnectKongVersion(ctx, client)
-	if err != nil {
-		return fmt.Errorf("reading Konnect Kong version: %w", err)
-	}
 	rawState, err := dump.Get(ctx, client, dumpConfig)
 	if err != nil {
 		return fmt.Errorf("reading configuration from Kong: %w", err)
@@ -136,7 +131,7 @@ func dumpKonnectV2(ctx context.Context) error {
 		FileFormat:       file.Format(strings.ToUpper(dumpCmdStateFormat)),
 		WithID:           dumpWithID,
 		ControlPlaneName: konnectControlPlane,
-		KongVersion:      kongVersion,
+		KongVersion:      fetchKonnectKongVersion(),
 	})
 }
 
@@ -346,17 +341,10 @@ func getKonnectState(ctx context.Context,
 	return ks, nil
 }
 
-func fetchKonnectKongVersion(ctx context.Context, client *kong.Client) (string, error) {
-	req, err := http.NewRequest("GET",
-		utils.CleanAddress(client.BaseRootURL())+"/v1", nil)
-	if err != nil {
-		return "", err
-	}
-
-	var resp map[string]interface{}
-	_, err = client.Do(ctx, req, &resp)
-	if err != nil {
-		return "", err
-	}
-	return resp["version"].(string), nil
+func fetchKonnectKongVersion() string {
+	// Returning an hardcoded version for now. decK only needs the version
+	// to determine the format_version expected in the state file. Since
+	// Konnect is always on the latest version, we can safely return the
+	// latest version here and avoid making an extra and unnecessary request.
+	return "3.5.0.0"
 }


### PR DESCRIPTION
This commit removes the logic to fetch the Konnect version from Konnect API and it simply hardcodes it. The Konnect version is used only to evaluate and decide which format_version to expect or dump in state files. Since Konnect only uses '_format_verion: 3.0', and since Konnect always uses the latest Kong version, then we can simply hardcode the Konnect version and avoid an unnecessary network call