### PR TITLE
ci: add testifylint to golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,7 @@ linters:
     - staticcheck
     - stylecheck
     - unconvert
+    - testifylint
     - unparam
     - unused
     - wastedassign

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kong/go-database-reconciler/pkg/utils"
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseFormat(t *testing.T) {
@@ -561,7 +562,7 @@ func Test_convertAutoFields(t *testing.T) {
 	}
 
 	got, err := convertKongGateway2xTo3x(content, "-")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	globalPluginConfig := got.Plugins[0].Config
 	assert.NotEmpty(t, globalPluginConfig["namespace"])

--- a/tests/integration/diff_test.go
+++ b/tests/integration/diff_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kong/go-database-reconciler/pkg/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -484,7 +485,7 @@ func Test_Diff_Workspace_OlderThan3x(t *testing.T) {
 			setup(t)
 
 			_, err := diff(tc.stateFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 	}
 }
@@ -508,7 +509,7 @@ func Test_Diff_Workspace_NewerThan3x(t *testing.T) {
 			setup(t)
 
 			_, err := diff(tc.stateFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 	}
 }
@@ -539,10 +540,10 @@ func Test_Diff_Masked_OlderThan3x(t *testing.T) {
 			setup(t)
 
 			// initialize state
-			assert.NoError(t, sync(context.Background(), tc.initialStateFile))
+			require.NoError(t, sync(context.Background(), tc.initialStateFile))
 
 			out, err := diff(tc.stateFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, expectedOutputMasked, out)
 		})
 	}
@@ -556,11 +557,11 @@ func Test_Diff_Masked_OlderThan3x(t *testing.T) {
 			setup(t)
 
 			// initialize state
-			assert.NoError(t, sync(context.Background(), tc.initialStateFile))
+			require.NoError(t, sync(context.Background(), tc.initialStateFile))
 
 			out, err := diff(tc.stateFile, "--json-output")
-			assert.NoError(t, err)
-			assert.Equal(t, expectedOutputMaskedJSON, out)
+			require.NoError(t, err)
+			assert.JSONEq(t, expectedOutputMaskedJSON, out)
 		})
 	}
 }
@@ -591,10 +592,10 @@ func Test_Diff_Masked_NewerThan3x(t *testing.T) {
 			setup(t)
 
 			// initialize state
-			assert.NoError(t, sync(context.Background(), tc.initialStateFile))
+			require.NoError(t, sync(context.Background(), tc.initialStateFile))
 
 			out, err := diff(tc.stateFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, expectedOutputMasked, out)
 		})
 	}
@@ -607,11 +608,11 @@ func Test_Diff_Masked_NewerThan3x(t *testing.T) {
 			setup(t)
 
 			// initialize state
-			assert.NoError(t, sync(context.Background(), tc.initialStateFile))
+			require.NoError(t, sync(context.Background(), tc.initialStateFile))
 
 			out, err := diff(tc.stateFile, "--json-output")
-			assert.NoError(t, err)
-			assert.Equal(t, expectedOutputMaskedJSON30x, out)
+			require.NoError(t, err)
+			assert.JSONEq(t, expectedOutputMaskedJSON30x, out)
 		})
 	}
 	for _, tc := range tests {
@@ -623,11 +624,11 @@ func Test_Diff_Masked_NewerThan3x(t *testing.T) {
 			setup(t)
 
 			// initialize state
-			assert.NoError(t, sync(context.Background(), tc.initialStateFile))
+			require.NoError(t, sync(context.Background(), tc.initialStateFile))
 
 			out, err := diff(tc.stateFile, "--json-output")
-			assert.NoError(t, err)
-			assert.Equal(t, expectedOutputMaskedJSON, out)
+			require.NoError(t, err)
+			assert.JSONEq(t, expectedOutputMaskedJSON, out)
 		})
 	}
 }
@@ -658,10 +659,10 @@ func Test_Diff_Unmasked_OlderThan3x(t *testing.T) {
 			setup(t)
 
 			// initialize state
-			assert.NoError(t, sync(context.Background(), tc.initialStateFile))
+			require.NoError(t, sync(context.Background(), tc.initialStateFile))
 
 			out, err := diff(tc.stateFile, "--no-mask-deck-env-vars-value")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, expectedOutputUnMasked, out)
 		})
 	}
