### PR TITLE
fix: improve error messaging when mandatory flag is missing in file convert (#1429)

### DIFF
--- a/cmd/file_convert.go
+++ b/cmd/file_convert.go
@@ -114,16 +114,23 @@ can be converted into a 'kong-gateway-3.x' configuration file.`,
 		Args: validateNoArgs,
 		RunE: execute,
 		PreRunE: func(_ *cobra.Command, _ []string) error {
-			if convertCmdSourceFormat != string(convert.FormatKongGateway) &&
-				convertCmdSourceFormat != string(convert.FormatKongGateway2x) {
-				return fmt.Errorf("invalid value '%s' found for the 'from' flag. Allowed values: [%s, %s]",
-					convertCmdSourceFormat, string(convert.FormatKongGateway), string(convert.FormatKongGateway2x))
+			validSourceFormats := []string{string(convert.FormatKongGateway), string(convert.FormatKongGateway2x)}
+			validDestinationFormats := []string{string(convert.FormatKonnect), string(convert.FormatKongGateway3x)}
+
+			err := validateStringOneOf(convertCmdSourceFormat, validSourceFormats,
+				fmt.Sprintf("invalid value '%s' found for the 'from' flag. Allowed values: %v",
+					convertCmdSourceFormat, validSourceFormats))
+			if err != nil {
+				return err
 			}
-			if convertCmdDestinationFormat != string(convert.FormatKonnect) &&
-				convertCmdDestinationFormat != string(convert.FormatKongGateway3x) {
-				return fmt.Errorf("invalid value '%s' found for the 'to' flag. Allowed values: [%s, %s]",
-					convertCmdDestinationFormat, string(convert.FormatKonnect), string(convert.FormatKongGateway3x))
+
+			err = validateStringOneOf(convertCmdDestinationFormat, validDestinationFormats,
+				fmt.Sprintf("invalid value '%s' found for the 'to' flag. Allowed values: %v",
+					convertCmdDestinationFormat, validDestinationFormats))
+			if err != nil {
+				return err
 			}
+
 			return nil
 		},
 	}

--- a/cmd/file_convert.go
+++ b/cmd/file_convert.go
@@ -113,6 +113,19 @@ into another compatible format. For example, a configuration for 'kong-gateway-2
 can be converted into a 'kong-gateway-3.x' configuration file.`,
 		Args: validateNoArgs,
 		RunE: execute,
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			if convertCmdSourceFormat != string(convert.FormatKongGateway) &&
+				convertCmdSourceFormat != string(convert.FormatKongGateway2x) {
+				return fmt.Errorf("invalid value '%s' found for the 'from' flag. Allowed values: [%s, %s]",
+					convertCmdSourceFormat, string(convert.FormatKongGateway), string(convert.FormatKongGateway2x))
+			}
+			if convertCmdDestinationFormat != string(convert.FormatKonnect) &&
+				convertCmdDestinationFormat != string(convert.FormatKongGateway3x) {
+				return fmt.Errorf("invalid value '%s' found for the 'to' flag. Allowed values: [%s, %s]",
+					convertCmdDestinationFormat, string(convert.FormatKonnect), string(convert.FormatKongGateway3x))
+			}
+			return nil
+		},
 	}
 
 	sourceFormats := []convert.Format{convert.FormatKongGateway, convert.FormatKongGateway2x}

