### PR TITLE
CI: Ignoring errors from latest images to account for flaky tests

### DIFF
--- a/.github/workflows/integration-enterprise.yaml
+++ b/.github/workflows/integration-enterprise.yaml
@@ -65,3 +65,4 @@ jobs:
         env:
           KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
         run: make test-integration
+        continue-on-error: ${{ matrix.kong_image == 'kong/kong-gateway-dev:latest' }}

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -52,3 +52,4 @@ jobs:
         run: make setup-kong
       - name: Run integration tests
         run: make test-integration
+        continue-on-error: ${{ matrix.kong_image == 'kong/kong:master' }}


### PR DESCRIPTION
Latest images may have bugs and thus, lead to failing tests, even if the submitted changes have no connection with the test.
Ignoring them from the CI for clean builds.

This change is similar to: https://github.com/Kong/go-database-reconciler/commit/c70e4ecf881c99043fee22cf08d23b03643659d3