### PR TITLE
Fix panic when field is an empty list

### DIFF
--- a/kong2tf/generate_resource.go
+++ b/kong2tf/generate_resource.go
@@ -353,6 +353,9 @@ func outputList(entityType string, key string, input []interface{}, depth int) s
 
 // Ends a list rendering in Go
 func endList(input []interface{}, depth int) string {
+	if len(input) == 0 {
+		return "]\n"
+	}
 	lastLine := line("]", depth, "\n")
 	if _, ok := input[len(input)-1].(map[string]interface{}); ok {
 		return lastLine

--- a/kong2tf/generate_resource_test.go
+++ b/kong2tf/generate_resource_test.go
@@ -22,7 +22,8 @@ func TestGenerateComplexLayout(t *testing.T) {
 					"nested_nested_nested_field1": "nested_nested_nested_string"
 				}
 			}
-		}
+		},
+		"field4": []
 	}`
 
 	var entity map[string]any
@@ -43,6 +44,7 @@ func TestGenerateComplexLayout(t *testing.T) {
       }
     }
   }
+  field4 = []	
 
   service = {
     id = konnect_gateway_service.some_service.id


### PR DESCRIPTION
This PR fixes kong2tf panics when a field is an empty list:

```
➜ cat kong.yaml | deck file kong2tf
panic: runtime error: index out of range [-1]

goroutine 1 [running]:
github.com/kong/deck/kong2tf.endList({0x2b3dd00, 0x0, 0x17d555a?}, 0xc00057a010?)
	github.com/kong/deck/kong2tf/generate_resource.go:357 +0xaa
github.com/kong/deck/kong2tf.outputList({0xc00054e6d8, 0x12}, {0xc000563f30?, 0xc?}, {0x2b3dd00, 0x0, 0x0}, 0x2)
	github.com/kong/deck/kong2tf/generate_resource.go:350 +0x225
github.com/kong/deck/kong2tf.output({0xc00054e6d8, 0x12}, 0xc000567170, 0x2, 0x1, {0x1a93448, 0x1}, 0xc0005bd868)
	github.com/kong/deck/kong2tf/generate_resource.go:288 +0x5c5
github.com/kong/deck/kong2tf.outputHash({0xc00054e6d8, 0x12}, {0xc000563f78, 0x6}, 0xc000567170, 0x1, 0x10?, {0x1a93448, 0x1}, 0xc0005bd868)
	github.com/kong/deck/kong2tf/generate_resource.go:319 +0x2d8
github.com/kong/deck/kong2tf.output({0xc00054e6d8, 0x12}, 0xc0005670b0, 0x1, 0x1, {0x1a93448, 0x1}, 0xc0005bd868)
	github.com/kong/deck/kong2tf/generate_resource.go:286 +0x6d2
github.com/kong/deck/kong2tf.generateResourceWithCustomizations({0x17efcf3, 0xe}, {0xc000563729, 0x3}, 0xc0005670b0, 0xc0005bd9a8, 0xc0005bd868, {0x0?, 0xc0005bdaa8?}, {0xc0005bd698, ...})
	github.com/kong/deck/kong2tf/generate_resource.go:107 +0xca5
github.com/kong/deck/kong2tf.generateResource(...)
	github.com/kong/deck/kong2tf/generate_resource.go:22
github.com/kong/deck/kong2tf.(*DefaultTerraformBuider).buildGlobalPlugins(0xc000539ec0, 0x10?, 0x0)
	github.com/kong/deck/kong2tf/builder_default_terraform.go:134 +0x2e5
github.com/kong/deck/kong2tf.(*Director).builTerraformResources(0xc0005bdb38, 0xc00013a000, 0x0, 0x0)
	github.com/kong/deck/kong2tf/builder.go:41 +0x55
github.com/kong/deck/kong2tf.Convert(0xc00013a000, 0x0, 0x0)
	github.com/kong/deck/kong2tf/kong2tf.go:12 +0x65
github.com/kong/deck/cmd.executeKong2Tf(0xc000361808, {0x2b3dd00?, 0x4?, 0x17d7ae3?})
	github.com/kong/deck/cmd/file_kong2tf.go:47 +0x337
github.com/spf13/cobra.(*Command).execute(0xc000361808, {0x2b3dd00, 0x0, 0x0})
	github.com/spf13/cobra@v1.8.1/command.go:985 +0xaca
github.com/spf13/cobra.(*Command).ExecuteC(0xc000496008)
	github.com/spf13/cobra@v1.8.1/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.8.1/command.go:1041
github.com/spf13/cobra.(*Command).ExecuteContext(...)
	github.com/spf13/cobra@v1.8.1/command.go:1034
github.com/kong/deck/cmd.Execute({0x1ab5a50, 0xc000366c30})
	github.com/kong/deck/cmd/root.go:266 +0x5f
main.main()
	github.com/kong/deck/main.go:31 +0x18
```

```
_format_version: "3.0"
_konnect:
  control_plane_name: default
consumers:
- custom_id: 4cb717ee-1227-4a6c-a8f4-954c4f9e6595
  id: 0fff4c7c-f7c5-4533-9a63-d0a93a846019
  username: app_4a8eb475-354a-4820-8a4f-7b64d71c3280
plugins:
- config:
    anonymous: null
    claims_to_verify: null
    cookie_names: []
    header_names:
    - authorization
    key_claim_name: iss
    maximum_expiration: 0
    realm: null
    run_on_preflight: true
    secret_is_base64: false
    uri_param_names:
    - jwt
  enabled: true
  id: fc46e92c-7f95-49da-a3eb-b21ee71db38e
  name: jwt
  protocols:
  - grpc
  - grpcs
  - http
  - https
services:
- connect_timeout: 60000
  enabled: true
  host: echo.aufomm.com
  id: 2db09ad4-9ebe-49ca-912f-7b5c11c70760
  name: demo-svc
  port: 443
  protocol: https
  read_timeout: 60000
  retries: 5
  routes:
  - https_redirect_status_code: 426
    id: ba2febcb-bb47-4886-9d8b-10aa30e07636
    name: demo-route
    path_handling: v0
    paths:
    - /test
    preserve_host: false
    protocols:
    - http
    - https
    regex_priority: 0
    request_buffering: true
    response_buffering: true
    strip_path: true
  - https_redirect_status_code: 426
    id: f9866d15-49a3-4cb7-8e1c-e99c21351f77
    name: jwt-route
    path_handling: v0
    paths:
    - /jwt
    preserve_host: false
    protocols:
    - http
    - https
    regex_priority: 0
    request_buffering: true
    response_buffering: true
    strip_path: true
  write_timeout: 60000
```