### PR TITLE
fix: konnect cli flags getting considered for online validation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [v1.41.1](#v1411)
 - [v1.41.0](#v1410)
 - [v1.40.3](#v1403)
 - [v1.40.2](#v1402)
@@ -96,6 +97,13 @@
 - [v0.3.0](#v030)
 - [v0.2.0](#v020)
 - [v0.1.0](#v010)
+
+## [v1.41.1]
+> Release date: 2024/10/22
+
+### Fixes
+- `deck gateway validate` for Konnect supports Konnect configs passed by CLI flags now.
+Earlier, the validation was failing if control plane information was passed via CLI flags.
 
 ## [v1.41.0]
 > Release date: 2024/10/21
@@ -1835,6 +1843,7 @@ No breaking changes have been introduced in this release.
 
 Debut release of decK
 
+[v1.41.1]: https://github.com/Kong/deck/compare/v1.40.0...v1.41.1
 [v1.41.0]: https://github.com/Kong/deck/compare/v1.40.3...v1.41.0
 [v1.40.3]: https://github.com/Kong/deck/compare/v1.40.2...v1.40.3
 [v1.40.2]: https://github.com/Kong/deck/compare/v1.40.1...v1.40.2

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ the GitHub [release page](https://github.com/kong/deck/releases)
 or install by downloading the binary:
 
 ```shell
-$ curl -sL https://github.com/kong/deck/releases/download/v1.41.0/deck_1.41.0_linux_amd64.tar.gz -o deck.tar.gz
+$ curl -sL https://github.com/kong/deck/releases/download/v1.41.1/deck_1.41.1_linux_amd64.tar.gz -o deck.tar.gz
 $ tar -xf deck.tar.gz -C /tmp
 $ sudo cp /tmp/deck /usr/local/bin/
 ```
@@ -84,7 +84,7 @@ If you are on Windows, you can download the binary from the GitHub
 [release page](https://github.com/kong/deck/releases) or via PowerShell:
 
 ```shell
-$ curl -sL https://github.com/kong/deck/releases/download/v1.41.0/deck_1.41.0_windows_amd64.tar.gz -o deck.tar.gz
+$ curl -sL https://github.com/kong/deck/releases/download/v1.41.1/deck_1.41.1_windows_amd64.tar.gz -o deck.tar.gz
 $ tar -xzvf deck.tar.gz
 ```
 

--- a/cmd/gateway_validate.go
+++ b/cmd/gateway_validate.go
@@ -141,7 +141,7 @@ func executeValidate(cmd *cobra.Command, _ []string) error {
 	}
 
 	if validateKonnectCompatibility || (mode == modeKonnect && validateOnline) {
-		if errs := validate.KonnectCompatibility(targetContent); len(errs) != 0 {
+		if errs := validate.KonnectCompatibility(targetContent, dumpConfig); len(errs) != 0 {
 			return validate.ErrorsWrapper{Errors: errs}
 		}
 

--- a/tests/integration/validate_test.go
+++ b/tests/integration/validate_test.go
@@ -65,11 +65,16 @@ func Test_Validate_Konnect(t *testing.T) {
 			errorString:    "[workspaces] not supported by Konnect - use control planes instead",
 		},
 		{
-			name:           "validate with no konnect config in file",
+			name:           "validate with no konnect config in file, passed via cli flag konnect control plane",
 			stateFile:      "testdata/validate/konnect_invalid.yaml",
-			additionalArgs: []string{},
-			errorExpected:  true,
-			errorString:    "[konnect] section not specified - ensure details are set via cli flags",
+			additionalArgs: []string{"--konnect-control-plane-name=default"},
+			errorExpected:  false,
+		},
+		{
+			name:           "validate with no konnect config in file, passed via cli flag konnect runtime group",
+			stateFile:      "testdata/validate/konnect_invalid.yaml",
+			additionalArgs: []string{"--konnect-runtime-group-name=default"},
+			errorExpected:  false,
 		},
 	}
 

--- a/validate/konnect_compatibility.go
+++ b/validate/konnect_compatibility.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/kong/go-database-reconciler/pkg/dump"
 	"github.com/kong/go-database-reconciler/pkg/file"
 	"github.com/kong/go-kong/kong"
 )
@@ -39,14 +40,14 @@ func checkPlugin(name *string, config kong.Configuration) error {
 	return nil
 }
 
-func KonnectCompatibility(targetContent *file.Content) []error {
+func KonnectCompatibility(targetContent *file.Content, dumpConfig dump.Config) []error {
 	var errs []error
 
 	if targetContent.Workspace != "" {
 		errs = append(errs, errors.New(errWorkspace))
 	}
 
-	if targetContent.Konnect == nil {
+	if targetContent.Konnect == nil && dumpConfig.KonnectControlPlane == "" {
 		errs = append(errs, errors.New(errKonnect))
 	}
 


### PR DESCRIPTION
Earlier, if konnect control plane information was passed via cli flags, online validation for Konnect was failing. This change fixes the issue.