### PR TITLE
feat: Add flag to render allowing DECK_ env var processing

### DIFF
--- a/cmd/file_render.go
+++ b/cmd/file_render.go
@@ -9,9 +9,10 @@ import (
 )
 
 var (
-	fileRenderCmdKongStateFile  []string
-	fileRenderCmdKongFileOutput string
-	fileRenderCmdStateFormat    string
+	fileRenderCmdKongStateFile   []string
+	fileRenderCmdKongFileOutput  string
+	fileRenderCmdStateFormat     string
+	fileRenderCmdPopulateEnvVars bool
 )
 
 func executeFileRenderCmd(_ *cobra.Command, _ []string) error {
@@ -22,7 +23,7 @@ func executeFileRenderCmd(_ *cobra.Command, _ []string) error {
 		file.Format(strings.ToUpper(fileRenderCmdStateFormat)),
 		convert.FormatDistributed,
 		convert.FormatKongGateway3x,
-		true)
+		!fileRenderCmdPopulateEnvVars)
 }
 
 func newFileRenderCmd() *cobra.Command {
@@ -61,6 +62,9 @@ combined JSON file:
 			"Use `-` to write to stdout.")
 	renderCmd.Flags().StringVar(&fileRenderCmdStateFormat, "format",
 		"yaml", "output file format: json or yaml.")
