### PR TITLE
ci: use license action

### DIFF
--- a/.github/workflows/integration-enterprise.yaml
+++ b/.github/workflows/integration-enterprise.yaml
@@ -28,22 +28,29 @@ jobs:
     env:
       KONG_ANONYMOUS_REPORTS: "off"
       KONG_IMAGE: ${{ matrix.kong_image }}
-      KONG_LICENSE_DATA: ${{ secrets.KONG_LICENSE_DATA }}
 
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Setup go
         uses: actions/setup-go@v4
         with:
           go-version: '^1.20'
-      - name: Checkout repository
-        uses: actions/checkout@v4
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKERHUB_PULL_USERNAME}}
           password: ${{secrets.DOCKERHUB_PULL_TOKEN}}
+      - uses: Kong/kong-license@master
+        id: license
+        with:
+          password: ${{ secrets.PULP_PASSWORD }}
       - name: Setup Kong
+        env:
+          KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
         run: make setup-kong-ee
       - name: Run integration tests
+        env:
+          KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
         run: make test-integration

--- a/.github/workflows/integration-konnect.yaml
+++ b/.github/workflows/integration-konnect.yaml
@@ -12,11 +12,11 @@ jobs:
       DECK_KONNECT_TOKEN : ${{ secrets.DECK_KONNECT_TOKEN }}
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Setup go
         uses: actions/setup-go@v4
         with:
           go-version: '^1.20'
-      - name: Checkout repository
-        uses: actions/checkout@v4
       - name: Run integration tests
         run: make test-integration

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -32,12 +32,12 @@ jobs:
       KONG_IMAGE: ${{ matrix.kong_image }}
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Setup go
         uses: actions/setup-go@v4
         with:
           go-version: '^1.20'
-      - name: Checkout repository
-        uses: actions/checkout@v4
       - name: Setup Kong
         run: make setup-kong
       - name: Run integration tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,12 +10,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Setup go
         uses: actions/setup-go@v4
         with:
           go-version: '^1.20'
-      - name: Checkout repository
-        uses: actions/checkout@v4
       - name: Setup golangci-lint
         uses: golangci/golangci-lint-action@v3.7.0
       - name: Verify Codegen

--- a/.github/workflows/validate-kong-release.yaml
+++ b/.github/workflows/validate-kong-release.yaml
@@ -18,22 +18,29 @@ jobs:
     env:
       KONG_ANONYMOUS_REPORTS: "off"
       KONG_IMAGE: ${{ inputs.kong_image }}
-      KONG_LICENSE_DATA: ${{ secrets.KONG_LICENSE_DATA }}
     runs-on: ubuntu-latest
     steps:
       - name: Execution Information
         run: |
           echo "Kong Gateway Image = ${{ inputs.kong_image }}"
           echo "decK Branch = ${{ inputs.branch }}"
-      - name: Setup go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '^1.20'
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
+      - name: Setup go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '^1.20'
+      - uses: Kong/kong-license@master
+        id: license
+        with:
+          password: ${{ secrets.PULP_PASSWORD }}
       - name: Setup Kong
+        env:
+          KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
         run: make setup-kong-ee
       - name: Run integration tests
+        env:
+          KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
         run: make test-integration


### PR DESCRIPTION
Use https://github.com/Kong/kong-license/ instead of manually updated secret. 🤖 

Also while at it, change the order of steps in tests to utilize Go cache. Without this change repo is not checked out when go is being set up:

```
Restore cache failed: Dependencies file is not found in /home/runner/work/deck/deck. Supported file pattern: go.sum
```