### PR TITLE
fix: adjust multiline string formatting in resource generation

### DIFF
--- a/kong2tf/generate_resource.go
+++ b/kong2tf/generate_resource.go
@@ -410,7 +410,7 @@ func quote(input interface{}) string {
 		return fmt.Sprintf("%v", v)
 	case string:
 		if strings.Contains(v, "\n") {
-			return fmt.Sprintf("<<EOF\n%s\nEOF", strings.TrimRight(v, "\n"))
+			return fmt.Sprintf("\n<<EOF\n%s\nEOF\n", strings.TrimRight(v, "\n"))
 		}
 		return fmt.Sprintf("\"%s\"", strings.ReplaceAll(v, "\"", "\\\""))
 	default:

--- a/kong2tf/generate_resource_test.go
+++ b/kong2tf/generate_resource_test.go
@@ -23,7 +23,9 @@ func TestGenerateComplexLayout(t *testing.T) {
 				}
 			}
 		},
-		"field4": []
+		"field4": [],
+		"field5": "This is a multiline\nstring that spans\nmultiple lines",
+		"field6": ["This is a first multiline\nstring that spans\nmultiple lines", "This is a second multiline\nstring that spans\nmultiple lines"]
 	}`
 
 	var entity map[string]any
@@ -34,20 +36,39 @@ func TestGenerateComplexLayout(t *testing.T) {
   field1 = "basic_string"
   field2 = ["list", "of", "strings"]
   field3 = {
-    nested_field1 = "nested_string"
-    nested_field2 = ["list", "of", "nested", "strings"]
-    nested_field3 = {
-      nested_nested_field1 = "nested_nested_string"
-      nested_nested_field2 = ["list", "of", "nested", "nested", "strings"]
-      nested_nested_field3 = {
-        nested_nested_nested_field1 = "nested_nested_nested_string"
-      }
-    }
+	nested_field1 = "nested_string"
+	nested_field2 = ["list", "of", "nested", "strings"]
+	nested_field3 = {
+	  nested_nested_field1 = "nested_nested_string"
+	  nested_nested_field2 = ["list", "of", "nested", "nested", "strings"]
+	  nested_nested_field3 = {
+		nested_nested_nested_field1 = "nested_nested_nested_string"
+	  }
+	}
   }
-  field4 = []	
+  field4 = []
+  field5 = 
+    <<EOF
+    This is a multiline
+    string that spans
+    multiple lines
+    EOF
+  field6 = [
+    <<EOF
+	This is a first multiline
+	string that spans
+	multiple lines
+	EOF
+	,
+	<<EOF
+	This is a second multiline
+	string that spans
+	multiple lines
+	EOF
+	]
 
   service = {
-    id = konnect_gateway_service.some_service.id
+	id = konnect_gateway_service.some_service.id
   }
   control_plane_id = var.control_plane_id
 }

--- a/kong2tf/generate_resource_test.go
+++ b/kong2tf/generate_resource_test.go
@@ -24,8 +24,8 @@ func TestGenerateComplexLayout(t *testing.T) {
 			}
 		},
 		"field4": [],
-		"field5": "This is a multiline\nstring that spans\nmultiple lines",
-		"field6": ["This is a first multiline\nstring that spans\nmultiple lines", "This is a second multiline\nstring that spans\nmultiple lines"]
+		"field5": "Multi\nline\nstring",
+		"field6": ["Multi\nline\nstring", "Multi\nline\nstring"]
 	}`
 
 	var entity map[string]any
@@ -49,21 +49,21 @@ func TestGenerateComplexLayout(t *testing.T) {
   field4 = []
   field5 = 
     <<EOF
-    This is a multiline
-    string that spans
-    multiple lines
+    Multi
+	line
+	string
     EOF
   field6 = [
     <<EOF
-	This is a first multiline
-	string that spans
-	multiple lines
+	Multi
+	line
+	string
 	EOF
 	,
 	<<EOF
-	This is a second multiline
-	string that spans
-	multiple lines
+	Multi
+	line
+	string
 	EOF
 	]
 


### PR DESCRIPTION
Adjusted multiline string formatting in terraform resource generation. Make sure `<<EOF` and `EOF` are correctly placed.
Expanded current testing to verify multiline strings.
Fixes https://konghq.atlassian.net/browse/FTI-6414.