### PR TITLE
fix: auto-generate rla namespace when using Consumer Groups

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -219,10 +219,35 @@ func generateAutoFields(content *file.Content) error {
 		}
 	}
 
+	for _, consumerGroup := range content.ConsumerGroups {
+		for _, plugin := range consumerGroup.Plugins {
+			if *plugin.Name == rateLimitingAdvancedPluginName {
+				if err := autoGenerateNamespaceForRLAPluginConsumerGroups(plugin); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
 	return nil
 }
 
 func autoGenerateNamespaceForRLAPlugin(plugin *file.FPlugin) error {
+	if plugin.Config != nil {
+		ns, ok := plugin.Config["namespace"]
+		if !ok || ns == nil {
+			// namespace is not set, generate one.
+			randomNamespace, err := randomString(rlaNamespaceDefaultLength)
+			if err != nil {
+				return fmt.Errorf("error generating random namespace: %w", err)
+			}
+			plugin.Config["namespace"] = randomNamespace
+		}
+	}
+	return nil
+}
+
+func autoGenerateNamespaceForRLAPluginConsumerGroups(plugin *kong.ConsumerGroupPlugin) error {
 	if plugin.Config != nil {
 		ns, ok := plugin.Config["namespace"]
 		if !ok || ns == nil {

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -538,6 +538,19 @@ func Test_convertAutoFields(t *testing.T) {
 				},
 			},
 		},
+		ConsumerGroups: []file.FConsumerGroupObject{
+			{
+				ConsumerGroup: kong.ConsumerGroup{
+					Name: kong.String("my_consumer_group"),
+				},
+				Plugins: []*kong.ConsumerGroupPlugin{
+					{
+						Name:   kong.String("rate-limiting-advanced"),
+						Config: kong.Configuration{},
+					},
+				},
+			},
+		},
 		Plugins: []file.FPlugin{
 			{
 				Plugin: kong.Plugin{
@@ -562,4 +575,7 @@ func Test_convertAutoFields(t *testing.T) {
 
 	consumerPluginConfig := got.Consumers[0].Plugins[0].Config
 	assert.NotEmpty(t, consumerPluginConfig["namespace"])
+
+	consumerGroupPluginConfig := got.ConsumerGroups[0].Plugins[0].Config
+	assert.NotEmpty(t, consumerGroupPluginConfig["namespace"])
 }


### PR DESCRIPTION
Followup to #1206 

The previous implementation did not handle Consumer Groups, which is a requirement for the customer