### PR TITLE
fix: clarify validate konnect behaviors

### DIFF
--- a/cmd/gateway_validate.go
+++ b/cmd/gateway_validate.go
@@ -173,7 +173,7 @@ this command unless --online flag is used.
 			return preRunSilenceEventsFlag()
 		}
 
-		if validateOnline {
+		if online {
 			short = short + " (online)"
 			long = long + "Validates against the Kong API, via communication with Kong. This increases the\n" +
 				"time for validation but catches significant errors. No resource is created in Kong.\n" +
@@ -211,11 +211,13 @@ this command unless --online flag is used.
 		"", "validate configuration of a specific workspace "+
 			"(Kong Enterprise only).\n"+
 			"This takes precedence over _workspace fields in state files.")
-	validateCmd.Flags().IntVar(&validateParallelism, "parallelism",
-		10, "Maximum number of concurrent requests to Kong.")
-	validateCmd.Flags().BoolVar(&validateKonnectCompatibility, "konnect-compatibility",
-		false, "validate that the state file(s) are ready to be deployed to Konnect")
-
+	if online {
+		validateCmd.Flags().IntVar(&validateParallelism, "parallelism",
+			10, "Maximum number of concurrent requests to Kong.")
+	} else {
+		validateCmd.Flags().BoolVar(&validateKonnectCompatibility, "konnect-compatibility",
+			false, "validate that the state file(s) are ready to be deployed to Konnect")
+	}
 	if err := ensureGetAllMethods(); err != nil {
 		panic(err.Error())
 	}

--- a/validate/konnect_compatibility.go
+++ b/validate/konnect_compatibility.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/kong/go-database-reconciler/pkg/cprint"
 	"github.com/kong/go-database-reconciler/pkg/file"
 	"github.com/kong/go-kong/kong"
 )
 
 var (
-	errKonnect            = "[konnect] section not specified - ensure details are set via cli flags"
+	errKonnect            = "[konnect] section not specified - ensure details are set via cli flags when executing live commands against Konnect"
 	errWorkspace          = "[workspaces] not supported by Konnect - use control planes instead"
 	errNoVersion          = "[version] unable to determine decK file version"
 	errBadVersion         = fmt.Sprintf("[version] decK file version must be '%.1f' or greater", supportedVersion)
@@ -47,7 +48,7 @@ func KonnectCompatibility(targetContent *file.Content) []error {
 	}
 
 	if targetContent.Konnect == nil {
-		errs = append(errs, errors.New(errKonnect))
+		cprint.UpdatePrintf("Warning: " + errKonnect + "\n")
 	}
 
 	versionNumber, err := strconv.ParseFloat(targetContent.FormatVersion, 32)


### PR DESCRIPTION
Few quick fixes around Konnect behavior:
- The help description for `gateway validate` vs `file validate` was incorrect (said both would contact a running CP to validate, `file validate` does not do this, `gateway validate` does).
- Message about the `konnect` section being missing has been changed to a warning (as you can specify konnect cli flags still, and it now returns a 0 exit code for automation purposes) and the message has been clarified.
- `--konnect-compatibility` and `--parallelism` flags gated to their relevant parent commands (`file validate` and `gateway validate` respectively).