### PR TITLE
chore: updated go-database-reconciler to v1.14.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/fatih/color v1.17.0
 	github.com/google/go-cmp v0.6.0
 	github.com/kong/go-apiops v0.1.36
-	github.com/kong/go-database-reconciler v1.14.4
+	github.com/kong/go-database-reconciler v1.14.5
 	github.com/kong/go-kong v0.56.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ github.com/klauspost/cpuid/v2 v2.2.5 h1:0E5MSMDEoAulmXNFquVs//DdoomxaoTY1kUhbc/q
 github.com/klauspost/cpuid/v2 v2.2.5/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/kong/go-apiops v0.1.36 h1:WejXoJZXAI8ZdwrCUyx1ONOfBw0e2GeopqW1/rjy7Wk=
 github.com/kong/go-apiops v0.1.36/go.mod h1:B0WFsqonn+xnHgHg0x063fADFC21mhNOsOXsbKdZTpM=
-github.com/kong/go-database-reconciler v1.14.4 h1:UTUTQu681VtwSgIvy28oyv5OveP8ksr1zKkLJyWitaw=
-github.com/kong/go-database-reconciler v1.14.4/go.mod h1:IA7iVZ7F7UZXABXdYPw1oJaMEvBYQ0Vq6/RfCjxhM4g=
+github.com/kong/go-database-reconciler v1.14.5 h1:XBvHpO/nabgbziU1KmD3yZgbWWHXPZl0vUzIqrdbz6Q=
+github.com/kong/go-database-reconciler v1.14.5/go.mod h1:IA7iVZ7F7UZXABXdYPw1oJaMEvBYQ0Vq6/RfCjxhM4g=
 github.com/kong/go-kong v0.56.0 h1:/9qbnQJWAgrSAKzL2RViBhHMTYOEyG8N4ClkKnUwEW4=
 github.com/kong/go-kong v0.56.0/go.mod h1:gyNwyP1fzztT6sX/0/ygMQ30OiRMIQ51b2jSfstMrcU=
 github.com/kong/go-slugify v1.0.0 h1:vCFAyf2sdoSlBtLcrmDWUFn0ohlpKiKvQfXZkO5vSKY=


### PR DESCRIPTION
This version of go-database-reconciler has the fix that ensures that plugins are not shown as global
if they have a consumer group attached.
Earlier, they were wrongly shown as global, despite the actual associations working fine.

Fixes #1005

GDR PR with the fix: https://github.com/Kong/go-database-reconciler/pull/134