### PR TITLE
ci(tests): test against go `stable` & `oldstable`

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,6 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'go' ]
+        golang: ["oldstable", "stable"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
@@ -45,7 +46,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v5
       with:
-        go-version: '^1.20'
+        go-version: "${{ matrix.golang }}"
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/integration-enterprise.yaml
+++ b/.github/workflows/integration-enterprise.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.20'
+          go-version: 'stable'
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/integration-konnect.yaml
+++ b/.github/workflows/integration-konnect.yaml
@@ -24,6 +24,6 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.20'
+          go-version: 'stable'
       - name: Run integration tests
         run: make test-integration

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.20'
+          go-version: 'stable'
       - name: Setup Kong
         run: make setup-kong
       - name: Run integration tests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.20'
+          go-version: 'stable'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,13 +16,16 @@ jobs:
   test:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        golang: ["oldstable", "stable"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.20'
+          go-version: "${{ matrix.golang }}"
       - name: Setup golangci-lint
         uses: golangci/golangci-lint-action@v3.7.0
       - name: Run tests with Coverage

--- a/.github/workflows/validate-kong-release.yaml
+++ b/.github/workflows/validate-kong-release.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.20'
+          go-version: 'stable'
       - uses: Kong/kong-license@master
         id: license
         with:


### PR DESCRIPTION
* Change the tests and codeql-analysis workflows to run against both Go `stable` and `oldstable`. (If we do not want to test against both, please let me know.)
* Change remaining workflows to run against `stable` - rather than hardcoding