### PR TITLE
fix: validate presence of flags and args in file patch command

### DIFF
--- a/cmd/file_patch.go
+++ b/cmd/file_patch.go
@@ -167,6 +167,18 @@ If the 'values' object instead is an array, then any arrays returned by the sele
 will get the 'values' appended to them.
 `,
 		RunE: executePatch,
+		PersistentPreRunE: func(_ *cobra.Command, args []string) error {
+			if len(args) > 0 && (len(cmdPatchSelectors) > 0 || len(cmdPatchValues) > 0) {
+				return fmt.Errorf("cannot use patch file argument along with '--selector' and '--value'")
+			}
+
+			if len(args) == 0 && len(cmdPatchSelectors) == 0 && len(cmdPatchValues) == 0 {
+				return fmt.Errorf("must specify at least one of these: " +
+					"a patch file argument or a '--selector' and '--value' combination")
+			}
+
+			return nil
+		},
 		Example: "# update the read-timeout on all services\n" +
 			"cat kong.yml | deck file patch --selector=\"$..services[*]\" --value=\"read_timeout:10000\"",
 	}


### PR DESCRIPTION
The command intends to patch input files either via selector-value flags or patch file arguments. The change ensures that at least one of these is present, but not both at the same time. Till now, the command accepted patches from flags and patch files at the same time, but ignored the patches passed via flags. This was a confusing behaviour for customers.

Fix #1130

@rspurgeon I have created a new issue for patch file validation [here](https://github.com/Kong/deck/issues/1341).
We can discuss its feasibility and usecase there. For this particular issue (#1130), I felt erroring out with a proper reasoning given to user should be the best way to move forward.

