### PR TITLE
Remove quoted type constraints

### DIFF
--- a/kong2tf/builder_default_terraform.go
+++ b/kong2tf/builder_default_terraform.go
@@ -40,7 +40,7 @@ func (b *DefaultTerraformBuider) buildControlPlaneVar(controlPlaneID *string) {
 		cpID = *controlPlaneID
 	}
 	b.content += fmt.Sprintf(`variable "control_plane_id" {
-  type = "string"
+  type = string
   default = "%s"
 }`, cpID) + "\n\n"
 }

--- a/kong2tf/testdata/ca-certificate-output-expected.tf
+++ b/kong2tf/testdata/ca-certificate-output-expected.tf
@@ -1,5 +1,5 @@
 variable "control_plane_id" {
-  type = "string"
+  type = string
   default = "YOUR_CONTROL_PLANE_ID"
 }
 

--- a/kong2tf/testdata/certificate-sni-output-expected.tf
+++ b/kong2tf/testdata/certificate-sni-output-expected.tf
@@ -1,5 +1,5 @@
 variable "control_plane_id" {
-  type = "string"
+  type = string
   default = "YOUR_CONTROL_PLANE_ID"
 }
 

--- a/kong2tf/testdata/consumer-acl-output-expected.tf
+++ b/kong2tf/testdata/consumer-acl-output-expected.tf
@@ -1,5 +1,5 @@
 variable "control_plane_id" {
-  type = "string"
+  type = string
   default = "YOUR_CONTROL_PLANE_ID"
 }
 

--- a/kong2tf/testdata/consumer-basic-auth-output-expected.tf
+++ b/kong2tf/testdata/consumer-basic-auth-output-expected.tf
@@ -1,5 +1,5 @@
 variable "control_plane_id" {
-  type = "string"
+  type = string
   default = "YOUR_CONTROL_PLANE_ID"
 }
 

--- a/kong2tf/testdata/consumer-group-output-expected.tf
+++ b/kong2tf/testdata/consumer-group-output-expected.tf
@@ -1,5 +1,5 @@
 variable "control_plane_id" {
-  type = "string"
+  type = string
   default = "YOUR_CONTROL_PLANE_ID"
 }
 

--- a/kong2tf/testdata/consumer-group-plugin-output-expected.tf
+++ b/kong2tf/testdata/consumer-group-plugin-output-expected.tf
@@ -1,5 +1,5 @@
 variable "control_plane_id" {
-  type = "string"
+  type = string
   default = "YOUR_CONTROL_PLANE_ID"
 }
 

--- a/kong2tf/testdata/consumer-hmac-auth-output-expected.tf
+++ b/kong2tf/testdata/consumer-hmac-auth-output-expected.tf
@@ -1,5 +1,5 @@
 variable "control_plane_id" {
-  type = "string"
+  type = string
   default = "YOUR_CONTROL_PLANE_ID"
 }
 

--- a/kong2tf/testdata/consumer-jwt-output-expected.tf
+++ b/kong2tf/testdata/consumer-jwt-output-expected.tf
@@ -1,5 +1,5 @@
 variable "control_plane_id" {
-  type = "string"
+  type = string
   default = "YOUR_CONTROL_PLANE_ID"
 }
 

--- a/kong2tf/testdata/consumer-jwt-output-with-imports-expected.tf
+++ b/kong2tf/testdata/consumer-jwt-output-with-imports-expected.tf
@@ -1,5 +1,5 @@
 variable "control_plane_id" {
-  type = "string"
+  type = string
   default = "abc-123"
 }
 

--- a/kong2tf/testdata/consumer-key-auth-output-expected.tf
+++ b/kong2tf/testdata/consumer-key-auth-output-expected.tf
@@ -1,5 +1,5 @@
 variable "control_plane_id" {
-  type = "string"
+  type = string
   default = "YOUR_CONTROL_PLANE_ID"
 }
 

--- a/kong2tf/testdata/consumer-no-auth-output-expected.tf
+++ b/kong2tf/testdata/consumer-no-auth-output-expected.tf
@@ -1,5 +1,5 @@
 variable "control_plane_id" {
-  type = "string"
+  type = string
   default = "YOUR_CONTROL_PLANE_ID"
 }
 

--- a/kong2tf/testdata/consumer-plugin-output-expected.tf
+++ b/kong2tf/testdata/consumer-plugin-output-expected.tf
@@ -1,5 +1,5 @@
 variable "control_plane_id" {
-  type = "string"
+  type = string
   default = "YOUR_CONTROL_PLANE_ID"
 }
 

--- a/kong2tf/testdata/global-plugin-oidc-output-expected.tf
+++ b/kong2tf/testdata/global-plugin-oidc-output-expected.tf
@@ -1,5 +1,5 @@
 variable "control_plane_id" {
-  type = "string"
+  type = string
   default = "YOUR_CONTROL_PLANE_ID"
 }
 

--- a/kong2tf/testdata/global-plugin-rate-limiting-output-expected.tf
+++ b/kong2tf/testdata/global-plugin-rate-limiting-output-expected.tf
@@ -1,5 +1,5 @@
 variable "control_plane_id" {
-  type = "string"
+  type = string
   default = "YOUR_CONTROL_PLANE_ID"
 }
 

--- a/kong2tf/testdata/route-output-expected.tf
+++ b/kong2tf/testdata/route-output-expected.tf
@@ -1,5 +1,5 @@
 variable "control_plane_id" {
-  type = "string"
+  type = string
   default = "YOUR_CONTROL_PLANE_ID"
 }
 

--- a/kong2tf/testdata/route-plugin-output-expected.tf
+++ b/kong2tf/testdata/route-plugin-output-expected.tf
@@ -1,5 +1,5 @@
 variable "control_plane_id" {
-  type = "string"
+  type = string
   default = "YOUR_CONTROL_PLANE_ID"
 }
 

--- a/kong2tf/testdata/service-output-expected.tf
+++ b/kong2tf/testdata/service-output-expected.tf
@@ -1,5 +1,5 @@
 variable "control_plane_id" {
-  type = "string"
+  type = string
   default = "YOUR_CONTROL_PLANE_ID"
 }
 

--- a/kong2tf/testdata/service-plugin-output-expected.tf
+++ b/kong2tf/testdata/service-plugin-output-expected.tf
@@ -1,5 +1,5 @@
 variable "control_plane_id" {
-  type = "string"
+  type = string
   default = "YOUR_CONTROL_PLANE_ID"
 }
 

--- a/kong2tf/testdata/upstream-target-output-expected.tf
+++ b/kong2tf/testdata/upstream-target-output-expected.tf
@@ -1,5 +1,5 @@
 variable "control_plane_id" {
-  type = "string"
+  type = string
   default = "YOUR_CONTROL_PLANE_ID"
 }
 

--- a/kong2tf/testdata/vault-output-expected.tf
+++ b/kong2tf/testdata/vault-output-expected.tf
@@ -1,5 +1,5 @@
 variable "control_plane_id" {
-  type = "string"
+  type = string
   default = "YOUR_CONTROL_PLANE_ID"
 }
 


### PR DESCRIPTION
Type constraints in quotes was required in Terraform 0.11 and earlier, but that form is now deprecated and will be removed in a future version of Terraform. For example:

```
variable "control_plane_id" {
  type = "string"
  default = "YOUR_CONTROL_PLANE_ID"
}
```
should be

```
variable "control_plane_id" {
  type = string
  default = "YOUR_CONTROL_PLANE_ID"
}
```
if the quotes are present, an error is shown during terraform apply.