### PR TITLE
fix: do not fetch kong version when running `validate`

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,6 @@
+package utils
+
+const (
+	DefaultFormatVersion = "1.1"
+	FormatVersion30      = "3.0"
+)


### PR DESCRIPTION
decK used to fetch the running Kong version in order to gate route regex patterns validation. This is problematic in the case users don't have access to the `/` endpoint, which is the one used to fetch the version of the runtime.

This commit removes the need of fetching the Kong version entirely by relying on the `_format_version` field from the config file instead.