### PR TITLE
Fix `deck gateway apply`

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -521,7 +521,6 @@ func performDiff(ctx context.Context, currentState, targetState *state.KongState
 	dry bool, parallelism int, delay int, client *kong.Client, isKonnect bool,
 	enableJSONOutput bool, applyType ApplyType,
 ) (int, error) {
-
 	shouldSkipDeletes := applyType == ApplyTypePartial
 
 	s, err := diff.NewSyncer(diff.SyncerOpts{

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -521,13 +521,7 @@ func performDiff(ctx context.Context, currentState, targetState *state.KongState
 	dry bool, parallelism int, delay int, client *kong.Client, isKonnect bool,
 	enableJSONOutput bool, applyType ApplyType,
 ) (int, error) {
-	shouldSkipDeletes := false
-	diffApplyType := diff.ApplyTypeFull
-
-	if applyType == ApplyTypePartial {
-		shouldSkipDeletes = true
-		diffApplyType = diff.ApplyTypePartial
-	}
+	shouldSkipDeletes := applyType == ApplyTypePartial
 
 	s, err := diff.NewSyncer(diff.SyncerOpts{
 		CurrentState:  currentState,
@@ -542,7 +536,7 @@ func performDiff(ctx context.Context, currentState, targetState *state.KongState
 		return 0, err
 	}
 
-	stats, errs, changes := s.Solve(ctx, parallelism, dry, enableJSONOutput, diffApplyType)
+	stats, errs, changes := s.Solve(ctx, parallelism, dry, enableJSONOutput)
 	// print stats before error to report completed operations
 	if !enableJSONOutput {
 		printStats(stats)

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -131,7 +131,7 @@ func RemoveConsumerPlugins(targetContentPlugins []file.FPlugin) []file.FPlugin {
 }
 
 func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
-	delay int, workspace string, enableJSONOutput bool, noDeletes bool,
+	delay int, workspace string, enableJSONOutput bool,
 ) error {
 	// read target file
 	if enableJSONOutput {
@@ -157,13 +157,6 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 	}
 
 	cmd := "sync"
-
-	isPartialApply := false
-	if noDeletes {
-		cmd = "apply"
-		isPartialApply = true
-	}
-
 	if dry {
 		cmd = "diff"
 	}
@@ -209,31 +202,14 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 	// load Kong version after workspace
 	var kongVersion string
 	var parsedKongVersion semver.Version
-	isLicensedKongEnterprise := false
 	if mode == modeKonnect {
 		kongVersion = fetchKonnectKongVersion()
-		isLicensedKongEnterprise = true
 	} else {
 		kongVersion, err = fetchKongVersion(ctx, wsConfig)
 		if err != nil {
 			return fmt.Errorf("reading Kong version: %w", err)
 		}
-
-		// Are we running enterprise?
-		v, err := kong.ParseSemanticVersion(kongVersion)
-		if err != nil {
-			return fmt.Errorf("parsing Kong version: %w", err)
-		}
-
-		// Check if there's an active license for Consumer Group checks
-		if v.IsKongGatewayEnterprise() {
-			isLicensedKongEnterprise, err = isLicensed(ctx, wsConfig)
-			if err != nil {
-				return fmt.Errorf("checking if Kong is licensed: %w", err)
-			}
-		}
 	}
-
 	parsedKongVersion, err = reconcilerUtils.ParseKongVersion(kongVersion)
 	if err != nil {
 		return fmt.Errorf("parsing Kong version: %w", err)
@@ -272,24 +248,21 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 		return err
 	}
 
-	// Consumer groups are an enterprise 3.4+ feature
-	if parsedKongVersion.GTE(reconcilerUtils.Kong340Version) && isLicensedKongEnterprise {
-		dumpConfig.LookUpSelectorTagsConsumerGroups, err = determineLookUpSelectorTagsConsumerGroups(*targetContent)
-		if err != nil {
-			return fmt.Errorf("error determining lookup selector tags for consumer groups: %w", err)
-		}
+	dumpConfig.LookUpSelectorTagsConsumerGroups, err = determineLookUpSelectorTagsConsumerGroups(*targetContent)
+	if err != nil {
+		return fmt.Errorf("error determining lookup selector tags for consumer groups: %w", err)
+	}
 
-		if dumpConfig.LookUpSelectorTagsConsumerGroups != nil || isPartialApply {
-			consumerGroupsGlobal, err := dump.GetAllConsumerGroups(ctx, kongClient, dumpConfig.LookUpSelectorTagsConsumerGroups)
+	if dumpConfig.LookUpSelectorTagsConsumerGroups != nil {
+		consumerGroupsGlobal, err := dump.GetAllConsumerGroups(ctx, kongClient, dumpConfig.LookUpSelectorTagsConsumerGroups)
+		if err != nil {
+			return fmt.Errorf("error retrieving global consumer groups via lookup selector tags: %w", err)
+		}
+		for _, c := range consumerGroupsGlobal {
+			targetContent.ConsumerGroups = append(targetContent.ConsumerGroups,
+				file.FConsumerGroupObject{ConsumerGroup: *c.ConsumerGroup})
 			if err != nil {
-				return fmt.Errorf("error retrieving global consumer groups via lookup selector tags: %w", err)
-			}
-			for _, c := range consumerGroupsGlobal {
-				targetContent.ConsumerGroups = append(targetContent.ConsumerGroups,
-					file.FConsumerGroupObject{ConsumerGroup: *c.ConsumerGroup})
-				if err != nil {
-					return fmt.Errorf("error adding global consumer group %v: %w", *c.ConsumerGroup.Name, err)
-				}
+				return fmt.Errorf("error adding global consumer group %v: %w", *c.ConsumerGroup.Name, err)
 			}
 		}
 	}
@@ -299,7 +272,7 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 		return fmt.Errorf("error determining lookup selector tags for consumers: %w", err)
 	}
 
-	if dumpConfig.LookUpSelectorTagsConsumers != nil || isPartialApply {
+	if dumpConfig.LookUpSelectorTagsConsumers != nil {
 		consumersGlobal, err := dump.GetAllConsumers(ctx, kongClient, dumpConfig.LookUpSelectorTagsConsumers)
 		if err != nil {
 			return fmt.Errorf("error retrieving global consumers via lookup selector tags: %w", err)
@@ -317,7 +290,7 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 		return fmt.Errorf("error determining lookup selector tags for routes: %w", err)
 	}
 
-	if dumpConfig.LookUpSelectorTagsRoutes != nil || isPartialApply {
+	if dumpConfig.LookUpSelectorTagsRoutes != nil {
 		routesGlobal, err := dump.GetAllRoutes(ctx, kongClient, dumpConfig.LookUpSelectorTagsRoutes)
 		if err != nil {
 			return fmt.Errorf("error retrieving global routes via lookup selector tags: %w", err)
@@ -335,7 +308,7 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 		return fmt.Errorf("error determining lookup selector tags for services: %w", err)
 	}
 
-	if dumpConfig.LookUpSelectorTagsServices != nil || isPartialApply {
+	if dumpConfig.LookUpSelectorTagsServices != nil {
 		servicesGlobal, err := dump.GetAllServices(ctx, kongClient, dumpConfig.LookUpSelectorTagsServices)
 		if err != nil {
 			return fmt.Errorf("error retrieving global services via lookup selector tags: %w", err)
@@ -400,7 +373,7 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 	}
 
 	totalOps, err := performDiff(
-		ctx, currentState, targetState, dry, parallelism, delay, kongClient, mode == modeKonnect, enableJSONOutput, noDeletes)
+		ctx, currentState, targetState, dry, parallelism, delay, kongClient, mode == modeKonnect, enableJSONOutput)
 	if err != nil {
 		if enableJSONOutput {
 			var errs reconcilerUtils.ErrArray
@@ -529,7 +502,7 @@ func fetchCurrentState(ctx context.Context, client *kong.Client, dumpConfig dump
 
 func performDiff(ctx context.Context, currentState, targetState *state.KongState,
 	dry bool, parallelism int, delay int, client *kong.Client, isKonnect bool,
-	enableJSONOutput bool, noDeletes bool,
+	enableJSONOutput bool,
 ) (int, error) {
 	s, err := diff.NewSyncer(diff.SyncerOpts{
 		CurrentState:  currentState,
@@ -538,7 +511,6 @@ func performDiff(ctx context.Context, currentState, targetState *state.KongState
 		StageDelaySec: delay,
 		NoMaskValues:  noMaskValues,
 		IsKonnect:     isKonnect,
-		NoDeletes:     noDeletes,
 	})
 	if err != nil {
 		return 0, err
@@ -568,31 +540,6 @@ func performDiff(ctx context.Context, currentState, targetState *state.KongState
 		}
 	}
 	return int(totalOps), nil
-}
-
-func isLicensed(ctx context.Context, config reconcilerUtils.KongClientConfig) (bool, error) {
-	client, err := reconcilerUtils.GetKongClient(config)
-	if err != nil {
-		return false, err
-	}
-
-	req, err := http.NewRequest("GET",
-		reconcilerUtils.CleanAddress(config.Address)+"/",
-		nil)
-	if err != nil {
-		return false, err
-	}
-	var resp map[string]interface{}
-	_, err = client.Do(ctx, req, &resp)
-	if err != nil {
-		return false, err
-	}
-	_, ok := resp["license"]
-	if !ok {
-		return false, nil
-	}
-
-	return true, nil
 }
 
 func fetchKongVersion(ctx context.Context, config reconcilerUtils.KongClientConfig) (string, error) {

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -521,7 +521,13 @@ func performDiff(ctx context.Context, currentState, targetState *state.KongState
 	dry bool, parallelism int, delay int, client *kong.Client, isKonnect bool,
 	enableJSONOutput bool, applyType ApplyType,
 ) (int, error) {
-	shouldSkipDeletes := applyType == ApplyTypePartial
+	shouldSkipDeletes := false
+	diffApplyType := diff.ApplyTypeFull
+
+	if applyType == ApplyTypePartial {
+		shouldSkipDeletes = true
+		diffApplyType = diff.ApplyTypePartial
+	}
 
 	s, err := diff.NewSyncer(diff.SyncerOpts{
 		CurrentState:  currentState,
@@ -536,7 +542,7 @@ func performDiff(ctx context.Context, currentState, targetState *state.KongState
 		return 0, err
 	}
 
-	stats, errs, changes := s.Solve(ctx, parallelism, dry, enableJSONOutput, shouldSkipDeletes)
+	stats, errs, changes := s.Solve(ctx, parallelism, dry, enableJSONOutput, diffApplyType)
 	// print stats before error to report completed operations
 	if !enableJSONOutput {
 		printStats(stats)

--- a/cmd/common_konnect.go
+++ b/cmd/common_konnect.go
@@ -127,7 +127,7 @@ func resetKonnectV2(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	_, err = performDiff(ctx, currentState, targetState, false, 10, 0, client, true, resetJSONOutput)
+	_, err = performDiff(ctx, currentState, targetState, false, 10, 0, client, true, resetJSONOutput, false)
 	if err != nil {
 		return err
 	}
@@ -246,7 +246,7 @@ func syncKonnect(ctx context.Context,
 		return err
 	}
 
-	stats, errs, _ := s.Solve(ctx, parallelism, dry, false)
+	stats, errs, _ := s.Solve(ctx, parallelism, dry, false, false)
 	// print stats before error to report completed operations
 	printStats(stats)
 	if errs != nil {

--- a/cmd/common_konnect.go
+++ b/cmd/common_konnect.go
@@ -127,7 +127,7 @@ func resetKonnectV2(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	_, err = performDiff(ctx, currentState, targetState, false, 10, 0, client, true, resetJSONOutput, false)
+	_, err = performDiff(ctx, currentState, targetState, false, 10, 0, client, true, resetJSONOutput)
 	if err != nil {
 		return err
 	}

--- a/cmd/common_konnect.go
+++ b/cmd/common_konnect.go
@@ -127,7 +127,7 @@ func resetKonnectV2(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	_, err = performDiff(ctx, currentState, targetState, false, 10, 0, client, true, resetJSONOutput, false)
+	_, err = performDiff(ctx, currentState, targetState, false, 10, 0, client, true, resetJSONOutput, ApplyTypeFull)
 	if err != nil {
 		return err
 	}

--- a/cmd/common_konnect.go
+++ b/cmd/common_konnect.go
@@ -246,9 +246,7 @@ func syncKonnect(ctx context.Context,
 		return err
 	}
 
-	// This is a deprecated Konnect sync command. Default to always performing a full sync
-	// which matches the existing behavior.
-	stats, errs, _ := s.Solve(ctx, parallelism, dry, false, diff.ApplyTypeFull)
+	stats, errs, _ := s.Solve(ctx, parallelism, dry, false)
 
 	// print stats before error to report completed operations
 	printStats(stats)

--- a/cmd/common_konnect.go
+++ b/cmd/common_konnect.go
@@ -246,7 +246,10 @@ func syncKonnect(ctx context.Context,
 		return err
 	}
 
-	stats, errs, _ := s.Solve(ctx, parallelism, dry, false, false)
+	// This is a deprecated Konnect sync command. Default to always performing a full sync
+	// which matches the existing behavior.
+	stats, errs, _ := s.Solve(ctx, parallelism, dry, false, diff.ApplyTypeFull)
+
 	// print stats before error to report completed operations
 	printStats(stats)
 	if errs != nil {

--- a/cmd/gateway_apply.go
+++ b/cmd/gateway_apply.go
@@ -15,7 +15,7 @@ var applyCmdKongStateFile []string
 
 func executeApply(cmd *cobra.Command, _ []string) error {
 	return syncMain(cmd.Context(), applyCmdKongStateFile, false,
-		applyCmdParallelism, applyCmdDBUpdateDelay, applyWorkspace, applyJSONOutput, true)
+		applyCmdParallelism, applyCmdDBUpdateDelay, applyWorkspace, applyJSONOutput, ApplyTypePartial)
 }
 
 func newApplyCmd() *cobra.Command {

--- a/cmd/gateway_apply.go
+++ b/cmd/gateway_apply.go
@@ -15,7 +15,7 @@ var applyCmdKongStateFile []string
 
 func executeApply(cmd *cobra.Command, _ []string) error {
 	return syncMain(cmd.Context(), applyCmdKongStateFile, false,
-		applyCmdParallelism, applyCmdDBUpdateDelay, applyWorkspace, applyJSONOutput, true)
+		applyCmdParallelism, applyCmdDBUpdateDelay, applyWorkspace, applyJSONOutput)
 }
 
 func newApplyCmd() *cobra.Command {

--- a/cmd/gateway_apply.go
+++ b/cmd/gateway_apply.go
@@ -15,7 +15,7 @@ var applyCmdKongStateFile []string
 
 func executeApply(cmd *cobra.Command, _ []string) error {
 	return syncMain(cmd.Context(), applyCmdKongStateFile, false,
-		applyCmdParallelism, applyCmdDBUpdateDelay, applyWorkspace, applyJSONOutput)
+		applyCmdParallelism, applyCmdDBUpdateDelay, applyWorkspace, applyJSONOutput, true)
 }
 
 func newApplyCmd() *cobra.Command {

--- a/cmd/gateway_diff.go
+++ b/cmd/gateway_diff.go
@@ -17,7 +17,7 @@ var (
 
 func executeDiff(cmd *cobra.Command, _ []string) error {
 	return syncMain(cmd.Context(), diffCmdKongStateFile, true,
-		diffCmdParallelism, 0, diffWorkspace, diffJSONOutput)
+		diffCmdParallelism, 0, diffWorkspace, diffJSONOutput, false)
 }
 
 // newDiffCmd represents the diff command

--- a/cmd/gateway_diff.go
+++ b/cmd/gateway_diff.go
@@ -17,7 +17,7 @@ var (
 
 func executeDiff(cmd *cobra.Command, _ []string) error {
 	return syncMain(cmd.Context(), diffCmdKongStateFile, true,
-		diffCmdParallelism, 0, diffWorkspace, diffJSONOutput, false)
+		diffCmdParallelism, 0, diffWorkspace, diffJSONOutput)
 }
 
 // newDiffCmd represents the diff command

--- a/cmd/gateway_diff.go
+++ b/cmd/gateway_diff.go
@@ -17,7 +17,7 @@ var (
 
 func executeDiff(cmd *cobra.Command, _ []string) error {
 	return syncMain(cmd.Context(), diffCmdKongStateFile, true,
-		diffCmdParallelism, 0, diffWorkspace, diffJSONOutput, false)
+		diffCmdParallelism, 0, diffWorkspace, diffJSONOutput, ApplyTypeFull)
 }
 
 // newDiffCmd represents the diff command

--- a/cmd/gateway_reset.go
+++ b/cmd/gateway_reset.go
@@ -97,7 +97,7 @@ func executeReset(cmd *cobra.Command, _ []string) error {
 		if err != nil {
 			return err
 		}
-		_, err = performDiff(ctx, currentState, targetState, false, 10, 0, wsClient, false, resetJSONOutput, false)
+		_, err = performDiff(ctx, currentState, targetState, false, 10, 0, wsClient, false, resetJSONOutput, ApplyTypeFull)
 		if err != nil {
 			return err
 		}

--- a/cmd/gateway_reset.go
+++ b/cmd/gateway_reset.go
@@ -97,7 +97,7 @@ func executeReset(cmd *cobra.Command, _ []string) error {
 		if err != nil {
 			return err
 		}
-		_, err = performDiff(ctx, currentState, targetState, false, 10, 0, wsClient, false, resetJSONOutput, false)
+		_, err = performDiff(ctx, currentState, targetState, false, 10, 0, wsClient, false, resetJSONOutput)
 		if err != nil {
 			return err
 		}

--- a/cmd/gateway_reset.go
+++ b/cmd/gateway_reset.go
@@ -97,7 +97,7 @@ func executeReset(cmd *cobra.Command, _ []string) error {
 		if err != nil {
 			return err
 		}
-		_, err = performDiff(ctx, currentState, targetState, false, 10, 0, wsClient, false, resetJSONOutput)
+		_, err = performDiff(ctx, currentState, targetState, false, 10, 0, wsClient, false, resetJSONOutput, false)
 		if err != nil {
 			return err
 		}

--- a/cmd/gateway_sync.go
+++ b/cmd/gateway_sync.go
@@ -18,7 +18,7 @@ var syncCmdKongStateFile []string
 
 func executeSync(cmd *cobra.Command, _ []string) error {
 	return syncMain(cmd.Context(), syncCmdKongStateFile, false,
-		syncCmdParallelism, syncCmdDBUpdateDelay, syncWorkspace, syncJSONOutput, false)
+		syncCmdParallelism, syncCmdDBUpdateDelay, syncWorkspace, syncJSONOutput, ApplyTypeFull)
 }
 
 // newSyncCmd represents the sync command

--- a/cmd/gateway_sync.go
+++ b/cmd/gateway_sync.go
@@ -18,7 +18,7 @@ var syncCmdKongStateFile []string
 
 func executeSync(cmd *cobra.Command, _ []string) error {
 	return syncMain(cmd.Context(), syncCmdKongStateFile, false,
-		syncCmdParallelism, syncCmdDBUpdateDelay, syncWorkspace, syncJSONOutput, false)
+		syncCmdParallelism, syncCmdDBUpdateDelay, syncWorkspace, syncJSONOutput)
 }
 
 // newSyncCmd represents the sync command

--- a/cmd/gateway_sync.go
+++ b/cmd/gateway_sync.go
@@ -18,7 +18,7 @@ var syncCmdKongStateFile []string
 
 func executeSync(cmd *cobra.Command, _ []string) error {
 	return syncMain(cmd.Context(), syncCmdKongStateFile, false,
-		syncCmdParallelism, syncCmdDBUpdateDelay, syncWorkspace, syncJSONOutput)
+		syncCmdParallelism, syncCmdDBUpdateDelay, syncWorkspace, syncJSONOutput, false)
 }
 
 // newSyncCmd represents the sync command

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/fatih/color v1.17.0
 	github.com/google/go-cmp v0.6.0
 	github.com/kong/go-apiops v0.1.41
-	github.com/kong/go-database-reconciler v1.18.1
+	github.com/kong/go-database-reconciler v1.19.2
 	github.com/kong/go-kong v0.63.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -249,6 +249,8 @@ github.com/kong/go-apiops v0.1.41 h1:1KXbQqyhO2E4nEnXJNqUDmHZU/LQ1U7Zoi+MAlcM2P0
 github.com/kong/go-apiops v0.1.41/go.mod h1:sATq9Tz+ivzHKZU+tDXkRtEZnf64xroU3lgv3yXqP4I=
 github.com/kong/go-database-reconciler v1.18.1 h1:NhV3oDWMO02yj9scFIYfUwoK/KxMxCP0fXkZIBF1QME=
 github.com/kong/go-database-reconciler v1.18.1/go.mod h1:BqaV17xmjYAJfQYlaMKNz/DbJO4FfpwZpKD5dg2Pku0=
+github.com/kong/go-database-reconciler v1.19.2 h1:+TA5fs5BJWrX3FpsuekIitCqW66M/rw5ToRoUZTLxdA=
+github.com/kong/go-database-reconciler v1.19.2/go.mod h1:fSzg8w4rBaiMqF0H9XqoGXCJsqLIxRBG9f1BhvKU2Lg=
 github.com/kong/go-kong v0.63.0 h1:8ECLgkgDqON61qCMq/M0gTwZKYxg55Oy692dRDOOBiU=
 github.com/kong/go-kong v0.63.0/go.mod h1:ma9GWnhkxtrXZlLFfED955HjVzmUojYEHet3lm+PDik=
 github.com/kong/go-slugify v1.0.0 h1:vCFAyf2sdoSlBtLcrmDWUFn0ohlpKiKvQfXZkO5vSKY=

--- a/tests/integration/apply_test.go
+++ b/tests/integration/apply_test.go
@@ -86,7 +86,7 @@ func Test_Apply_3x(t *testing.T) {
 		runWhen(t, "kong", ">=3.0.0")
 		setup(t)
 
-		apply("testdata/apply/007-update-existing-entity/service-01.yaml")
+		apply(context.Background(), "testdata/apply/007-update-existing-entity/service-01.yaml")
 
 		out, err := dump()
 		require.NoError(t, err)
@@ -95,7 +95,7 @@ func Test_Apply_3x(t *testing.T) {
 
 		assert.Equal(t, expectedOriginal, out)
 
-		apply("testdata/apply/007-update-existing-entity/service-02.yaml")
+		apply(context.Background(), "testdata/apply/007-update-existing-entity/service-02.yaml")
 		expectedChanged, err := readFile("testdata/apply/007-update-existing-entity/expected-state-02.yaml")
 		require.NoError(t, err, "failed to read expected state")
 

--- a/tests/integration/apply_test.go
+++ b/tests/integration/apply_test.go
@@ -48,6 +48,20 @@ func Test_Apply_3x(t *testing.T) {
 			expectedState: "testdata/apply/004-foreign-keys-consumer-groups/expected-state.yaml",
 			runWhen:       "enterprise",
 		},
+		{
+			name:          "accepts service foreign keys",
+			firstFile:     "testdata/apply/005-foreign-keys-services/service-01.yaml",
+			secondFile:    "testdata/apply/005-foreign-keys-services/plugin-01.yaml",
+			expectedState: "testdata/apply/005-foreign-keys-services/expected-state.yaml",
+			runWhen:       "kong",
+		},
+		{
+			name:          "accepts route foreign keys",
+			firstFile:     "testdata/apply/006-foreign-keys-routes/route-01.yaml",
+			secondFile:    "testdata/apply/006-foreign-keys-routes/plugin-01.yaml",
+			expectedState: "testdata/apply/006-foreign-keys-routes/expected-state.yaml",
+			runWhen:       "kong",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -67,4 +81,28 @@ func Test_Apply_3x(t *testing.T) {
 			assert.Equal(t, expected, out)
 		})
 	}
+
+	t.Run("updates existing entities", func(t *testing.T) {
+		runWhen(t, "kong", ">=3.0.0")
+		setup(t)
+
+		apply("testdata/apply/007-update-existing-entity/service-01.yaml")
+
+		out, _ := dump()
+		expectedOriginal, err := readFile("testdata/apply/007-update-existing-entity/expected-state-01.yaml")
+		if err != nil {
+			t.Fatalf("failed to read expected state: %v", err)
+		}
+
+		assert.Equal(t, expectedOriginal, out)
+
+		apply("testdata/apply/007-update-existing-entity/service-02.yaml")
+		expectedChanged, err := readFile("testdata/apply/007-update-existing-entity/expected-state-02.yaml")
+		if err != nil {
+			t.Fatalf("failed to read expected state: %v", err)
+		}
+
+		outChanged, _ := dump()
+		assert.Equal(t, expectedChanged, outChanged)
+	})
 }

--- a/tests/integration/apply_test.go
+++ b/tests/integration/apply_test.go
@@ -86,7 +86,8 @@ func Test_Apply_3x(t *testing.T) {
 		runWhen(t, "kong", ">=3.0.0")
 		setup(t)
 
-		apply(context.Background(), "testdata/apply/007-update-existing-entity/service-01.yaml")
+		err := apply(context.Background(), "testdata/apply/007-update-existing-entity/service-01.yaml")
+		require.NoError(t, err, "failed to apply service-01")
 
 		out, err := dump()
 		require.NoError(t, err)
@@ -95,7 +96,9 @@ func Test_Apply_3x(t *testing.T) {
 
 		assert.Equal(t, expectedOriginal, out)
 
-		apply(context.Background(), "testdata/apply/007-update-existing-entity/service-02.yaml")
+		err = apply(context.Background(), "testdata/apply/007-update-existing-entity/service-02.yaml")
+		require.NoError(t, err, "failed to apply service-02")
+
 		expectedChanged, err := readFile("testdata/apply/007-update-existing-entity/expected-state-02.yaml")
 		require.NoError(t, err, "failed to read expected state")
 

--- a/tests/integration/apply_test.go
+++ b/tests/integration/apply_test.go
@@ -88,21 +88,19 @@ func Test_Apply_3x(t *testing.T) {
 
 		apply("testdata/apply/007-update-existing-entity/service-01.yaml")
 
-		out, _ := dump()
+		out, err := dump()
+		require.NoError(t, err)
 		expectedOriginal, err := readFile("testdata/apply/007-update-existing-entity/expected-state-01.yaml")
-		if err != nil {
-			t.Fatalf("failed to read expected state: %v", err)
-		}
+		require.NoError(t, err, "failed to read expected state")
 
 		assert.Equal(t, expectedOriginal, out)
 
 		apply("testdata/apply/007-update-existing-entity/service-02.yaml")
 		expectedChanged, err := readFile("testdata/apply/007-update-existing-entity/expected-state-02.yaml")
-		if err != nil {
-			t.Fatalf("failed to read expected state: %v", err)
-		}
+		require.NoError(t, err, "failed to read expected state")
 
-		outChanged, _ := dump()
+		outChanged, err := dump()
+		require.NoError(t, err)
 		assert.Equal(t, expectedChanged, outChanged)
 	})
 }

--- a/tests/integration/testdata/apply/005-foreign-keys-services/expected-state.yaml
+++ b/tests/integration/testdata/apply/005-foreign-keys-services/expected-state.yaml
@@ -1,0 +1,24 @@
+_format_version: "3.0"
+services:
+- connect_timeout: 60000
+  enabled: true
+  host: httpbin.konghq.com
+  name: example-service
+  plugins:
+  - config:
+      body: null
+      content_type: null
+      echo: false
+      message: null
+      status_code: 404
+      trigger: null
+    enabled: true
+    name: request-termination
+    protocols:
+    - http
+    - https
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000

--- a/tests/integration/testdata/apply/005-foreign-keys-services/plugin-01.yaml
+++ b/tests/integration/testdata/apply/005-foreign-keys-services/plugin-01.yaml
@@ -1,0 +1,15 @@
+_format_version: "3.0"
+plugins:
+  - name: request-termination
+    enabled: true
+    service: example-service
+    config:
+      status_code: 404
+      body: null
+      content_type: null
+      echo: false
+      message: null
+      trigger: null
+    protocols:
+      - http
+      - https

--- a/tests/integration/testdata/apply/005-foreign-keys-services/service-01.yaml
+++ b/tests/integration/testdata/apply/005-foreign-keys-services/service-01.yaml
@@ -1,0 +1,4 @@
+_format_version: "3.0"
+services:
+  - name: example-service
+    url: http://httpbin.konghq.com

--- a/tests/integration/testdata/apply/006-foreign-keys-routes/expected-state.yaml
+++ b/tests/integration/testdata/apply/006-foreign-keys-routes/expected-state.yaml
@@ -1,0 +1,28 @@
+_format_version: "3.0"
+routes:
+- https_redirect_status_code: 426
+  name: example-route
+  path_handling: v0
+  paths:
+  - /mock
+  plugins:
+  - config:
+      body: null
+      content_type: null
+      echo: false
+      message: null
+      status_code: 404
+      trigger: null
+    enabled: true
+    name: request-termination
+    protocols:
+    - http
+    - https
+  preserve_host: false
+  protocols:
+  - http
+  - https
+  regex_priority: 0
+  request_buffering: true
+  response_buffering: true
+  strip_path: true

--- a/tests/integration/testdata/apply/006-foreign-keys-routes/plugin-01.yaml
+++ b/tests/integration/testdata/apply/006-foreign-keys-routes/plugin-01.yaml
@@ -1,0 +1,15 @@
+_format_version: "3.0"
+plugins:
+  - name: request-termination
+    enabled: true
+    route: example-route
+    config:
+      status_code: 404
+      body: null
+      content_type: null
+      echo: false
+      message: null
+      trigger: null
+    protocols:
+      - http
+      - https

--- a/tests/integration/testdata/apply/006-foreign-keys-routes/route-01.yaml
+++ b/tests/integration/testdata/apply/006-foreign-keys-routes/route-01.yaml
@@ -1,0 +1,5 @@
+_format_version: "3.0"
+routes:
+ - name: example-route
+   paths:
+   - "/mock"

--- a/tests/integration/testdata/apply/007-update-existing-entity/expected-state-01.yaml
+++ b/tests/integration/testdata/apply/007-update-existing-entity/expected-state-01.yaml
@@ -1,0 +1,12 @@
+_format_version: "3.0"
+services:
+- connect_timeout: 60000
+  enabled: true
+  host: httpbin.org
+  name: mock1
+  path: /anything
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000

--- a/tests/integration/testdata/apply/007-update-existing-entity/expected-state-02.yaml
+++ b/tests/integration/testdata/apply/007-update-existing-entity/expected-state-02.yaml
@@ -1,0 +1,12 @@
+_format_version: "3.0"
+services:
+- connect_timeout: 60000
+  enabled: true
+  host: httpbin.org
+  name: mock1
+  path: /changed
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000

--- a/tests/integration/testdata/apply/007-update-existing-entity/service-01.yaml
+++ b/tests/integration/testdata/apply/007-update-existing-entity/service-01.yaml
@@ -1,0 +1,12 @@
+_format_version: "3.0"
+services:
+  - connect_timeout: 60000
+    enabled: true
+    host: httpbin.org
+    name: mock1
+    path: /anything
+    port: 80
+    protocol: http
+    read_timeout: 60000
+    retries: 5
+    write_timeout: 60000

--- a/tests/integration/testdata/apply/007-update-existing-entity/service-02.yaml
+++ b/tests/integration/testdata/apply/007-update-existing-entity/service-02.yaml
@@ -1,0 +1,12 @@
+_format_version: "3.0"
+services:
+  - connect_timeout: 60000
+    enabled: true
+    host: httpbin.org
+    name: mock1
+    path: /changed
+    port: 80
+    protocol: http
+    read_timeout: 60000
+    retries: 5
+    write_timeout: 60000


### PR DESCRIPTION
The existing `deck gateway apply` command works when applying a resource for the first time, but error due to duplicate entities when trying to update the resource.

This PR moves the partial apply logic to `go-database-reconciler` (https://github.com/Kong/go-database-reconciler/pull/182) and removes the `isPartialApply` logic from decK. This also removes the license checks that were previously added for Consumer Group fetching as GDR now handles this.