### PR TITLE
ci: add Kong 3.7 and remove EOLd versions from CI

### DIFF
--- a/.github/workflows/integration-enterprise.yaml
+++ b/.github/workflows/integration-enterprise.yaml
@@ -18,19 +18,7 @@ jobs:
     strategy:
       matrix:
         kong_image:
-        - 'kong/kong-gateway:1.5.0.11'
-        - 'kong/kong-gateway:2.1.4.6'
-        - 'kong/kong-gateway:2.2.1.3'
-        - 'kong/kong-gateway:2.3.3.4'
-        - 'kong/kong-gateway:2.4.1.3'
-        - 'kong/kong-gateway:2.5.1.2'
-        - 'kong/kong-gateway:2.6.0.2'
-        - 'kong/kong-gateway:2.7'
         - 'kong/kong-gateway:2.8'
-        - 'kong/kong-gateway:3.0'
-        - 'kong/kong-gateway:3.1'
-        - 'kong/kong-gateway:3.2'
-        - 'kong/kong-gateway:3.3'
         - 'kong/kong-gateway:3.4'
         - 'kong/kong-gateway:3.5'
         - 'kong/kong-gateway:3.6'

--- a/.github/workflows/integration-enterprise.yaml
+++ b/.github/workflows/integration-enterprise.yaml
@@ -34,6 +34,7 @@ jobs:
         - 'kong/kong-gateway:3.4'
         - 'kong/kong-gateway:3.5'
         - 'kong/kong-gateway:3.6'
+        - 'kong/kong-gateway:3.7'
         - 'kong/kong-gateway-dev:latest'
     env:
       KONG_ANONYMOUS_REPORTS: "off"

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -18,21 +18,7 @@ jobs:
     strategy:
       matrix:
         kong_image:
-        - 'kong:1.4.3'
-        - 'kong:1.5.1'
-        - 'kong:2.0.5'
-        - 'kong:2.1.4'
-        - 'kong:2.2.2'
-        - 'kong:2.3.3'
-        - 'kong:2.4.1'
-        - 'kong:2.5.1'
-        - 'kong:2.6.0'
-        - 'kong:2.7'
         - 'kong:2.8'
-        - 'kong:3.0'
-        - 'kong:3.1'
-        - 'kong:3.2'
-        - 'kong:3.3'
         - 'kong:3.4'
         - 'kong:3.5'
         - 'kong:3.6'

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -36,6 +36,7 @@ jobs:
         - 'kong:3.4'
         - 'kong:3.5'
         - 'kong:3.6'
+        - 'kong:3.7'
         - 'kong/kong:master'
     env:
       KONG_ANONYMOUS_REPORTS: "off"


### PR DESCRIPTION
Add 3.7 to test matrix.

Removed EOLd versions from test matrix, as listed in https://docs.konghq.com/gateway/latest/support-policy/#older-versions