### PR TITLE
feat: added --skip-consumers-with-consumer-groups to sync and diff commands

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -26,8 +26,9 @@ import (
 const exitCodeDiffDetection = 2
 
 var (
-	assumeYes    bool
-	noMaskValues bool
+	assumeYes        bool
+	noMaskValues     bool
+	syncCmdAssumeYes bool
 )
 
 type mode int
@@ -449,7 +450,7 @@ func validateSkipConsumersWithConsumerGroups(targetContent file.Content, config 
 		printFn("--skip-consumers-with-consumer-groups flag is added, but no select tags are specified.\n" +
 			"This can lead to unintended changes.\n\n")
 
-		ok, err := reconcilerUtils.Confirm("> Do you wish to continue? ")
+		ok, err := confirmPrompt("> Do you wish to continue? ", syncCmdAssumeYes)
 		if err != nil {
 			return false, err
 		}

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -439,6 +439,14 @@ func validateSkipConsumersWithConsumerGroups(targetContent file.Content, config 
 		printFn := color.New(color.FgYellow, color.Bold).PrintfFunc()
 		printFn("--skip-consumers-with-consumer-groups flag is added, but no select tags are specified.\n" +
 			"This can lead to unintended changes.\n\n")
+
+		ok, err := reconcilerUtils.Confirm("> Do you wish to continue? ")
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return nil
+		}
 	}
 
 	if len(targetContent.Consumers) > 0 {

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -179,6 +179,7 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 	var kongClient *kong.Client
 	mode := getMode(targetContent)
 	if mode == modeKonnect {
+		// Konnect ConsumerGroup APIs don't support the query-parameter list_consumers yet
 		if dumpConfig.SkipConsumersWithConsumerGroups {
 			return errors.New("the flag --skip-consumers-with-consumer-groups can not be used with Konnect")
 		}

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -450,12 +450,14 @@ func validateSkipConsumersWithConsumerGroups(targetContent file.Content, config 
 		printFn("--skip-consumers-with-consumer-groups flag is added, but no select tags are specified.\n" +
 			"This can lead to unintended changes.\n\n")
 
-		ok, err := confirmPrompt("> Do you wish to continue? ", syncCmdAssumeYes)
-		if err != nil {
-			return false, err
-		}
-		if !ok {
-			return false, nil
+		if !syncCmdAssumeYes {
+			ok, err := reconcilerUtils.Confirm("> Do you wish to continue? ")
+			if err != nil {
+				return false, err
+			}
+			if !ok {
+				return false, nil
+			}
 		}
 	}
 

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 
 	"github.com/blang/semver/v4"
+	"github.com/fatih/color"
 	"github.com/kong/deck/utils"
 	"github.com/kong/go-database-reconciler/pkg/cprint"
 	"github.com/kong/go-database-reconciler/pkg/diff"
@@ -178,6 +179,10 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 	var kongClient *kong.Client
 	mode := getMode(targetContent)
 	if mode == modeKonnect {
+		if dumpConfig.SkipConsumersWithConsumerGroups {
+			return errors.New("the flag --skip-consumers-with-consumer-groups can not be used with Konnect")
+		}
+
 		if targetContent.Workspace != "" {
 			return fmt.Errorf("_workspace set in config file.\n"+
 				"Workspaces are not supported in Konnect. "+
@@ -262,6 +267,13 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 	dumpConfig.SelectorTags, err = determineSelectorTag(*targetContent, dumpConfig)
 	if err != nil {
 		return err
+	}
+
+	if dumpConfig.SkipConsumersWithConsumerGroups {
+		err := validateSkipConsumersWithConsumerGroups(*targetContent, dumpConfig)
+		if err != nil {
+			return err
+		}
 	}
 
 	dumpConfig.LookUpSelectorTagsConsumerGroups, err = determineLookUpSelectorTagsConsumerGroups(*targetContent)
@@ -419,6 +431,24 @@ func syncMain(ctx context.Context, filenames []string, dry bool, parallelism,
 
 		cprint.BluePrintLn(jsonOutputString + "\n")
 	}
+	return nil
+}
+
+func validateSkipConsumersWithConsumerGroups(targetContent file.Content, config dump.Config) error {
+	if len(config.SelectorTags) == 0 {
+		printFn := color.New(color.FgYellow, color.Bold).PrintfFunc()
+		printFn("--skip-consumers-with-consumer-groups flag is added, but no select tags are specified.\n" +
+			"This can lead to unintended changes.\n\n")
+	}
+
+	if len(targetContent.Consumers) > 0 {
+		for _, consumer := range targetContent.Consumers {
+			if consumer.Groups != nil {
+				return fmt.Errorf("can not use --skip-consumers-with-consumer-groups while adding consumers.groups")
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/cmd/gateway_diff.go
+++ b/cmd/gateway_diff.go
@@ -111,6 +111,8 @@ that will be created, updated, or deleted.
 			"thus gaining some performance with large configs.\n"+
 			"Usage of this flag without apt select-tags and default-lookup-tags can be problematic.\n"+
 			"This flag is not valid with Konnect.")
+	diffCmd.Flags().BoolVar(&syncCmdAssumeYes, "yes",
+		false, "assume `yes` to prompts and run non-interactively.")
 	addSilenceEventsFlag(diffCmd.Flags())
 	return diffCmd
 }

--- a/cmd/gateway_diff.go
+++ b/cmd/gateway_diff.go
@@ -105,6 +105,12 @@ that will be created, updated, or deleted.
 		false, "allow deck to diff consumer-group policy overrides.\n"+
 			"This allows policy overrides to work with Kong GW versions >= 3.4\n"+
 			"Warning: do not mix with consumer-group scoped plugins")
+	diffCmd.Flags().BoolVar(&dumpConfig.SkipConsumersWithConsumerGroups, "skip-consumers-with-consumer-groups",
+		false, "do not show the association between consumer and consumer-group.\n"+
+			"If set to true, deck skips listing consumers with consumer-groups,\n"+
+			"thus gaining some performance with large configs.\n"+
+			"Usage of this flag without apt select-tags and default-lookup-tags can be problematic.\n"+
+			"This flag is not valid with Konnect.")
 	addSilenceEventsFlag(diffCmd.Flags())
 	return diffCmd
 }

--- a/cmd/gateway_dump.go
+++ b/cmd/gateway_dump.go
@@ -49,6 +49,7 @@ func executeDump(cmd *cobra.Command, _ []string) error {
 	}
 
 	if inKonnectMode(nil) {
+		// Konnect ConsumerGroup APIs don't support the query-parameter list_consumers yet
 		if dumpConfig.SkipConsumersWithConsumerGroups {
 			return errors.New("the flag --skip-consumers-with-consumer-groups can not be used with Konnect")
 		}

--- a/cmd/gateway_sync.go
+++ b/cmd/gateway_sync.go
@@ -106,6 +106,8 @@ to get Kong's state in sync with the input state.`,
 			"thus gaining some performance with large configs.\n"+
 			"Usage of this flag without apt select-tags and default-lookup-tags can be problematic.\n"+
 			"This flag is not valid with Konnect.")
+	syncCmd.Flags().BoolVar(&syncCmdAssumeYes, "yes",
+		false, "assume `yes` to prompts and run non-interactively.")
 	syncCmd.Flags().BoolVar(&syncJSONOutput, "json-output",
 		false, "generate command execution report in a JSON format")
 	addSilenceEventsFlag(syncCmd.Flags())

--- a/cmd/gateway_sync.go
+++ b/cmd/gateway_sync.go
@@ -100,6 +100,12 @@ to get Kong's state in sync with the input state.`,
 		false, "allow deck to sync consumer-group policy overrides.\n"+
 			"This allows policy overrides to work with Kong GW versions >= 3.4\n"+
 			"Warning: do not mix with consumer-group scoped plugins")
+	syncCmd.Flags().BoolVar(&dumpConfig.SkipConsumersWithConsumerGroups, "skip-consumers-with-consumer-groups",
+		false, "do not show the association between consumer and consumer-group.\n"+
+			"If set to true, deck skips listing consumers with consumer-groups,\n"+
+			"thus gaining some performance with large configs.\n"+
+			"Usage of this flag without apt select-tags and default-lookup-tags can be problematic.\n"+
+			"This flag is not valid with Konnect.")
 	syncCmd.Flags().BoolVar(&syncJSONOutput, "json-output",
 		false, "generate command execution report in a JSON format")
 	addSilenceEventsFlag(syncCmd.Flags())

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/kong/go-database-reconciler/pkg/cprint"
@@ -46,4 +47,28 @@ func validateInputFlag(flagName string, flagValue string, allowedValues []string
 
 	return fmt.Errorf("invalid value '%s' found for the '%s' flag. Allowed values: %v",
 		flagValue, flagName, allowedValues)
+}
+
+// confirmPrompt prompts a user for a confirmation with message
+// and returns true with no error if input is "yes" or "y" (case-insensitive),
+// otherwise false.
+func confirmPrompt(message string, assumeYes bool) (bool, error) {
+	if assumeYes {
+		return true, nil
+	}
+
+	fmt.Print(message)
+	validOptions := []string{"yes", "y"}
+	var input string
+	_, err := fmt.Scanln(&input)
+	if err != nil {
+		return false, err
+	}
+	input = strings.ToLower(input)
+	for _, validOption := range validOptions {
+		if input == validOption {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/fatih/color"
 	"github.com/kong/go-database-reconciler/pkg/cprint"
@@ -47,28 +46,4 @@ func validateInputFlag(flagName string, flagValue string, allowedValues []string
 
 	return fmt.Errorf("invalid value '%s' found for the '%s' flag. Allowed values: %v",
 		flagValue, flagName, allowedValues)
-}
-
-// confirmPrompt prompts a user for a confirmation with message
-// and returns true with no error if input is "yes" or "y" (case-insensitive),
-// otherwise false.
-func confirmPrompt(message string, assumeYes bool) (bool, error) {
-	if assumeYes {
-		return true, nil
-	}
-
-	fmt.Print(message)
-	validOptions := []string{"yes", "y"}
-	var input string
-	_, err := fmt.Scanln(&input)
-	if err != nil {
-		return false, err
-	}
-	input = strings.ToLower(input)
-	for _, validOption := range validOptions {
-		if input == validOption {
-			return true, nil
-		}
-	}
-	return false, nil
 }

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -7476,3 +7476,16 @@ func Test_Sync_SkipConsumersWithConsumerGroups(t *testing.T) {
 		assert.ErrorContains(t, err, "can not use --skip-consumers-with-consumer-groups while adding consumers.groups")
 	})
 }
+
+func Test_Sync_SkipConsumersWithConsumerGroups_Konnect(t *testing.T) {
+	runWhen(t, "konnect", "")
+	setup(t)
+
+	ctx := context.Background()
+
+	t.Run("--skip-consumers-with-consumer-groups flag set", func(t *testing.T) {
+		err := sync(ctx, "testdata/sync/038-skip-consumers-with-cgs/base.yaml", "--skip-consumers-with-consumer-groups")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "the flag --skip-consumers-with-consumer-groups can not be used with Konnect")
+	})
+}

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -479,6 +479,7 @@ var (
 				"per_consumer":            false,
 				"status_code_metrics":     false,
 				"upstream_health_metrics": false,
+				"wasm_metrics":            false,
 			},
 			Service: &kong.Service{
 				ID: kong.String("58076db2-28b6-423b-ba39-a797193017f7"),
@@ -500,6 +501,7 @@ var (
 				"per_consumer":            false,
 				"status_code_metrics":     false,
 				"upstream_health_metrics": false,
+				"wasm_metrics":            false,
 			},
 			Route: &kong.Route{
 				ID: kong.String("87b6a97e-f3f7-4c47-857a-7464cb9e202b"),
@@ -521,6 +523,7 @@ var (
 				"per_consumer":            false,
 				"status_code_metrics":     false,
 				"upstream_health_metrics": false,
+				"wasm_metrics":            false,
 			},
 			Consumer: &kong.Consumer{
 				ID: kong.String("d2965b9b-0608-4458-a9f8-0b93d88d03b8"),

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -7448,3 +7448,31 @@ func Test_Sync_ConsumerGroupPlugin_Policy_Overrides_39x(t *testing.T) {
 		assert.ErrorContains(t, err, errorConsumerGroupPolicies)
 	})
 }
+
+func Test_Sync_SkipConsumersWithConsumerGroups(t *testing.T) {
+	runWhen(t, "enterprise", ">=3.0.0")
+	setup(t)
+
+	ctx := context.Background()
+
+	t.Run("--skip-consumers-with-consumer-groups flag set", func(t *testing.T) {
+		// Ensure that sync goes through without any errors
+		// We aren't checking for expected state as that is not the prime motive of the test
+		// We just want to ensure that sync runs without errors in case consumers are synced separately.
+		err := sync(ctx, "testdata/sync/038-skip-consumers-with-cgs/base.yaml", "--skip-consumers-with-consumer-groups")
+		require.NoError(t, err)
+
+		err = sync(ctx, "testdata/sync/038-skip-consumers-with-cgs/consumers.yaml")
+		require.NoError(t, err)
+
+		// second sync to ensure it goes through successfully too without any errors
+		err = sync(ctx, "testdata/sync/038-skip-consumers-with-cgs/base.yaml", "--skip-consumers-with-consumer-groups")
+		require.NoError(t, err)
+	})
+
+	t.Run("--skip-consumers-with-consumer-groups flag set with consumers.group present in file", func(t *testing.T) {
+		err := sync(ctx, "testdata/sync/038-skip-consumers-with-cgs/consumers.yaml", "--skip-consumers-with-consumer-groups")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "can not use --skip-consumers-with-consumer-groups while adding consumers.groups")
+	})
+}

--- a/tests/integration/testdata/sync/038-skip-consumers-with-cgs/base.yaml
+++ b/tests/integration/testdata/sync/038-skip-consumers-with-cgs/base.yaml
@@ -15,16 +15,39 @@ services:
 consumer_groups:
   - name: bronze
     plugins:
-      - name: request-termination
-        config:
-          body: You are a BRONZE consumer
+    - name: rate-limiting-advanced
+      config:
+        namespace: bronze
+        limit:
+        - 5
+        retry_after_jitter_max: 1
+        window_size:
+        - 60
+        window_type: sliding
+        sync_rate: -1
+      
   - name: silver
     plugins:
-      - name: request-termination
-        config:
-          body: You are a SILVER consumer
+    - name: rate-limiting-advanced
+      config:
+        namespace: silver
+        limit:
+        - 7
+        retry_after_jitter_max: 1
+        window_size:
+        - 60
+        window_type: sliding
+        sync_rate: -1
+          
   - name: gold
     plugins:
-      - name: request-termination
-        config:
-          body: You are a GOLD consumer
+    - name: rate-limiting-advanced
+      config:
+        namespace: gold
+        limit:
+        - 10
+        retry_after_jitter_max: 1
+        window_size:
+        - 60
+        window_type: sliding
+        sync_rate: -1

--- a/tests/integration/testdata/sync/038-skip-consumers-with-cgs/base.yaml
+++ b/tests/integration/testdata/sync/038-skip-consumers-with-cgs/base.yaml
@@ -1,0 +1,30 @@
+_format_version: "3.0"
+_info:
+  select_tags: [base]
+
+services:
+  - name: HTTPBin
+    url: https://httpbin.org
+    routes:
+      - name: All
+        paths:
+          - /
+    plugins:
+      - name: key-auth
+
+consumer_groups:
+  - name: bronze
+    plugins:
+      - name: request-termination
+        config:
+          body: You are a BRONZE consumer
+  - name: silver
+    plugins:
+      - name: request-termination
+        config:
+          body: You are a SILVER consumer
+  - name: gold
+    plugins:
+      - name: request-termination
+        config:
+          body: You are a GOLD consumer

--- a/tests/integration/testdata/sync/038-skip-consumers-with-cgs/consumers.yaml
+++ b/tests/integration/testdata/sync/038-skip-consumers-with-cgs/consumers.yaml
@@ -1,0 +1,17 @@
+_format_version: "3.0"
+_info:
+  select_tags: [consumers]
+  default_lookup_tags:
+    consumer_groups:
+      - base
+consumers:
+  - username: alice
+    groups:
+      - name: gold
+    keyauth_credentials:
+      - key: hello
+  - username: bob
+    groups:
+      - name: silver
+    keyauth_credentials:
+      - key: world


### PR DESCRIPTION
This flag was earlier enabled on dump command.
We are adding it to sync and diff commands too
as it provides performance benefits in case an
enterprise has thousands of consumers per group.
It ensures that list_consumers=false while
querying a consumer-group. This is beneficial for
enterprise customers who sync consumers separately on a different cadence 
but require frequent changes in other entity configurations. 
Not listing consumers leads to a boost in performance in such cases.

Related changes:
https://github.com/Kong/go-database-reconciler/pull/159
https://github.com/Kong/go-kong/pull/494

Why was this change necessary?
Check linked FTI: https://konghq.atlassian.net/browse/FTI-6183

More info: https://kongstrong.slack.com/archives/C07AQH7SAF8/p1736409331920239

For #1524 