### PR TITLE
Revert "chore(ci): wrap codecov upload in a retry (#1178)"

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,20 +28,10 @@ jobs:
       - name: Run tests with Coverage
         run: make coverage
       - name: Upload Code Coverage
-        # this action often fails, hence we wrap it in a retry
-        # uses: codecov/codecov-action@v3
-        # with:
-        #   name: codecov-deck
-        #   token: ${{ secrets.CODECOV_TOKEN }}
-        #   fail_ci_if_error: true
-        uses: Wandalen/wretry.action@v1.3.0
+        uses: codecov/codecov-action@v3
         with:
-          action: codecov/codecov-action@v3
-          with: |
-            name: codecov-deck
-            token: ${{ secrets.CODECOV_TOKEN }}
-            fail_ci_if_error: true
-          attempt_limit: 3
-          attempt_delay: 15000
+          name: codecov-deck
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
       - name: Build
         run: make build


### PR DESCRIPTION
This reverts commit bfd04d22acd8e6e9d743fcac22871ee7c160b471.

The retry action doesn't solve the issue, but did introduce CI warning wrt Node 16 being used. Hence reverting.