### PR TITLE
fix: creating a retryable kong client for tests and retry logic in konnect authentication for CI rate-limit errors

### DIFF
--- a/cmd/common_konnect.go
+++ b/cmd/common_konnect.go
@@ -30,7 +30,6 @@ func authenticate(
 	backoff := 200 * time.Millisecond
 
 	for {
-		// fmt.Printf("Attempt #%d\n", attempts+1)
 		authResponse, err := client.Auth.LoginV2(ctx, konnectConfig.Email, konnectConfig.Password, konnectConfig.Token)
 		if err == nil {
 			return authResponse, nil
@@ -48,7 +47,6 @@ func authenticate(
 		time.Sleep(backoff)
 		backoff *= 2
 	}
-	// return client.Auth.LoginV2(ctx, konnectConfig.Email, konnectConfig.Password, konnectConfig.Token)
 }
 
 // GetKongClientForKonnectMode abstracts the different cloud environments users

--- a/tests/integration/test_utils.go
+++ b/tests/integration/test_utils.go
@@ -43,7 +43,8 @@ func getTestClient() (*kong.Client, error) {
 		return cmd.GetKongClientForKonnectMode(ctx, &konnectConfig)
 	}
 	return utils.GetKongClient(utils.KongClientConfig{
-		Address: getKongAddress(),
+		Address:   getKongAddress(),
+		Retryable: true,
 	})
 }
 
@@ -236,7 +237,7 @@ func reset(t *testing.T, opts ...string) {
 	t.Helper()
 
 	deckCmd := cmd.NewRootCmd()
-	args := []string{"reset", "--force"}
+	args := []string{"gateway", "reset", "--force"}
 	if len(opts) > 0 {
 		args = append(args, opts...)
 	}


### PR DESCRIPTION
- chore: creating a retryable kong client for tests to account for rate-limit errors
- fix: added retry and backoff logic in Konnect authentication layer to account for rate-limit errors during authentication.

Fixes [#1364](https://github.com/Kong/deck/issues/1364)