### PR TITLE
chore(deps): Bump go-database-reconciler to 1.18.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/fatih/color v1.17.0
 	github.com/google/go-cmp v0.6.0
 	github.com/kong/go-apiops v0.1.41
-	github.com/kong/go-database-reconciler v1.18.0
+	github.com/kong/go-database-reconciler v1.18.1
 	github.com/kong/go-kong v0.63.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.8.1
@@ -23,9 +23,9 @@ require (
 	golang.org/x/sync v0.10.0
 	k8s.io/api v0.32.0
 	k8s.io/apiextensions-apiserver v0.32.0
-	k8s.io/apimachinery v0.32.0
+	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.32.0
-	k8s.io/code-generator v0.32.0
+	k8s.io/code-generator v0.32.1
 	sigs.k8s.io/gateway-api v1.2.1
 	sigs.k8s.io/yaml v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -249,6 +249,8 @@ github.com/kong/go-apiops v0.1.41 h1:1KXbQqyhO2E4nEnXJNqUDmHZU/LQ1U7Zoi+MAlcM2P0
 github.com/kong/go-apiops v0.1.41/go.mod h1:sATq9Tz+ivzHKZU+tDXkRtEZnf64xroU3lgv3yXqP4I=
 github.com/kong/go-database-reconciler v1.18.0 h1:j1gVZ1uPfKglBXTyLEqDn0N374z2y/oaXOuCnWRuQTE=
 github.com/kong/go-database-reconciler v1.18.0/go.mod h1:T0SYIHeC/3DeHzThtUS+ooxouN5KBGeKWcjkuCg4MS8=
+github.com/kong/go-database-reconciler v1.18.1 h1:NhV3oDWMO02yj9scFIYfUwoK/KxMxCP0fXkZIBF1QME=
+github.com/kong/go-database-reconciler v1.18.1/go.mod h1:BqaV17xmjYAJfQYlaMKNz/DbJO4FfpwZpKD5dg2Pku0=
 github.com/kong/go-kong v0.63.0 h1:8ECLgkgDqON61qCMq/M0gTwZKYxg55Oy692dRDOOBiU=
 github.com/kong/go-kong v0.63.0/go.mod h1:ma9GWnhkxtrXZlLFfED955HjVzmUojYEHet3lm+PDik=
 github.com/kong/go-slugify v1.0.0 h1:vCFAyf2sdoSlBtLcrmDWUFn0ohlpKiKvQfXZkO5vSKY=
@@ -670,12 +672,15 @@ k8s.io/apiextensions-apiserver v0.32.0 h1:S0Xlqt51qzzqjKPxfgX1xh4HBZE+p8KKBq+k2S
 k8s.io/apiextensions-apiserver v0.32.0/go.mod h1:86hblMvN5yxMvZrZFX2OhIHAuFIMJIZ19bTvzkP+Fmw=
 k8s.io/apimachinery v0.32.0 h1:cFSE7N3rmEEtv4ei5X6DaJPHHX0C+upp+v5lVPiEwpg=
 k8s.io/apimachinery v0.32.0/go.mod h1:GpHVgxoKlTxClKcteaeuF1Ul/lDVb74KpZcxcmLDElE=
+k8s.io/apimachinery v0.32.1 h1:683ENpaCBjma4CYqsmZyhEzrGz6cjn1MY/X2jB2hkZs=
+k8s.io/apimachinery v0.32.1/go.mod h1:GpHVgxoKlTxClKcteaeuF1Ul/lDVb74KpZcxcmLDElE=
 k8s.io/cli-runtime v0.31.0 h1:V2Q1gj1u3/WfhD475HBQrIYsoryg/LrhhK4RwpN+DhA=
 k8s.io/cli-runtime v0.31.0/go.mod h1:vg3H94wsubuvWfSmStDbekvbla5vFGC+zLWqcf+bGDw=
 k8s.io/client-go v0.32.0 h1:DimtMcnN/JIKZcrSrstiwvvZvLjG0aSxy8PxN8IChp8=
 k8s.io/client-go v0.32.0/go.mod h1:boDWvdM1Drk4NJj/VddSLnx59X3OPgwrOo0vGbtq9+8=
 k8s.io/code-generator v0.32.0 h1:s0lNN8VSWny8LBz5t5iy7MCdgwdOhdg7vAGVxvS+VWU=
 k8s.io/code-generator v0.32.0/go.mod h1:b7Q7KMZkvsYFy72A79QYjiv4aTz3GvW0f1T3UfhFq4s=
+k8s.io/code-generator v0.32.1/go.mod h1:zaILfm00CVyP/6/pJMJ3zxRepXkxyDfUV5SNG4CjZI4=
 k8s.io/component-base v0.32.0 h1:d6cWHZkCiiep41ObYQS6IcgzOUQUNpywm39KVYaUqzU=
 k8s.io/component-base v0.32.0/go.mod h1:JLG2W5TUxUu5uDyKiH2R/7NnxJo1HlPoRIIbVLkK5eM=
 k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9 h1:si3PfKm8dDYxgfbeA6orqrtLkvvIeH8UqffFJDl0bz4=

--- a/tests/integration/testdata/dump/001-entities-with-tags/expected.yaml
+++ b/tests/integration/testdata/dump/001-entities-with-tags/expected.yaml
@@ -56,22 +56,48 @@ certificates:
     -----END PRIVATE KEY-----
   snis:
   - name: demo1.example.com
+    tags:
+    - managed-by-deck
+    - org-unit-42
   - name: demo2.example.com
+    tags:
+    - managed-by-deck
+    - org-unit-42
   - name: demo3.example.com
+    tags:
+    - managed-by-deck
+    - org-unit-42
   tags:
   - cloudops-managed
+  - managed-by-deck
+  - org-unit-42
 consumers:
 - acls:
   - group: foo-group
+    tags:
+    - managed-by-deck
+    - org-unit-42
   hmacauth_credentials:
   - secret: yeNZBeqCuk0D3H85VX77Umacf91MwqRo
+    tags:
+    - managed-by-deck
+    - org-unit-42
     username: hmac-user
   jwt_secrets:
   - algorithm: HS256
     key: MKWeR0nu9OAUR9HrjpUG82Hbfz7ZXsIw
     secret: 6gkrxTKAraykMSpmnLNEGiEE3Yz8XL6U
+    tags:
+    - managed-by-deck
+    - org-unit-42
   keyauth_credentials:
   - key: iwb6Djkk4HhUlOCmLilDIKh6nZrn90ts
+    tags:
+    - managed-by-deck
+    - org-unit-42
+  tags:
+  - managed-by-deck
+  - org-unit-42
   username: harry
 plugins:
 - config:
@@ -85,6 +111,9 @@ plugins:
   protocols:
   - http
   - https
+  tags:
+  - managed-by-deck
+  - org-unit-42
 services:
 - connect_timeout: 60000
   enabled: true
@@ -108,8 +137,13 @@ services:
     request_buffering: true
     response_buffering: true
     strip_path: true
+    tags:
+    - managed-by-deck
+    - org-unit-42
   tags:
   - team-svc1
+  - managed-by-deck
+  - org-unit-42
   write_timeout: 60000
 - connect_timeout: 60000
   enabled: true
@@ -133,6 +167,12 @@ services:
     request_buffering: true
     response_buffering: true
     strip_path: true
+    tags:
+    - managed-by-deck
+    - org-unit-42
+  tags:
+  - managed-by-deck
+  - org-unit-42
   write_timeout: 60000
 - connect_timeout: 60000
   enabled: true
@@ -158,6 +198,12 @@ services:
     request_buffering: true
     response_buffering: true
     strip_path: true
+    tags:
+    - managed-by-deck
+    - org-unit-42
+  tags:
+  - managed-by-deck
+  - org-unit-42
   write_timeout: 60000
 upstreams:
 - algorithm: round-robin
@@ -226,11 +272,23 @@ upstreams:
     threshold: 0
   name: upstream1
   slots: 10000
+  tags:
+  - managed-by-deck
+  - org-unit-42
   targets:
-  - target: 198.51.100.11:80
+  - tags:
+    - managed-by-deck
+    - org-unit-42
+    target: 198.51.100.11:80
     weight: 100
-  - target: 198.51.100.12:80
+  - tags:
+    - managed-by-deck
+    - org-unit-42
+    target: 198.51.100.12:80
     weight: 100
-  - target: 198.51.100.13:80
+  - tags:
+    - managed-by-deck
+    - org-unit-42
+    target: 198.51.100.13:80
     weight: 100
   use_srv_name: false

--- a/tests/integration/testdata/dump/001-entities-with-tags/expected30.yaml
+++ b/tests/integration/testdata/dump/001-entities-with-tags/expected30.yaml
@@ -56,22 +56,48 @@ certificates:
     -----END PRIVATE KEY-----
   snis:
   - name: demo1.example.com
+    tags:
+    - managed-by-deck
+    - org-unit-42
   - name: demo2.example.com
+    tags:
+    - managed-by-deck
+    - org-unit-42
   - name: demo3.example.com
+    tags:
+    - managed-by-deck
+    - org-unit-42
   tags:
   - cloudops-managed
+  - managed-by-deck
+  - org-unit-42
 consumers:
 - acls:
   - group: foo-group
+    tags:
+    - managed-by-deck
+    - org-unit-42
   hmacauth_credentials:
   - secret: yeNZBeqCuk0D3H85VX77Umacf91MwqRo
+    tags:
+    - managed-by-deck
+    - org-unit-42
     username: hmac-user
   jwt_secrets:
   - algorithm: HS256
     key: MKWeR0nu9OAUR9HrjpUG82Hbfz7ZXsIw
     secret: 6gkrxTKAraykMSpmnLNEGiEE3Yz8XL6U
+    tags:
+    - managed-by-deck
+    - org-unit-42
   keyauth_credentials:
   - key: iwb6Djkk4HhUlOCmLilDIKh6nZrn90ts
+    tags:
+    - managed-by-deck
+    - org-unit-42
+  tags:
+  - managed-by-deck
+  - org-unit-42
   username: harry
 plugins:
 - config:
@@ -85,6 +111,9 @@ plugins:
   protocols:
   - http
   - https
+  tags:
+  - managed-by-deck
+  - org-unit-42
 services:
 - connect_timeout: 60000
   enabled: true
@@ -108,8 +137,13 @@ services:
     request_buffering: true
     response_buffering: true
     strip_path: true
+    tags:
+    - managed-by-deck
+    - org-unit-42
   tags:
   - team-svc1
+  - managed-by-deck
+  - org-unit-42
   write_timeout: 60000
 - connect_timeout: 60000
   enabled: true
@@ -133,6 +167,12 @@ services:
     request_buffering: true
     response_buffering: true
     strip_path: true
+    tags:
+    - managed-by-deck
+    - org-unit-42
+  tags:
+  - managed-by-deck
+  - org-unit-42
   write_timeout: 60000
 - connect_timeout: 60000
   enabled: true
@@ -158,6 +198,12 @@ services:
     request_buffering: true
     response_buffering: true
     strip_path: true
+    tags:
+    - managed-by-deck
+    - org-unit-42
+  tags:
+  - managed-by-deck
+  - org-unit-42
   write_timeout: 60000
 upstreams:
 - algorithm: round-robin
@@ -226,10 +272,22 @@ upstreams:
     threshold: 0
   name: upstream1
   slots: 10000
+  tags:
+  - managed-by-deck
+  - org-unit-42
   targets:
-  - target: 198.51.100.11:80
+  - tags:
+    - managed-by-deck
+    - org-unit-42
+    target: 198.51.100.11:80
     weight: 100
-  - target: 198.51.100.12:80
+  - tags:
+    - managed-by-deck
+    - org-unit-42
+    target: 198.51.100.12:80
     weight: 100
-  - target: 198.51.100.13:80
+  - tags:
+    - managed-by-deck
+    - org-unit-42
+    target: 198.51.100.13:80
     weight: 100

--- a/tests/integration/testdata/dump/001-entities-with-tags/expected381.yaml
+++ b/tests/integration/testdata/dump/001-entities-with-tags/expected381.yaml
@@ -56,22 +56,48 @@ certificates:
     -----END PRIVATE KEY-----
   snis:
   - name: demo1.example.com
+    tags:
+    - managed-by-deck
+    - org-unit-42
   - name: demo2.example.com
+    tags:
+    - managed-by-deck
+    - org-unit-42
   - name: demo3.example.com
+    tags:
+    - managed-by-deck
+    - org-unit-42
   tags:
   - cloudops-managed
+  - managed-by-deck
+  - org-unit-42
 consumers:
 - acls:
   - group: foo-group
+    tags:
+    - managed-by-deck
+    - org-unit-42
   hmacauth_credentials:
   - secret: yeNZBeqCuk0D3H85VX77Umacf91MwqRo
+    tags:
+    - managed-by-deck
+    - org-unit-42
     username: hmac-user
   jwt_secrets:
   - algorithm: HS256
     key: MKWeR0nu9OAUR9HrjpUG82Hbfz7ZXsIw
     secret: 6gkrxTKAraykMSpmnLNEGiEE3Yz8XL6U
+    tags:
+    - managed-by-deck
+    - org-unit-42
   keyauth_credentials:
   - key: iwb6Djkk4HhUlOCmLilDIKh6nZrn90ts
+    tags:
+    - managed-by-deck
+    - org-unit-42
+  tags:
+  - managed-by-deck
+  - org-unit-42
   username: harry
 plugins:
 - config:
@@ -86,6 +112,9 @@ plugins:
   protocols:
   - http
   - https
+  tags:
+  - managed-by-deck
+  - org-unit-42
 services:
 - connect_timeout: 60000
   enabled: true
@@ -109,8 +138,13 @@ services:
     request_buffering: true
     response_buffering: true
     strip_path: true
+    tags:
+    - managed-by-deck
+    - org-unit-42
   tags:
   - team-svc1
+  - managed-by-deck
+  - org-unit-42
   write_timeout: 60000
 - connect_timeout: 60000
   enabled: true
@@ -134,6 +168,12 @@ services:
     request_buffering: true
     response_buffering: true
     strip_path: true
+    tags:
+    - managed-by-deck
+    - org-unit-42
+  tags:
+  - managed-by-deck
+  - org-unit-42
   write_timeout: 60000
 - connect_timeout: 60000
   enabled: true
@@ -159,6 +199,12 @@ services:
     request_buffering: true
     response_buffering: true
     strip_path: true
+    tags:
+    - managed-by-deck
+    - org-unit-42
+  tags:
+  - managed-by-deck
+  - org-unit-42
   write_timeout: 60000
 upstreams:
 - algorithm: round-robin
@@ -227,11 +273,23 @@ upstreams:
     threshold: 0
   name: upstream1
   slots: 10000
+  tags:
+  - managed-by-deck
+  - org-unit-42
   targets:
-  - target: 198.51.100.11:80
+  - tags:
+    - managed-by-deck
+    - org-unit-42
+    target: 198.51.100.11:80
     weight: 100
-  - target: 198.51.100.12:80
+  - tags:
+    - managed-by-deck
+    - org-unit-42
+    target: 198.51.100.12:80
     weight: 100
-  - target: 198.51.100.13:80
+  - tags:
+    - managed-by-deck
+    - org-unit-42
+    target: 198.51.100.13:80
     weight: 100
   use_srv_name: false


### PR DESCRIPTION
chore(deps): Bump go-database-reconciler to 1.18.1

This fixes https://github.com/Kong/deck/issues/1488
PR on go-database-reconciler for reference: https://github.com/Kong/go-database-reconciler/pull/165

Some indirect dependencies have been bumped as well.

Changelog: https://github.com/Kong/go-database-reconciler/releases/tag/v1.18.1