### PR TITLE
chore: added changelog for v1.46.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Table of Contents
 
-- [v1.46.0](#v1450)
+- [v1.46.0](#v1460)
 - [v1.45.0](#v1450)
 - [v1.44.2](#v1442)
 - [v1.44.1](#v1441)
@@ -111,7 +111,7 @@
 - [v0.1.0](#v010)
 
 ## [v1.46.0]
-> Release date: 2025/03/27
+> Release date: 2025/04/01
 
 ### Added
 - Added support for `partials` entity in deck.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [v1.46.0](#v1450)
 - [v1.45.0](#v1450)
 - [v1.44.2](#v1442)
 - [v1.44.1](#v1441)
@@ -108,6 +109,27 @@
 - [v0.3.0](#v030)
 - [v0.2.0](#v020)
 - [v0.1.0](#v010)
+
+## [v1.46.0]
+> Release date: 2025/03/27
+
+### Added
+- Added support for `partials` entity in deck.
+[#1570](https://github.com/Kong/deck/pull/1570)
+[go-database-reconciler #](https://github.com/Kong/go-database-reconciler/pull/215)
+[go-kong #](https://github.com/Kong/go-kong/pull/507)
+
+### Fixed
+- Updated `golang.org/x/net` from 0.34.0 to 0.36.0 to
+account for vulnerability [CVE-2025-22870](https://github.com/advisories/GHSA-qxp5-gwg8-xv66)
+- Fixed false errors coming for consumer creation while using
+default_lookup_tags for consumer_groups, specifically when tags
+on the consumer_group and consumer didn't match.
+[#1576](https://github.com/Kong/deck/pull/1576)
+[go-database-reconciler](https://github.com/Kong/go-database-reconciler/pull/228)
+- Fixed `deck file kong2kic` command to correctly process
+top-level plugin and route entities.
+[#1555](https://github.com/Kong/deck/pull/1555)
 
 ## [v1.45.0]
 > Release date: 2025/02/26
@@ -2032,6 +2054,7 @@ No breaking changes have been introduced in this release.
 
 Debut release of decK
 
+[v1.46.0]: https://github.com/Kong/deck/compare/v1.45.0...v1.46.0
 [v1.45.0]: https://github.com/Kong/deck/compare/v1.44.2...v1.45.0
 [v1.44.2]: https://github.com/Kong/deck/compare/v1.44.1...v1.44.2
 [v1.44.1]: https://github.com/Kong/deck/compare/v1.44.0...v1.44.1

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ the GitHub [release page](https://github.com/kong/deck/releases)
 or install by downloading the binary:
 
 ```shell
-$ curl -sL https://github.com/kong/deck/releases/download/v1.45.0/deck_1.45.0_linux_amd64.tar.gz -o deck.tar.gz
+$ curl -sL https://github.com/kong/deck/releases/download/v1.46.0/deck_1.46.0_linux_amd64.tar.gz -o deck.tar.gz
 $ tar -xf deck.tar.gz -C /tmp
 $ sudo cp /tmp/deck /usr/local/bin/
 ```
@@ -84,7 +84,7 @@ If you are on Windows, you can download the binary from the GitHub
 [release page](https://github.com/kong/deck/releases) or via PowerShell:
 
 ```shell
-$ curl -sL https://github.com/kong/deck/releases/download/v1.45.0/deck_1.45.0_windows_amd64.tar.gz -o deck.tar.gz
+$ curl -sL https://github.com/kong/deck/releases/download/v1.46.0/deck_1.46.0_windows_amd64.tar.gz -o deck.tar.gz
 $ tar -xzvf deck.tar.gz
 ```
 


### PR DESCRIPTION
go-database-reconciler diff: https://github.com/Kong/go-database-reconciler/compare/v1.20.3...v1.22.0
go-kong diff: https://github.com/Kong/go-kong/compare/v0.63.0...v0.64.1

Apart from the changes listed in changelog, the following would be shipped alongside:
- https://github.com/Kong/deck/pull/1550