### PR TITLE
chore: updated contents permission to write

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       actions: write
     steps:
       - name: Checkout


### PR DESCRIPTION
[POST /repos/{owner}/{repo}/releases](https://docs.github.com/en/rest/releases/releases#create-a-release) requires `write` permissions for content.
Required for homebrew/deck.