### PR TITLE
chore(ci): don't use deprecated password field with kong-license action

### DIFF
--- a/.github/workflows/integration-enterprise.yaml
+++ b/.github/workflows/integration-enterprise.yaml
@@ -44,7 +44,6 @@ jobs:
       - uses: Kong/kong-license@master
         id: license
         with:
-          password: ${{ secrets.PULP_PASSWORD }}
           op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       - name: Setup Kong
         env:

--- a/.github/workflows/validate-kong-release.yaml
+++ b/.github/workflows/validate-kong-release.yaml
@@ -36,7 +36,6 @@ jobs:
       - uses: Kong/kong-license@master
         id: license
         with:
-          password: ${{ secrets.PULP_PASSWORD }}
           op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       - name: Setup Kong
         env:


### PR DESCRIPTION
This gets rid of 

```
Warning: Input 'password' has been deprecated with message: pulp no longer used, only 'op-token' is needed
```

warning in CI workflow runs.