--- a/cmd/file_convert.go
+++ b/cmd/file_convert.go
@@ -117,16 +117,12 @@ can be converted into a 'kong-gateway-3.x' configuration file.`,
 			validSourceFormats := []string{string(convert.FormatKongGateway), string(convert.FormatKongGateway2x)}
 			validDestinationFormats := []string{string(convert.FormatKonnect), string(convert.FormatKongGateway3x)}
 
-			err := validateStringOneOf(convertCmdSourceFormat, validSourceFormats,
-				fmt.Sprintf("invalid value '%s' found for the 'from' flag. Allowed values: %v",
-					convertCmdSourceFormat, validSourceFormats))
+			err := validateInputFlag("from", convertCmdSourceFormat, validSourceFormats, "")
 			if err != nil {
 				return err
 			}
 
-			err = validateStringOneOf(convertCmdDestinationFormat, validDestinationFormats,
-				fmt.Sprintf("invalid value '%s' found for the 'to' flag. Allowed values: %v",
-					convertCmdDestinationFormat, validDestinationFormats))
+			err = validateInputFlag("to", convertCmdDestinationFormat, validDestinationFormats, "")
 			if err != nil {
 				return err
 			}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"slices"
 
 	"github.com/fatih/color"
@@ -34,10 +35,15 @@ func addSilenceEventsFlag(set *pflag.FlagSet) {
 		"disable printing events to stdout")
 }
 
-func validateStringOneOf(value string, allowedValues []string, errorMessage string) error {
-	if slices.Contains(allowedValues, value) {
+func validateInputFlag(flagName string, flagValue string, allowedValues []string, errorMessage string) error {
+	if slices.Contains(allowedValues, flagValue) {
 		return nil
 	}
 
-	return errors.New(errorMessage)
+	if errorMessage != "" {
+		return errors.New(errorMessage)
+	}
+
+	return fmt.Errorf("invalid value '%s' found for the '%s' flag. Allowed values: %v",
+		flagValue, flagName, allowedValues)
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"errors"
+	"slices"
+
 	"github.com/fatih/color"
 	"github.com/kong/go-database-reconciler/pkg/cprint"
 	"github.com/kong/go-database-reconciler/pkg/diff"
@@ -29,4 +32,12 @@ func preRunSilenceEventsFlag() error {
 func addSilenceEventsFlag(set *pflag.FlagSet) {
 	set.BoolVar(&silenceEvents, "silence-events", false,
 		"disable printing events to stdout")
+}
+
+func validateStringOneOf(value string, allowedValues []string, errorMessage string) error {
+	if slices.Contains(allowedValues, value) {
+		return nil
+	}
+
+	return errors.New(errorMessage)
 }

--- a/tests/integration/file_convert_test.go
+++ b/tests/integration/file_convert_test.go
@@ -26,7 +26,7 @@ func Test_FileConvert(t *testing.T) {
 			convertCmdDestinationFormat: "kong-gateway-3.x",
 			errorExpected:               true,
 			errorString: "invalid value 'random-value' found for the 'from' flag." +
-				" Allowed values: [kong-gateway, kong-gateway-2.x]",
+				" Allowed values: [kong-gateway kong-gateway-2.x]",
 		},
 		{
 			name:                        "Invalid destination format",
@@ -34,7 +34,7 @@ func Test_FileConvert(t *testing.T) {
 			convertCmdDestinationFormat: "random-value",
 			errorExpected:               true,
 			errorString: "invalid value 'random-value' found for the 'to' flag." +
-				" Allowed values: [konnect, kong-gateway-3.x]",
+				" Allowed values: [konnect kong-gateway-3.x]",
 		},
 	}
 	for _, tc := range tests {

--- a/tests/integration/file_convert_test.go
+++ b/tests/integration/file_convert_test.go
@@ -1,0 +1,56 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_FileConvert(t *testing.T) {
+	tests := []struct {
+		name                        string
+		convertCmdSourceFormat      string
+		convertCmdDestinationFormat string
+		errorExpected               bool
+		errorString                 string
+	}{
+		{
+			name:                        "Valid source and destination format",
+			convertCmdSourceFormat:      "kong-gateway-2.x",
+			convertCmdDestinationFormat: "kong-gateway-3.x",
+			errorExpected:               false,
+		},
+		{
+			name:                        "Invalid source format",
+			convertCmdSourceFormat:      "random-value",
+			convertCmdDestinationFormat: "kong-gateway-3.x",
+			errorExpected:               true,
+			errorString: "invalid value 'random-value' found for the 'from' flag." +
+				" Allowed values: [kong-gateway, kong-gateway-2.x]",
+		},
+		{
+			name:                        "Invalid destination format",
+			convertCmdSourceFormat:      "kong-gateway-2.x",
+			convertCmdDestinationFormat: "random-value",
+			errorExpected:               true,
+			errorString: "invalid value 'random-value' found for the 'to' flag." +
+				" Allowed values: [konnect, kong-gateway-3.x]",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := fileConvert(
+				"--from", tc.convertCmdSourceFormat,
+				"--to", tc.convertCmdDestinationFormat,
+				"--input-file", "testdata/file-convert/001-kong-gateway-config/kong-gateway-2-x.yaml",
+			)
+
+			if tc.errorExpected {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errorString)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/tests/integration/file_convert_test.go
+++ b/tests/integration/file_convert_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"encoding/json"
 	"os"
 	"testing"
 
@@ -17,13 +16,11 @@ func Test_FileConvert(t *testing.T) {
 		errorExpected               bool
 		errorString                 string
 		expectedOutputFile          string
-		format                      string
 	}{
 		{
 			name:                        "Valid source and destination format",
 			convertCmdSourceFormat:      "kong-gateway-2.x",
 			convertCmdDestinationFormat: "kong-gateway-3.x",
-			format:                      "yaml",
 			errorExpected:               false,
 			expectedOutputFile:          "testdata/file-convert/001-kong-gateway-config/kong-gateway-3-x.yaml",
 		},
@@ -31,7 +28,6 @@ func Test_FileConvert(t *testing.T) {
 			name:                        "Invalid source format",
 			convertCmdSourceFormat:      "random-value",
 			convertCmdDestinationFormat: "kong-gateway-3.x",
-			format:                      "yaml",
 			errorExpected:               true,
 			errorString: "invalid value 'random-value' found for the 'from' flag." +
 				" Allowed values: [kong-gateway kong-gateway-2.x]",
@@ -40,7 +36,6 @@ func Test_FileConvert(t *testing.T) {
 			name:                        "Invalid destination format",
 			convertCmdSourceFormat:      "kong-gateway-2.x",
 			convertCmdDestinationFormat: "random-value",
-			format:                      "yaml",
 			errorExpected:               true,
 			errorString: "invalid value 'random-value' found for the 'to' flag." +
 				" Allowed values: [konnect kong-gateway-3.x]",
@@ -68,18 +63,10 @@ func Test_FileConvert(t *testing.T) {
 			content, err := os.ReadFile(tc.expectedOutputFile)
 			assert.NoError(t, err)
 
-			if tc.format == "yaml" {
-				err = yaml.Unmarshal(content, &expectedOutput)
-				assert.NoError(t, err)
-				err = yaml.Unmarshal([]byte(output), &currentOutput)
-				assert.NoError(t, err)
-			} else if tc.format == "json" {
-				err = json.Unmarshal(content, &expectedOutput)
-				assert.NoError(t, err)
-				err = json.Unmarshal([]byte(output), &currentOutput)
-				assert.NoError(t, err)
-			}
-
+			err = yaml.Unmarshal(content, &expectedOutput)
+			assert.NoError(t, err)
+			err = yaml.Unmarshal([]byte(output), &currentOutput)
+			assert.NoError(t, err)
 			assert.Equal(t, expectedOutput, currentOutput)
 		})
 	}

--- a/tests/integration/file_convert_test.go
+++ b/tests/integration/file_convert_test.go
@@ -1,9 +1,12 @@
 package integration
 
 import (
+	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/yaml"
 )
 
 func Test_FileConvert(t *testing.T) {
@@ -13,17 +16,22 @@ func Test_FileConvert(t *testing.T) {
 		convertCmdDestinationFormat string
 		errorExpected               bool
 		errorString                 string
+		expectedOutputFile          string
+		format                      string
 	}{
 		{
 			name:                        "Valid source and destination format",
 			convertCmdSourceFormat:      "kong-gateway-2.x",
 			convertCmdDestinationFormat: "kong-gateway-3.x",
+			format:                      "yaml",
 			errorExpected:               false,
+			expectedOutputFile:          "testdata/file-convert/001-kong-gateway-config/kong-gateway-3-x.yaml",
 		},
 		{
 			name:                        "Invalid source format",
 			convertCmdSourceFormat:      "random-value",
 			convertCmdDestinationFormat: "kong-gateway-3.x",
+			format:                      "yaml",
 			errorExpected:               true,
 			errorString: "invalid value 'random-value' found for the 'from' flag." +
 				" Allowed values: [kong-gateway kong-gateway-2.x]",
@@ -32,6 +40,7 @@ func Test_FileConvert(t *testing.T) {
 			name:                        "Invalid destination format",
 			convertCmdSourceFormat:      "kong-gateway-2.x",
 			convertCmdDestinationFormat: "random-value",
+			format:                      "yaml",
 			errorExpected:               true,
 			errorString: "invalid value 'random-value' found for the 'to' flag." +
 				" Allowed values: [konnect kong-gateway-3.x]",
@@ -39,7 +48,7 @@ func Test_FileConvert(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := fileConvert(
+			output, err := fileConvert(
 				"--from", tc.convertCmdSourceFormat,
 				"--to", tc.convertCmdDestinationFormat,
 				"--input-file", "testdata/file-convert/001-kong-gateway-config/kong-gateway-2-x.yaml",
@@ -48,9 +57,30 @@ func Test_FileConvert(t *testing.T) {
 			if tc.errorExpected {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tc.errorString)
-			} else {
+
+				return
+			}
+
+			assert.NoError(t, err)
+
+			var expectedOutput interface{}
+			var currentOutput interface{}
+			content, err := os.ReadFile(tc.expectedOutputFile)
+			assert.NoError(t, err)
+
+			if tc.format == "yaml" {
+				err = yaml.Unmarshal(content, &expectedOutput)
+				assert.NoError(t, err)
+				err = yaml.Unmarshal([]byte(output), &currentOutput)
+				assert.NoError(t, err)
+			} else if tc.format == "json" {
+				err = json.Unmarshal(content, &expectedOutput)
+				assert.NoError(t, err)
+				err = json.Unmarshal([]byte(output), &currentOutput)
 				assert.NoError(t, err)
 			}
+
+			assert.Equal(t, expectedOutput, currentOutput)
 		})
 	}
 }

--- a/tests/integration/test_utils.go
+++ b/tests/integration/test_utils.go
@@ -342,6 +342,28 @@ func lint(opts ...string) (string, error) {
 	return stripansi.Strip(string(out)), cmdErr
 }
 
+func fileConvert(opts ...string) (string, error) {
+	deckCmd := cmd.NewRootCmd()
+	args := []string{"file", "convert"}
+	if len(opts) > 0 {
+		args = append(args, opts...)
+	}
+	deckCmd.SetArgs(args)
+
+	// capture command output to be used during tests
+	rescueStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cmdErr := deckCmd.ExecuteContext(context.Background())
+
+	w.Close()
+	out, _ := io.ReadAll(r)
+	os.Stdout = rescueStdout
+
+	return stripansi.Strip(string(out)), cmdErr
+}
+
 func ping(opts ...string) error {
 	deckCmd := cmd.NewRootCmd()
 	args := []string{"gateway", "ping"}

--- a/tests/integration/testdata/file-convert/001-kong-gateway-config/kong-gateway-2-x.yaml
+++ b/tests/integration/testdata/file-convert/001-kong-gateway-config/kong-gateway-2-x.yaml
@@ -1,0 +1,10 @@
+_format_version: "1.1"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5

--- a/tests/integration/testdata/file-convert/001-kong-gateway-config/kong-gateway-3-x.yaml
+++ b/tests/integration/testdata/file-convert/001-kong-gateway-config/kong-gateway-3-x.yaml
@@ -1,0 +1,10 @@
+_format_version: "3.0"
+services:
+- connect_timeout: 60000
+  id: 58076db2-28b6-423b-ba39-a797193017f7
+  host: mockbin.org
+  name: svc1
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5


### PR DESCRIPTION
fix: improve error messaging when mandatory flag is missing in file convert (#1429)

When mandatory flags for file convert are missing, the error message is not helpful. In this commit, we have added additional validation to communicate more details in the message.
We have made use of the `PreRunE` function in cobra to validate the input passed in `to` flag - since local flags are not inherited by subcommands.

This PR validates the `from` and `to` flags only. This is because all the other flags have valid default values which get used when not specified.

How I have tested my changes:
- [x] Run file convert command with 'from' and 'to' specified (happy flow) - should not error out
- [x] Run file convert command without specifying the 'from'  and 'to' flag - should return helpful error message.

To do:
- [x] Define what flags we want to validate apart from 'to', and what the error messages should be, and make these changes
- [x] Add tests
- [x] Extract validation logic into a reusable module, so it can be used in other commands if needed
