### PR TITLE
Fix(cmd/docs): Correct file_merge example

### DIFF
--- a/cmd/file_merge.go
+++ b/cmd/file_merge.go
@@ -61,7 +61,7 @@ If the input files are not compatible, returns an error. Compatibility is
 determined by the '_transform' and '_format_version' fields.`,
 		RunE: executeMerge,
 		Example: "# Merge 3 files\n" +
-			"deck file patch -o merged.yaml file1.yaml file2.yaml file3.yaml",
+			"deck file merge -o merged.yaml file1.yaml file2.yaml file3.yaml",
 		Args: cobra.MinimumNArgs(1),
 	}
 


### PR DESCRIPTION
The file merge command example says `deck file patch`, so fixing that. 