### PR TITLE
chore: bump go-database-reconciler dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [v1.39.2](#v1392)
 - [v1.39.1](#v1391)
 - [v1.39.0](#v1390)
 - [v1.38.1](#v1381)
@@ -86,6 +87,19 @@
 - [v0.3.0](#v030)
 - [v0.2.0](#v020)
 - [v0.1.0](#v010)
+
+## [v1.39.2]
+
+> Release date: 2024/07/04
+
+### Fixes
+
+- Correct IPv6 targets comparison to avoid misleading diffs and failing syncs.
+  [#1333](https://github.com/Kong/deck/pull/1333)
+  [go-database-reconciler #109](https://github.com/Kong/go-database-reconciler/pull/109)
+- Make lookups for consumer-group's consumers more performant.
+  [#1333](https://github.com/Kong/deck/pull/1333)
+  [go-database-reconciler #102](https://github.com/Kong/go-database-reconciler/pull/102)
 
 ## [v1.39.1]
 
@@ -1723,6 +1737,7 @@ No breaking changes have been introduced in this release.
 
 Debut release of decK
 
+[v1.39.2]: https://github.com/kong/deck/compare/v1.39.1...v1.39.2
 [v1.39.1]: https://github.com/kong/deck/compare/v1.39.0...v1.39.1
 [v1.39.0]: https://github.com/kong/deck/compare/v1.38.1...v1.39.0
 [v1.38.1]: https://github.com/kong/deck/compare/v1.38.0...v1.38.1

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/fatih/color v1.15.0
 	github.com/google/go-cmp v0.6.0
 	github.com/kong/go-apiops v0.1.33
-	github.com/kong/go-database-reconciler v1.12.2
+	github.com/kong/go-database-reconciler v1.13.0
 	github.com/kong/go-kong v0.55.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,8 @@ github.com/klauspost/cpuid/v2 v2.2.5 h1:0E5MSMDEoAulmXNFquVs//DdoomxaoTY1kUhbc/q
 github.com/klauspost/cpuid/v2 v2.2.5/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/kong/go-apiops v0.1.33 h1:Y7IVksHPdHcXM6C+gPc25JiY4KRgYDAOn/jTx3sDU1k=
 github.com/kong/go-apiops v0.1.33/go.mod h1:o8lzBtbCLSXCMKzzqR8dcBhB7yzPs+9csAMZ1T1hsL0=
-github.com/kong/go-database-reconciler v1.12.2 h1:bnlvLCgP4OjgJOK5JYqq1MlIJ2F7erXERMj8n/LNU8M=
-github.com/kong/go-database-reconciler v1.12.2/go.mod h1:bUPJkoeW//x4hzNxewQMoIkeoDzJzunI0stDMYJ3BkU=
+github.com/kong/go-database-reconciler v1.13.0 h1:6gRGeLDep0mvzT/5fCQY5waQp0F/T9MsyZ9fJmJq+Cc=
+github.com/kong/go-database-reconciler v1.13.0/go.mod h1:bUPJkoeW//x4hzNxewQMoIkeoDzJzunI0stDMYJ3BkU=
 github.com/kong/go-kong v0.55.0 h1:lonKRzsDGk12dh9E+y+pWnY2ThXhKuMHjzBHSpCvQLw=
 github.com/kong/go-kong v0.55.0/go.mod h1:i1cMgTu6RYPHSyMpviShddRnc+DML/vlpgKC00hr8kU=
 github.com/kong/go-slugify v1.0.0 h1:vCFAyf2sdoSlBtLcrmDWUFn0ohlpKiKvQfXZkO5vSKY=

--- a/tests/integration/diff_test.go
+++ b/tests/integration/diff_test.go
@@ -765,3 +765,20 @@ func Test_Diff_NoDiffUnorderedArray(t *testing.T) {
 	assert.Equal(t, emptyOutput, out)
 	reset(t)
 }
+
+// test scope:
+//   - 3.5
+func Test_Diff_NoDiffCompressedTarget(t *testing.T) {
+	runWhen(t, "kong", ">=3.5.0")
+	setup(t)
+
+	// test that the diff command does not return any changes when
+	// target is a compressed IPv6.
+	stateFile := "testdata/diff/005-no-diff-target/kong.yaml"
+	assert.NoError(t, sync(stateFile))
+
+	out, err := diff(stateFile)
+	assert.NoError(t, err)
+	assert.Equal(t, emptyOutput, out)
+	reset(t)
+}

--- a/tests/integration/testdata/diff/005-no-diff-target/kong.yaml
+++ b/tests/integration/testdata/diff/005-no-diff-target/kong.yaml
@@ -1,0 +1,6 @@
+_format_version: "3.0"
+upstreams:
+- name: upstream1
+  algorithm: round-robin
+  targets:
+  - target: "::1"


### PR DESCRIPTION
- make lookups for consumer-group's consumers more performant
- properly expand ipv6 targets avoid misleading diffs