### PR TITLE
fix: make terraform imports keys order deterministic

### DIFF
--- a/kong2tf/generate_resource_test.go
+++ b/kong2tf/generate_resource_test.go
@@ -190,8 +190,10 @@ func TestImports(t *testing.T) {
 
 import {
   to = konnect_entity_type.name
-  id = "{\"id\": \"some_id\", \"field2_nested\": \"subkey\", \"control_plane_id\": \"abc-123\"}"
-}`
+  id = "{\"field2_nested\": \"subkey\", \"id\": \"some_id\", \"control_plane_id\": \"abc-123\"}"
+}
+
+`
 
 	cpID := new(string)
 	*cpID = "abc-123"
@@ -203,5 +205,5 @@ import {
 			"field2_nested": func() *string { s := "subkey"; return &s }(),
 		},
 	}, []string{})
-	require.Equal(t, strings.Fields(expected), strings.Fields(result))
+	require.Equal(t, expected, result)
 }


### PR DESCRIPTION
[`generateImportKeys`](https://github.com/Kong/deck/blob/f6f1880b299931c9e2afa47f1584a0f116d1f608/kong2tf/generate_resource.go#L212-L227) generated terraform's import keys. The test assumes that the keys are always in the same order but they are not as they are generated using a `map` which does not yield the same order each time it's being looped over.

This PR fixes that by sorting the keys on each marshal operation.