### PR TITLE
#1282 Updated git workflows to use go.mod for go versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v5
       with:
-        go-version: '^1.20'
+        go-version-file: go.mod
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/integration-enterprise.yaml
+++ b/.github/workflows/integration-enterprise.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.20'
+          go-version-file: go.mod
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/integration-konnect.yaml
+++ b/.github/workflows/integration-konnect.yaml
@@ -24,6 +24,6 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.20'
+          go-version-file: go.mod
       - name: Run integration tests
         run: make test-integration

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.20'
+          go-version-file: go.mod
       - name: Setup Kong
         run: make setup-kong
       - name: Run integration tests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.20'
+          go-version-file: go.mod
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.20'
+          go-version-file: go.mod
       - name: Setup golangci-lint
         uses: golangci/golangci-lint-action@v6.0.1
       - name: Run tests with Coverage

--- a/.github/workflows/validate-kong-release.yaml
+++ b/.github/workflows/validate-kong-release.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.20'
+          go-version-file: go.mod
       - uses: Kong/kong-license@master
         id: license
         with:


### PR DESCRIPTION
This would fix issue #1282.
Fetching the version directly from go.mod would help us to maintain consistency in the project and the released versions.