@@ -674,11 +675,11 @@ func Test_Diff_Unmasked_OlderThan3x(t *testing.T) {
 			setup(t)
 
 			// initialize state
-			assert.NoError(t, sync(context.Background(), tc.initialStateFile))
+			require.NoError(t, sync(context.Background(), tc.initialStateFile))
 
 			out, err := diff(tc.stateFile, "--no-mask-deck-env-vars-value", "--json-output")
-			assert.NoError(t, err)
-			assert.Equal(t, expectedOutputUnMaskedJSON, out)
+			require.NoError(t, err)
+			assert.JSONEq(t, expectedOutputUnMaskedJSON, out)
 		})
 	}
 }
@@ -709,10 +710,10 @@ func Test_Diff_Unmasked_NewerThan3x(t *testing.T) {
 			setup(t)
 
 			// initialize state
-			assert.NoError(t, sync(context.Background(), tc.initialStateFile))
+			require.NoError(t, sync(context.Background(), tc.initialStateFile))
 
 			out, err := diff(tc.stateFile, "--no-mask-deck-env-vars-value")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, expectedOutputUnMasked, out)
 		})
 	}
@@ -725,11 +726,11 @@ func Test_Diff_Unmasked_NewerThan3x(t *testing.T) {
 			setup(t)
 
 			// initialize state
-			assert.NoError(t, sync(context.Background(), tc.initialStateFile))
+			require.NoError(t, sync(context.Background(), tc.initialStateFile))
 
 			out, err := diff(tc.stateFile, "--no-mask-deck-env-vars-value", "--json-output")
-			assert.NoError(t, err)
-			assert.Equal(t, expectedOutputUnMaskedJSON30x, out)
+			require.NoError(t, err)
+			assert.JSONEq(t, expectedOutputUnMaskedJSON30x, out)
 		})
 	}
 	for _, tc := range tests {
@@ -741,11 +742,11 @@ func Test_Diff_Unmasked_NewerThan3x(t *testing.T) {
 			setup(t)
 
 			// initialize state
-			assert.NoError(t, sync(context.Background(), tc.initialStateFile))
+			require.NoError(t, sync(context.Background(), tc.initialStateFile))
 
 			out, err := diff(tc.stateFile, "--no-mask-deck-env-vars-value", "--json-output")
-			assert.NoError(t, err)
-			assert.Equal(t, expectedOutputUnMaskedJSON, out)
+			require.NoError(t, err)
+			assert.JSONEq(t, expectedOutputUnMaskedJSON, out)
 		})
 	}
 }
@@ -776,10 +777,10 @@ func Test_Diff_NoDiffUnorderedArray(t *testing.T) {
 
 			// test that the diff command does not return any changes when
 			// array fields are not sorted.
-			assert.NoError(t, sync(context.Background(), tc.stateFile, "--timeout", "60"))
+			require.NoError(t, sync(context.Background(), tc.stateFile, "--timeout", "60"))
 
 			out, err := diff(tc.stateFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, emptyOutput, out)
 			reset(t)
 		})
@@ -795,10 +796,10 @@ func Test_Diff_NoDiffCompressedTarget(t *testing.T) {
 	// test that the diff command does not return any changes when
 	// target is a compressed IPv6.
 	stateFile := "testdata/diff/005-no-diff-target/kong.yaml"
-	assert.NoError(t, sync(context.Background(), stateFile))
+	require.NoError(t, sync(context.Background(), stateFile))
 
 	out, err := diff(stateFile)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, emptyOutput, out)
 	reset(t)
 }

--- a/tests/integration/dump_test.go
+++ b/tests/integration/dump_test.go
@@ -27,18 +27,18 @@ func Test_Dump_SelectTags_30(t *testing.T) {
 			runWhen(t, "kong", ">=3.0.0 <3.1.0")
 			setup(t)
 
-			assert.NoError(t, sync(context.Background(), tc.stateFile))
+			require.NoError(t, sync(context.Background(), tc.stateFile))
 
 			output, err := dump(
 				"--select-tag", "managed-by-deck",
 				"--select-tag", "org-unit-42",
 				"-o", "-",
 			)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			expected, err := readFile(tc.expectedFile)
-			assert.NoError(t, err)
-			assert.Equal(t, output, expected)
+			require.NoError(t, err)
+			assert.Equal(t, expected, output)
 		})
 	}
 }
