### PR TITLE
deps(go-apiops): bump to 0.1.26, adding O2K security

### DIFF
--- a/cmd/file_openapi2kong.go
+++ b/cmd/file_openapi2kong.go
@@ -13,13 +13,15 @@ import (
 )
 
 var (
-	cmdO2KinputFilename  string
-	cmdO2KoutputFilename string
-	cmdO2KdocName        string
-	cmdO2KoutputFormat   string
-	cmdO2KentityTags     []string
-	cmdO2KskipID         bool
-	cmdO2KinsoCompat     bool
+	cmdO2KinputFilename       string
+	cmdO2KoutputFilename      string
+	cmdO2KdocName             string
+	cmdO2KoutputFormat        string
+	cmdO2KentityTags          []string
+	cmdO2KskipID              bool
+	cmdO2KinsoCompat          bool
+	cmdO2Ksecurity            bool
+	cmdO2KignoreSecurityError bool
 )
 
 // Executes the CLI command "openapi2kong"
@@ -38,10 +40,12 @@ func executeOpenapi2Kong(cmd *cobra.Command, _ []string) error {
 		cmdO2KskipID = true // this is implicit in inso compatibility mode
 	}
 	options := openapi2kong.O2kOptions{
-		Tags:       cmdO2KentityTags,
-		DocName:    cmdO2KdocName,
-		SkipID:     cmdO2KskipID,
-		InsoCompat: cmdO2KinsoCompat,
+		Tags:                 cmdO2KentityTags,
+		DocName:              cmdO2KdocName,
+		SkipID:               cmdO2KskipID,
+		InsoCompat:           cmdO2KinsoCompat,
+		OIDC:                 cmdO2Ksecurity,
+		IgnoreSecurityErrors: cmdO2KignoreSecurityError,
 	}
 
 	trackInfo := deckformat.HistoryNewEntry("openapi2kong")
@@ -103,6 +107,10 @@ The output will be targeted at Kong version 3.x.
 	openapi2kongCmd.Flags().BoolVarP(&cmdO2KinsoCompat, "inso-compatible", "i", false,
 		"This flag will enable Inso compatibility. The generated entity names will be\n"+
 			"the same, and no 'id' fields will be gnerated.")
+	openapi2kongCmd.Flags().BoolVarP(&cmdO2Ksecurity, "generate-security", "", false, "generate OpenIDConnect plugins "+
+		"from the security directives")
+	openapi2kongCmd.Flags().BoolVarP(&cmdO2KignoreSecurityError, "ignore-security-errors", "", false,
+		"ignore errors for unsupported security schemes")
 
 	return openapi2kongCmd
 }

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/daveshanley/vacuum v0.5.0
 	github.com/fatih/color v1.15.0
 	github.com/google/go-cmp v0.6.0
-	github.com/kong/go-apiops v0.1.24
+	github.com/kong/go-apiops v0.1.26
 	github.com/kong/go-database-reconciler v1.1.0
 	github.com/kong/go-kong v0.49.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/klauspost/cpuid/v2 v2.0.10/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuOb
 github.com/klauspost/cpuid/v2 v2.0.12/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=
 github.com/klauspost/cpuid/v2 v2.2.3 h1:sxCkb+qR91z4vsqw4vGGZlDgPz3G7gjaLyK3V8y70BU=
 github.com/klauspost/cpuid/v2 v2.2.3/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
-github.com/kong/go-apiops v0.1.24 h1:gFPwDzHBzhHih5oV/ru0fWYUiWMYwBYWXEdNS9i5ldo=
-github.com/kong/go-apiops v0.1.24/go.mod h1:kFc+1mlnUpmyCqem9O7aes3UaBnezu4WhgDCfrh5zAA=
+github.com/kong/go-apiops v0.1.26 h1:r03no2qgJRsJYlv7lyENnekaTNSMAeF+q+Fai5Kxy/c=
+github.com/kong/go-apiops v0.1.26/go.mod h1:FJ7wAcELop41pCUY6CT7cgwmfFhH1ciUS0FEQ8NN8gA=
 github.com/kong/go-database-reconciler v1.1.0 h1:USCdsAj/7eh9sOOfbnvsOe4jw5k4+FSTD3okcTLIVqQ=
 github.com/kong/go-database-reconciler v1.1.0/go.mod h1:p8NvafqBSuMR9YNCOZ24aIeeajc145+biXpAaMExvpI=
 github.com/kong/go-kong v0.49.0 h1:QtO0TtVPYQXjBJ/MNptvyodRNwubbtIkoNhQkh17Q1g=


### PR DESCRIPTION
Adds generating OIDC plugins from OpenAPI Security directives

This also makes go-apiops commands update the cli warnings, hence merging this PR should be aligned with;

- [x] #1123 which will display the same stdin warning as go-apiops for deck native commands
- [x] #1115 which improves the deprecation warnings