+	renderCmd.Flags().BoolVar(&fileRenderCmdPopulateEnvVars, "populate-env-vars", false,
+		"Populate 'DECK_' environment variables in the output file. The default behavior\n"+
+			"is to mock environment variable values.")
 
 	return renderCmd
 }

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -292,6 +292,24 @@ func Test_Convert(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "converts from distributed to kong gateway 3.x with env variables",
+			args: args{
+				inputFilenames:         []string{"testdata/8/input.yaml"},
+				outputFilename:         "testdata/8/output.yaml",
+				expectedOutputFilename: "testdata/8/output-expected.yaml",
+				fromFormat:             FormatDistributed,
+				toFormat:               FormatKongGateway3x,
+				disableMocks:           true,
+				envVars: map[string]string{
+					"DECK_MOCKBIN_HOST":    "mockbin.org",
+					"DECK_MOCKBIN_ENABLED": "true",
+					"DECK_WRITE_TIMEOUT":   "777",
+					"DECK_FOO_FLOAT":       "666",
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "converts from distributed to kong gateway with env variables (mocked)",
 			args: args{
 				inputFilenames:         []string{"testdata/9/input.yaml"},

--- a/tests/integration/render_test.go
+++ b/tests/integration/render_test.go
@@ -1,0 +1,56 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_RenderPlain(t *testing.T) {
+	tests := []struct {
+		name           string
+		stateFile      string
+		additionalArgs []string
+		expectedFile   string
+		envVars        map[string]string
+	}{
+		{
+			name:           "render with mocked env",
+			stateFile:      "testdata/render/001-mocked-env/input.yaml",
+			additionalArgs: []string{},
+			expectedFile:   "testdata/render/001-mocked-env/expected.yaml",
+			envVars:        map[string]string{},
+		},
+		{
+			name:           "render with populated env",
+			stateFile:      "testdata/render/002-populated-env/input.yaml",
+			additionalArgs: []string{"--populate-env-vars"},
+			expectedFile:   "testdata/render/002-populated-env/expected.yaml",
+			envVars: map[string]string{
+				"DECK_MOCKBIN_HOST":    "mockbin.org",
+				"DECK_MOCKBIN_ENABLED": "true",
+				"DECK_WRITE_TIMEOUT":   "777",
+				"DECK_FOO_FLOAT":       "123",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			renderOpts := []string{
+				tc.stateFile,
+			}
+			renderOpts = append(renderOpts, tc.additionalArgs...)
+
+			for k, v := range tc.envVars {
+				t.Setenv(k, v)
+			}
+
+			output, err := render(renderOpts...)
+			assert.NoError(t, err)
+
+			expected, err := readFile(tc.expectedFile)
+			assert.NoError(t, err)
+			assert.Equal(t, expected, output)
+		})
+	}
+}

--- a/tests/integration/test_utils.go
+++ b/tests/integration/test_utils.go
@@ -353,3 +353,26 @@ func ping(opts ...string) error {
 	deckCmd.SetArgs(args)
 	return deckCmd.ExecuteContext(context.Background())
 }
+
+func render(opts ...string) (string, error) {
+	deckCmd := cmd.NewRootCmd()
+	args := []string{"file", "render"}
+
+	if len(opts) > 0 {
+		args = append(args, opts...)
+	}
+	deckCmd.SetArgs(args)
+
+	// capture command output to be used during tests
+	rescueStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cmdErr := deckCmd.ExecuteContext(context.Background())
+
+	w.Close()
+	out, _ := io.ReadAll(r)
+	os.Stdout = rescueStdout
+
+	return stripansi.Strip(string(out)), cmdErr
+}

--- a/tests/integration/testdata/render/001-mocked-env/expected.yaml
+++ b/tests/integration/testdata/render/001-mocked-env/expected.yaml
@@ -1,0 +1,13 @@
+_format_version: "3.0"
+plugins:
+- config:
+    foo: 42
+  name: foofloat
+services:
+- connect_timeout: 60000
+  enabled: false
+  host: DECK_MOCKBIN_HOST
+  name: svc1
+  protocol: http
+  read_timeout: 60000
+  write_timeout: 42

--- a/tests/integration/testdata/render/001-mocked-env/input.yaml
+++ b/tests/integration/testdata/render/001-mocked-env/input.yaml
@@ -1,0 +1,13 @@
+_format_version: "3.0"
+plugins:
+- config:
+    foo: ${{ env "DECK_FOO_FLOAT" | toFloat }}
+  name: foofloat
+services:
+- connect_timeout: 60000
+  enabled: ${{ env "DECK_MOCKBIN_ENABLED" | toBool }}
+  host: ${{ env "DECK_MOCKBIN_HOST" }}
+  name: svc1
+  protocol: http
+  read_timeout: 60000
+  write_timeout: ${{ env "DECK_WRITE_TIMEOUT" | toInt }}

--- a/tests/integration/testdata/render/002-populated-env/expected.yaml
+++ b/tests/integration/testdata/render/002-populated-env/expected.yaml
@@ -1,0 +1,13 @@
+_format_version: "3.0"
+plugins:
+- config:
+    foo: 123
+  name: foofloat
+services:
+- connect_timeout: 60000
+  enabled: true
+  host: mockbin.org
+  name: svc1
+  protocol: http
+  read_timeout: 60000
+  write_timeout: 777

--- a/tests/integration/testdata/render/002-populated-env/input.yaml
+++ b/tests/integration/testdata/render/002-populated-env/input.yaml
@@ -1,0 +1,9 @@
+services:
+- name: svc1
+  host: ${{ env "DECK_MOCKBIN_HOST" }}
+  enabled: ${{ env "DECK_MOCKBIN_ENABLED" | toBool }}
+  write_timeout: ${{ env "DECK_WRITE_TIMEOUT" | toInt }}
+plugins:
+- config:
+    foo: ${{ env "DECK_FOO_FLOAT" | toFloat }}
+  name: foofloat


### PR DESCRIPTION
Resolves #1207 

By default `deck file render` mocks the values of `DECK_` env vars. This was intentional as to support rendering a full configuration in environments where all values are not present (ex: CI systems).  This PR adds a flag for `deck file render`, `--populate-env-vars` with a default of `false`.  The flag is written in the affirmative case while the `false` default prevents breaking previous default behavior. Users interested in populating the env vars must set `--populate-env-vars` to enable the behavior.

```
DECK_ECHO_DOWNSTREAM=true DECK_HEADER_NAME=X-Flag ./deck file render ~/kong/tmp/deck-file-render-1207.yaml
_format_version: "3.0"
plugins:
- config:
    echo_downstream: false
    generator: uuid
    header_name: DECK_HEADER_NAME
  enabled: true
  name: correlation-id
  protocols:
  - grpc
  - grpcs
  - http
  - https
```

```
> DECK_ECHO_DOWNSTREAM=true DECK_HEADER_NAME=X-Flag ./deck file render ~/kong/tmp/deck-file-render-1207.yaml --populate-env-vars
_format_version: "3.0"
plugins:
- config:
    echo_downstream: true
    generator: uuid
    header_name: X-Flag
  enabled: true
  name: correlation-id
  protocols:
  - grpc
  - grpcs
  - http
  - https

```