@@ -74,18 +74,18 @@ func Test_Dump_SelectTags_3x(t *testing.T) {
 			runWhen(t, "kong", tc.runWhen)
 			setup(t)
 
-			assert.NoError(t, sync(context.Background(), tc.stateFile))
+			require.NoError(t, sync(context.Background(), tc.stateFile))
 
 			output, err := dump(
 				"--select-tag", "managed-by-deck",
 				"--select-tag", "org-unit-42",
 				"-o", "-",
 			)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			expected, err := readFile(tc.expectedFile)
-			assert.NoError(t, err)
-			assert.Equal(t, output, expected)
+			require.NoError(t, err)
+			assert.Equal(t, expected, output)
 		})
 	}
 }
@@ -160,7 +160,7 @@ func Test_Dump_SkipConsumers(t *testing.T) {
 			tc.runWhen(t)
 			setup(t)
 
-			assert.NoError(t, sync(context.Background(), tc.stateFile))
+			require.NoError(t, sync(context.Background(), tc.stateFile))
 
 			var (
 				output string
@@ -176,10 +176,10 @@ func Test_Dump_SkipConsumers(t *testing.T) {
 					"-o", "-",
 				)
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			expected, err := readFile(tc.expectedFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, expected, output)
 		})
 	}
@@ -210,7 +210,7 @@ func Test_Dump_SkipConsumers_Konnect(t *testing.T) {
 			runWhenKonnect(t)
 			setup(t)
 
-			assert.NoError(t, sync(context.Background(), tc.stateFile))
+			require.NoError(t, sync(context.Background(), tc.stateFile))
 
 			var (
 				output string
@@ -226,10 +226,10 @@ func Test_Dump_SkipConsumers_Konnect(t *testing.T) {
 					"-o", "-",
 				)
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			expected, err := readFile(tc.expectedFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, expected, output)
 		})
 	}
@@ -263,7 +263,7 @@ func Test_Dump_KonnectRename(t *testing.T) {
 			runWhenKonnect(t)
 			setup(t)
 
-			assert.NoError(t, sync(context.Background(), tc.stateFile))
+			require.NoError(t, sync(context.Background(), tc.stateFile))
 
 			var (
 				output string
@@ -273,10 +273,10 @@ func Test_Dump_KonnectRename(t *testing.T) {
 			flags = append(flags, tc.flags...)
 			output, err = dump(flags...)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			expected, err := readFile(tc.expectedFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, expected, output)
 		})
 	}
@@ -291,10 +291,10 @@ func Test_Dump_ConsumerGroupConsumersWithCustomID(t *testing.T) {
 	var output string
 	flags := []string{"-o", "-", "--with-id"}
 	output, err := dump(flags...)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expected, err := readFile("testdata/sync/028-consumer-group-consumers-custom_id/kong.yaml")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expected, output)
 }
 
@@ -307,10 +307,10 @@ func Test_Dump_ConsumerGroupConsumersWithCustomID_Konnect(t *testing.T) {
 	var output string
 	flags := []string{"-o", "-", "--with-id"}
 	output, err := dump(flags...)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expected, err := readFile("testdata/dump/003-consumer-group-consumers-custom_id/konnect.yaml")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expected, output)
 }
 
@@ -343,10 +343,10 @@ func Test_Dump_FilterChains(t *testing.T) {
 			var output string
 			flags := []string{"-o", "-"}
 			output, err := dump(flags...)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			expected, err := readFile(tc.expected)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, expected, output)
 		})
 	}
