### PR TITLE
Handle nil error when port not defined in service with Gateway API.

### DIFF
--- a/kong2kic/route.go
+++ b/kong2kic/route.go
@@ -356,21 +356,15 @@ func populateKICIngressesWithGatewayAPI(content *file.Content, kicContent *KICCo
 			})
 
 			// add service details to HTTPBackendRef
-			var backendRef k8sgwapiv1.BackendRef
+
+			backendRef := k8sgwapiv1.BackendRef{
+				BackendObjectReference: k8sgwapiv1.BackendObjectReference{
+					Name: k8sgwapiv1.ObjectName(*service.Name),
+				},
+			}
 			if service.Port != nil {
 				portNumber := k8sgwapiv1.PortNumber(*service.Port)
-				backendRef = k8sgwapiv1.BackendRef{
-					BackendObjectReference: k8sgwapiv1.BackendObjectReference{
-						Name: k8sgwapiv1.ObjectName(*service.Name),
-						Port: &portNumber,
-					},
-				}
-			} else {
-				backendRef = k8sgwapiv1.BackendRef{
-					BackendObjectReference: k8sgwapiv1.BackendObjectReference{
-						Name: k8sgwapiv1.ObjectName(*service.Name),
-					},
-				}
+				backendRef.Port = &portNumber
 			}
 
 			var httpHeaderMatch []k8sgwapiv1.HTTPHeaderMatch

--- a/kong2kic/upstream.go
+++ b/kong2kic/upstream.go
@@ -29,14 +29,14 @@ func populateKICUpstreamPolicy(
 			return
 		}
 
-		k8sservice.ObjectMeta.Annotations["konghq.com/upstream-policy"] = kongUpstreamPolicy.ObjectMeta.Name
-
 		// Find the upstream (if any) whose name matches the service host and copy the upstream
 		// into kongUpstreamPolicy. Append the kongUpstreamPolicy to kicContent.KongUpstreamPolicies.
 		found := false
 		for _, upstream := range content.Upstreams {
 			if upstream.Name != nil && strings.EqualFold(*upstream.Name, *service.Host) {
 				found = true
+				// add an annotation to the k8sservice to link this kongUpstreamPolicy to it
+				k8sservice.ObjectMeta.Annotations["konghq.com/upstream-policy"] = kongUpstreamPolicy.ObjectMeta.Name
 				var threshold int
 				if upstream.Healthchecks != nil && upstream.Healthchecks.Threshold != nil {
 					threshold = int(*upstream.Healthchecks.Threshold)


### PR DESCRIPTION
Fixes 3 issues in kong2kic:

1. Handles nil pointer error when service port is not specified and output style is Gateway API
2. Handles the case in which no HTTP method is specified in a Route
3. Add annotation from service to upstream only when relationship is found.