### PR TITLE
Fixed --no-color flag behaviour in non-tty environments

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -373,7 +373,9 @@ func initConfig() {
 	// cookie-jar support
 	rootConfig.CookieJarPath = viper.GetString("kong-cookie-jar-path")
 
-	color.NoColor = (color.NoColor || viper.GetBool("no-color"))
+	if viper.IsSet("no-color") {
+		color.NoColor = viper.GetBool("no-color")
+	}
 
 	if err := initKonnectConfig(); err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
This fixes issue #1313 and makes the flag behaviour consistent across tty and non-tty.

<img width="824" alt="Screenshot 2024-07-17 at 11 11 02 AM" src="https://github.com/user-attachments/assets/6411f360-58de-4381-92ec-5d3ca6a9e72a">

The attached image shows the changed behaviour.
Now, the non-tty output also comes up as colored by default, same as tty output. This can be overridden by passing the `--no-color` flag.

I have a doubt though.
If our customers pass the deck output to a non-tty (may be a file), this can cause things to break if `--no-color` is not passed, as the colorised output may cause formatting issues in a file.
Is this doubt valid?
Should I check for non-tty environments separately and handle this, if this is indeed a valid usecase?
@GGabriele @mheap