@@ -426,7 +426,7 @@ func Test_SkipConsumersWithConsumerGroups(t *testing.T) {
 			tc.runWhen(t)
 			setup(t)
 
-			assert.NoError(t, sync(context.Background(), tc.stateFile))
+			require.NoError(t, sync(context.Background(), tc.stateFile))
 
 			var (
 				output string
@@ -448,10 +448,10 @@ func Test_SkipConsumersWithConsumerGroups(t *testing.T) {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			expected, err := readFile(tc.expectedFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, expected, output)
 		})
 	}

--- a/tests/integration/file_convert_test.go
+++ b/tests/integration/file_convert_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 )
 
@@ -50,23 +51,23 @@ func Test_FileConvert(t *testing.T) {
 			)
 
 			if tc.errorExpected {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.errorString)
 
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			var expectedOutput interface{}
 			var currentOutput interface{}
 			content, err := os.ReadFile(tc.expectedOutputFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			err = yaml.Unmarshal(content, &expectedOutput)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = yaml.Unmarshal([]byte(output), &currentOutput)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, expectedOutput, currentOutput)
 		})
 	}

--- a/tests/integration/lint_test.go
+++ b/tests/integration/lint_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/kong/deck/cmd"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 )
 
@@ -32,7 +33,7 @@ func Test_LintPlain(t *testing.T) {
 				"-s", tc.stateFile,
 				tc.rulesetFile,
 			)
-			assert.Error(t, err)
+			require.Error(t, err)
 
 			assert.Contains(t, output, "Linting Violations: 2")
 			assert.Contains(t, output, "Failures: 1")
@@ -129,27 +130,27 @@ func Test_LintStructured(t *testing.T) {
 				lintOpts = append(lintOpts, "--fail-severity", tc.failSeverity)
 			}
 			output, err := lint(lintOpts...)
-			assert.Error(t, err)
+			require.Error(t, err)
 
 			var expectedErrors, outputErrors lintErrors
 			// get expected errors from file
 			content, err := os.ReadFile(tc.expectedFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			if tc.format == "yaml" {
 				err = yaml.Unmarshal(content, &expectedErrors)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				// parse result errors from lint command
 				err = yaml.Unmarshal([]byte(output), &outputErrors)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			} else {
 				err = json.Unmarshal(content, &expectedErrors)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				// parse result errors from lint command
 				err = json.Unmarshal([]byte(output), &outputErrors)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 
 			cmpOpts := []cmp.Option{

--- a/tests/integration/render_test.go
+++ b/tests/integration/render_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_RenderPlain(t *testing.T) {
@@ -60,10 +61,10 @@ func Test_RenderPlain(t *testing.T) {
 			}
 
 			output, err := render(renderOpts...)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			expected, err := readFile(tc.expectedFile)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, expected, output)
 		})
 	}

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -3636,7 +3636,7 @@ func Test_Sync_Unsupported_Formats(t *testing.T) {
 			setup(t)
 
 			err := sync(context.Background(), tc.kongFile)
-			assert.Equal(t, err, tc.expectedError)
+			assert.Equal(t, tc.expectedError, err)
 		})
 	}
 }
@@ -3794,7 +3794,7 @@ func Test_Sync_Vault(t *testing.T) {
 			// use simple http client with https should result
 			// in a failure due missing certificate.
 			_, err := client.Get("https://localhost:8443/r1")
-			assert.NotNil(t, err)
+			require.Error(t, err)
 
 			// use transport with wrong CA cert this should result
 			// in a failure due to unknown authority.
@@ -3811,7 +3811,7 @@ func Test_Sync_Vault(t *testing.T) {
 			}
 
 			_, err = client.Get("https://localhost:8443/r1")
-			assert.NotNil(t, err)
+			require.Error(t, err)
 
 			// use transport with good CA cert should pass
 			// if referenced secrets are resolved correctly
@@ -3829,8 +3829,8 @@ func Test_Sync_Vault(t *testing.T) {
 			}
 
 			res, err := client.Get("https://localhost:8443/r1")
-			assert.NoError(t, err)
-			assert.Equal(t, res.StatusCode, http.StatusOK)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, res.StatusCode)
 		})
 	}
 }
