### PR TITLE
chore: enable linter rules for deprecated code and fix offending lines

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+run:
+  timeout: 10m
 linters:
   enable:
   - asciicheck
@@ -28,6 +30,7 @@ linters:
   - wastedassign
   - errorlint
 issues:
+  max-same-issues: 0
   exclude-rules:
   - linters:
     - gosec
@@ -53,7 +56,7 @@ issues:
   # ignore SA1019 deprecation warning
   - linters:
     - staticcheck
-    text:  "SA1019.*"
+    text:  "SA1019: rand..*"
   # ignore formatting warnings in cmd/root.go due to nolint statements
   - linters:
     - gofumpt

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ test:
 
 .PHONY: lint
 lint:
-	golangci-lint run ./...
+	golangci-lint run -v ./...
 
 .PHONY: build
 build:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"strings"
@@ -301,7 +300,7 @@ func initConfig() {
 	if caCertContent == "" {
 		caCertFileContent := viper.GetString("ca-cert-file")
 		if caCertFileContent != "" {
-			fileContent, err := ioutil.ReadFile(caCertFileContent)
+			fileContent, err := os.ReadFile(caCertFileContent)
 			if err != nil {
 				fmt.Printf("read file %q: %s", caCertFileContent, err)
 				os.Exit(1)
@@ -325,7 +324,7 @@ func initConfig() {
 	if clientCertContent == "" {
 		clientCertFileContent := viper.GetString("tls-client-cert-file")
 		if clientCertFileContent != "" {
-			fileContent, err := ioutil.ReadFile(clientCertFileContent)
+			fileContent, err := os.ReadFile(clientCertFileContent)
 			if err != nil {
 				fmt.Printf("read file %q: %s", clientCertFileContent, err)
 				os.Exit(1)
@@ -341,7 +340,7 @@ func initConfig() {
 	if clientKeyContent == "" {
 		clientKeyFileContent := viper.GetString("tls-client-key-file")
 		if clientKeyFileContent != "" {
-			fileContent, err := ioutil.ReadFile(clientKeyFileContent)
+			fileContent, err := os.ReadFile(clientKeyFileContent)
 			if err != nil {
 				fmt.Printf("read file %q: %s", clientKeyFileContent, err)
 				os.Exit(1)
@@ -376,7 +375,7 @@ func initKonnectConfig() error {
 	// read from password file only if password is not supplied using an
 	// environment variable or flag
 	if password == "" && passwordFile != "" {
-		fileContent, err := ioutil.ReadFile(passwordFile)
+		fileContent, err := os.ReadFile(passwordFile)
 		if err != nil {
 			return fmt.Errorf("read file %q: %w", passwordFile, err)
 		}
@@ -392,7 +391,7 @@ func initKonnectConfig() error {
 	// read from token file only if token is not supplied using an
 	// environment variable or flag
 	if token == "" && tokenFile != "" {
-		fileContent, err := ioutil.ReadFile(tokenFile)
+		fileContent, err := os.ReadFile(tokenFile)
 		if err != nil {
 			return fmt.Errorf("read file %q: %w", tokenFile, err)
 		}

--- a/file/codegen/main.go
+++ b/file/codegen/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"log"
+	"os"
 	"reflect"
 
 	"github.com/alecthomas/jsonschema"
@@ -114,7 +114,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	err = ioutil.WriteFile("kong_json_schema.json", jsonSchema, 0o644)
+	err = os.WriteFile("kong_json_schema.json", jsonSchema, 0o644)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/file/reader_test.go
+++ b/file/reader_test.go
@@ -3,7 +3,6 @@ package file
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -11,6 +10,7 @@ import (
 	"github.com/kong/deck/dump"
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_ensureJSON(t *testing.T) {
@@ -49,19 +49,15 @@ func TestReadKongStateFromStdinFailsToParseText(t *testing.T) {
 	var content bytes.Buffer
 	content.Write([]byte("hunter2\n"))
 
-	tmpfile, err := ioutil.TempFile("", "example")
-	if err != nil {
-		panic(err)
-	}
+	tmpfile, err := os.CreateTemp("", "example")
+	require.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 
-	if _, err := tmpfile.Write(content.Bytes()); err != nil {
-		panic(err)
-	}
+	_, err = tmpfile.Write(content.Bytes())
+	require.NoError(t, err)
 
-	if _, err := tmpfile.Seek(0, 0); err != nil {
-		panic(err)
-	}
+	_, err = tmpfile.Seek(0, 0)
+	require.NoError(t, err)
 
 	oldStdin := os.Stdin
 	defer func() { os.Stdin = oldStdin }() // Restore original Stdin
@@ -77,20 +73,15 @@ func TestTransformNotFalse(t *testing.T) {
 	filenames := []string{"-"}
 	assert := assert.New(t)
 
-	tmpfile, err := ioutil.TempFile("", "example")
-	if err != nil {
-		panic(err)
-	}
+	tmpfile, err := os.CreateTemp("", "example")
+	require.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 
 	_, err = tmpfile.WriteString("_transform: false\nservices:\n- host: test.com\n  name: test service\n")
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
-	if _, err := tmpfile.Seek(0, 0); err != nil {
-		panic(err)
-	}
+	_, err = tmpfile.Seek(0, 0)
+	require.NoError(t, err)
 
 	oldStdin := os.Stdin
 	defer func() { os.Stdin = oldStdin }() // Restore original Stdin
@@ -98,9 +89,7 @@ func TestTransformNotFalse(t *testing.T) {
 	os.Stdin = tmpfile
 
 	c, err := GetContentFromFiles(filenames, false)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	ctx := context.Background()
 	parsed, err := Get(ctx, c, RenderConfig{}, dump.Config{}, nil)
@@ -120,19 +109,15 @@ func TestReadKongStateFromStdin(t *testing.T) {
 	var content bytes.Buffer
 	content.Write([]byte("services:\n- host: test.com\n  name: test service\n"))
 
-	tmpfile, err := ioutil.TempFile("", "example")
-	if err != nil {
-		panic(err)
-	}
+	tmpfile, err := os.CreateTemp("", "example")
+	require.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 
-	if _, err := tmpfile.Write(content.Bytes()); err != nil {
-		panic(err)
-	}
+	_, err = tmpfile.Write(content.Bytes())
+	require.NoError(t, err)
 
-	if _, err := tmpfile.Seek(0, 0); err != nil {
-		panic(err)
-	}
+	_, err = tmpfile.Seek(0, 0)
+	require.NoError(t, err)
 
 	oldStdin := os.Stdin
 	defer func() { os.Stdin = oldStdin }() // Restore original Stdin

--- a/file/readfile.go
+++ b/file/readfile.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -106,8 +105,7 @@ func hasLeadingSpace(fileContent string) bool {
 // readContent reads all the byes until io.EOF and unmarshals the read
 // bytes into Content.
 func readContent(reader io.Reader, mockEnvVars bool) (*Content, error) {
-	var err error
-	contentBytes, err := ioutil.ReadAll(reader)
+	contentBytes, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}

--- a/file/writer.go
+++ b/file/writer.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -812,7 +811,7 @@ func WriteContentToFile(content *Content, filename string, format Format) error 
 	} else {
 		filename = utils.AddExtToFilename(filename, strings.ToLower(string(format)))
 		prefix, _ := filepath.Split(filename)
-		if err := ioutil.WriteFile(filename, c, 0o600); err != nil {
+		if err := os.WriteFile(filename, c, 0o600); err != nil {
 			return fmt.Errorf("writing file: %w", err)
 		}
 		for _, sp := range content.ServicePackages {

--- a/konnect/error.go
+++ b/konnect/error.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -13,7 +13,13 @@ func hasError(res *http.Response) error {
 		return nil
 	}
 
-	body, _ := ioutil.ReadAll(res.Body) // TODO error in error?
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return &APIError{
+			httpCode: res.StatusCode,
+			message:  fmt.Sprintf("<failed to read response body: %v>", err),
+		}
+	}
 	return &APIError{
 		httpCode: res.StatusCode,
 		message:  messageFromBody(body),

--- a/tests/integration/lint_test.go
+++ b/tests/integration/lint_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/kong/deck/cmd"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 func Test_LintPlain(t *testing.T) {


### PR DESCRIPTION
This PR makes `staticheck`'s exclude rules narrower by only ignoring the `rand.` regex (this is problematic to solve - not impossible - because we're using `rand.Seed()` which [is now deprecated](https://pkg.go.dev/math/rand#Seed) in favor of `New(NewSource(seed))` which returns a variable and doesn't affect the global behavior).