@@ -4258,12 +4258,12 @@ func Test_Sync_ConsumerGroupsRLAFrom31(t *testing.T) {
 
 			// test 'foo' consumer (part of 'gold' group)
 			req, err := http.NewRequest("GET", "http://localhost:8000/r1", nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			req.Header.Add("apikey", "i-am-special")
 			n := 0
 			for n < 11 {
 				resp, err := client.Do(req)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				defer resp.Body.Close()
 				if resp.StatusCode == http.StatusTooManyRequests {
 					break
@@ -4274,12 +4274,12 @@ func Test_Sync_ConsumerGroupsRLAFrom31(t *testing.T) {
 
 			// test 'bar' consumer (part of 'silver' group)
 			req, err = http.NewRequest("GET", "http://localhost:8000/r1", nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			req.Header.Add("apikey", "i-am-not-so-special")
 			n = 0
 			for n < 11 {
 				resp, err := client.Do(req)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				defer resp.Body.Close()
 				if resp.StatusCode == http.StatusTooManyRequests {
 					break
@@ -4290,12 +4290,12 @@ func Test_Sync_ConsumerGroupsRLAFrom31(t *testing.T) {
 
 			// test 'baz' consumer (not part of any group)
 			req, err = http.NewRequest("GET", "http://localhost:8000/r1", nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			req.Header.Add("apikey", "i-am-just-average")
 			n = 0
 			for n < 11 {
 				resp, err := client.Do(req)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				defer resp.Body.Close()
 				if resp.StatusCode == http.StatusTooManyRequests {
 					break
@@ -5676,12 +5676,12 @@ func Test_Sync_ConsumerGroupsScopedPlugins(t *testing.T) {
 
 			// test 'foo' consumer (part of 'gold' group)
 			req, err := http.NewRequest("GET", "http://localhost:8000/r1", nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			req.Header.Add("apikey", "i-am-special")
 			n := 0
 			for n < 11 {
 				resp, err := client.Do(req)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				defer resp.Body.Close()
 				if resp.StatusCode == http.StatusTooManyRequests {
 					break
@@ -5692,12 +5692,12 @@ func Test_Sync_ConsumerGroupsScopedPlugins(t *testing.T) {
 
 			// test 'bar' consumer (part of 'silver' group)
 			req, err = http.NewRequest("GET", "http://localhost:8000/r1", nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			req.Header.Add("apikey", "i-am-not-so-special")
 			n = 0
 			for n < 11 {
 				resp, err := client.Do(req)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				defer resp.Body.Close()
 				if resp.StatusCode == http.StatusTooManyRequests {
 					break
@@ -5708,12 +5708,12 @@ func Test_Sync_ConsumerGroupsScopedPlugins(t *testing.T) {
 
 			// test 'baz' consumer (not part of any group)
 			req, err = http.NewRequest("GET", "http://localhost:8000/r1", nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			req.Header.Add("apikey", "i-am-just-average")
 			n = 0
 			for n < 11 {
 				resp, err := client.Do(req)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				defer resp.Body.Close()
 				if resp.StatusCode == http.StatusTooManyRequests {
 					break
@@ -5970,12 +5970,12 @@ func Test_Sync_ConsumerGroupsScopedPlugins_After360(t *testing.T) {
 
 			// test 'foo' consumer (part of 'gold' group)
 			req, err := http.NewRequest("GET", "http://localhost:8000/r1", nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			req.Header.Add("apikey", "i-am-special")
 			n := 0
 			for n < 11 {
 				resp, err := client.Do(req)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				defer resp.Body.Close()
 				if resp.StatusCode == http.StatusTooManyRequests {
 					break
@@ -5986,12 +5986,12 @@ func Test_Sync_ConsumerGroupsScopedPlugins_After360(t *testing.T) {
 
 			// test 'bar' consumer (part of 'silver' group)
 			req, err = http.NewRequest("GET", "http://localhost:8000/r1", nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			req.Header.Add("apikey", "i-am-not-so-special")
 			n = 0
 			for n < 11 {
 				resp, err := client.Do(req)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				defer resp.Body.Close()
 				if resp.StatusCode == http.StatusTooManyRequests {
 					break
@@ -6002,12 +6002,12 @@ func Test_Sync_ConsumerGroupsScopedPlugins_After360(t *testing.T) {
 
 			// test 'baz' consumer (not part of any group)
 			req, err = http.NewRequest("GET", "http://localhost:8000/r1", nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			req.Header.Add("apikey", "i-am-just-average")
 			n = 0
 			for n < 11 {
 				resp, err := client.Do(req)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				defer resp.Body.Close()
 				if resp.StatusCode == http.StatusTooManyRequests {
 					break
@@ -6044,7 +6044,7 @@ func Test_Sync_ConsumerGroupsScopedPlugins_Post340(t *testing.T) {
 
 			err := sync(context.Background(), tc.kongFile)
 			if tc.expectedError == nil {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			} else {
 				assert.EqualError(t, err, tc.expectedError.Error())
 			}
@@ -6275,7 +6275,7 @@ func Test_Sync_KonnectRenameErrors(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			err := sync(context.Background(), tc.kongFile, tc.flags...)
-			assert.Equal(t, err, tc.expectedError)
+			assert.Equal(t, tc.expectedError, err)
 		})
 	}
 }
@@ -6994,7 +6994,7 @@ func Test_Sync_DegraphqlRoutes(t *testing.T) {
 		degraphqlRoutes, err := newState.DegraphqlRoutes.GetAll()
 		require.NoError(t, err)
 
-		assert.Equal(t, 1, len(degraphqlRoutes))
+		require.Len(t, degraphqlRoutes, 1)
 
 		d := degraphqlRoutes[0]
 		assert.Equal(t, "/foo", *d.URI)
@@ -7013,7 +7013,7 @@ func Test_Sync_DegraphqlRoutes(t *testing.T) {
 		degraphqlRoutes, err := newState.DegraphqlRoutes.GetAll()
 		require.NoError(t, err)
 
-		assert.Equal(t, 1, len(degraphqlRoutes))
+		require.Len(t, degraphqlRoutes, 1)
 
 		d := degraphqlRoutes[0]
 
@@ -7046,7 +7046,7 @@ func Test_Sync_DegraphqlRoutes_Konnect(t *testing.T) {
 		degraphqlRoutes, err := newState.DegraphqlRoutes.GetAll()
 		require.NoError(t, err)
 
-		assert.Equal(t, 1, len(degraphqlRoutes))
+		require.Len(t, degraphqlRoutes, 1)
 
 		d := degraphqlRoutes[0]
 		assert.Equal(t, "/foo", *d.URI)
@@ -7065,7 +7065,7 @@ func Test_Sync_DegraphqlRoutes_Konnect(t *testing.T) {
 		degraphqlRoutes, err := newState.DegraphqlRoutes.GetAll()
 		require.NoError(t, err)
 
-		assert.Equal(t, 1, len(degraphqlRoutes))
+		require.Len(t, degraphqlRoutes, 1)
 
 		d := degraphqlRoutes[0]
 

--- a/tests/integration/validate_test.go
+++ b/tests/integration/validate_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -103,14 +104,14 @@ func Test_Validate_Konnect(t *testing.T) {
 			err := validate(ONLINE, validateOpts...)
 
 			if tc.errorExpected {
-				assert.Error(t, err)
+				require.Error(t, err)
 				if tc.errorString != "" {
 					assert.Contains(t, err.Error(), tc.errorString)
 				}
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 	}
 }
@@ -159,7 +160,7 @@ func Test_Validate_File(t *testing.T) {
 			validateOpts = append(validateOpts, tc.additionalArgs...)
 
 			err := validate(OFFLINE, validateOpts...)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 	}
 }
@@ -209,7 +210,7 @@ func Test_Validate_Gateway(t *testing.T) {
 			validateOpts = append(validateOpts, tc.additionalArgs...)
 
 			err := validate(ONLINE, validateOpts...)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 	}
 }
@@ -265,7 +266,7 @@ func Test_Validate_Gateway_EE(t *testing.T) {
 			validateOpts = append(validateOpts, tc.additionalArgs...)
 
 			err := validate(ONLINE, validateOpts...)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 	}
 }


### PR DESCRIPTION
Add https://github.com/Antonboom/testifylint to golangci-lint to catch common testify mistakes.
