### PR TITLE
fix: tests failing due to missing timeout key

### DIFF
--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -7732,7 +7732,7 @@ func Test_Sync_SkipConsumersWithConsumerGroups_Konnect(t *testing.T) {
 }
 
 func Test_Sync_Partials_Plugins(t *testing.T) {
-	runWhenEnterpriseOrKonnect(t, ">=3.10.0")
+	runWhen(t, "enterprise", ">=3.10.0")
 
 	client, err := getTestClient()
 	require.NoError(t, err)
@@ -7763,6 +7763,114 @@ func Test_Sync_Partials_Plugins(t *testing.T) {
 		"ssl":                      bool(false),
 		"ssl_verify":               bool(false),
 		"username":                 nil,
+	}
+
+	t.Run("create a partial and link to a plugin via name", func(t *testing.T) {
+		require.NoError(t, sync(ctx, "testdata/sync/039-partials/kong.yaml"))
+		t.Cleanup(func() {
+			reset(t)
+		})
+
+		newState, err := fetchCurrentState(ctx, client, dumpConfig, t)
+		require.NoError(t, err)
+
+		// check for partial
+		partials, err := newState.Partials.GetAll()
+		require.NoError(t, err)
+		require.NotNil(t, partials)
+
+		require.Len(t, partials, 1)
+		assert.Equal(t, "my-ee-partial", *partials[0].Name)
+		assert.Equal(t, "redis-ee", *partials[0].Type)
+		assert.IsType(t, kong.Configuration{}, partials[0].Config)
+		assert.Equal(t, partialConfig, partials[0].Config)
+
+		// check for plugin
+		plugins, err := newState.Plugins.GetAll()
+		require.NoError(t, err)
+		require.NotNil(t, plugins)
+		require.Len(t, plugins, 1)
+		assert.Equal(t, "rate-limiting-advanced", *plugins[0].Name)
+		assert.IsType(t, []*kong.PartialLink{}, plugins[0].Partials)
+		require.Len(t, plugins[0].Partials, 1)
+		assert.Equal(t, *partials[0].ID, *plugins[0].Partials[0].ID)
+		assert.Equal(t, "config.redis", *plugins[0].Partials[0].Path)
+	})
+
+	t.Run("partial id is preserved if passed and linking can be done via id", func(t *testing.T) {
+		require.NoError(t, sync(ctx, "testdata/sync/039-partials/kong-ids.yaml"))
+		t.Cleanup(func() {
+			reset(t)
+		})
+
+		newState, err := fetchCurrentState(ctx, client, dumpConfig, t)
+		require.NoError(t, err)
+
+		// check for partial
+		partials, err := newState.Partials.GetAll()
+		require.NoError(t, err)
+		require.NotNil(t, partials)
+
+		require.Len(t, partials, 1)
+		assert.Equal(t, "13dc230d-d65e-439a-9f05-9fd71abfee4d", *partials[0].ID)
+		assert.Equal(t, "my-ee-partial", *partials[0].Name)
+		assert.Equal(t, "redis-ee", *partials[0].Type)
+		assert.IsType(t, kong.Configuration{}, partials[0].Config)
+		assert.Equal(t, partialConfig, partials[0].Config)
+
+		// check for plugin
+		plugins, err := newState.Plugins.GetAll()
+		require.NoError(t, err)
+		require.NotNil(t, plugins)
+		require.Len(t, plugins, 1)
+		assert.Equal(t, "rate-limiting-advanced", *plugins[0].Name)
+		assert.IsType(t, []*kong.PartialLink{}, plugins[0].Partials)
+		require.Len(t, plugins[0].Partials, 1)
+		assert.Equal(t, "13dc230d-d65e-439a-9f05-9fd71abfee4d", *plugins[0].Partials[0].ID)
+		assert.Equal(t, "config.redis", *plugins[0].Partials[0].Path)
+	})
+
+	t.Run("linking to a plugin fails in case of non-existent partial", func(t *testing.T) {
+		err := sync(ctx, "testdata/sync/039-partials/kong-wrong.yaml")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "partial non-existent-partial for plugin rate-limiting-advanced: entity not found")
+	})
+}
+
+func Test_Sync_Partials_Plugins_Konnect(t *testing.T) {
+	runWhen(t, "konnect", "")
+	setDefaultKonnectControlPlane(t)
+
+	client, err := getTestClient()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	dumpConfig := deckDump.Config{}
+
+	partialConfig := kong.Configuration{
+		"cluster_max_redirections": float64(5),
+		"cluster_nodes":            nil,
+		"connect_timeout":          float64(2000),
+		"connection_is_proxied":    bool(false),
+		"database":                 float64(0),
+		"host":                     string("127.0.0.1"),
+		"keepalive_backlog":        nil,
+		"keepalive_pool_size":      float64(256),
+		"password":                 nil,
+		"port":                     float64(6379),
+		"read_timeout":             float64(3001),
+		"send_timeout":             float64(2004),
+		"sentinel_master":          nil,
+		"sentinel_nodes":           nil,
+		"sentinel_password":        nil,
+		"sentinel_role":            nil,
+		"sentinel_username":        nil,
+		"server_name":              nil,
+		"ssl":                      bool(false),
+		"ssl_verify":               bool(false),
+		"username":                 nil,
+		"timeout":                  float64(2000),
 	}
 
 	t.Run("create a partial and link to a plugin via name", func(t *testing.T) {


### PR DESCRIPTION
Some tests for partials seem to be failing in konnect since a new property `timeout` is present in the response. ([link](https://github.com/Kong/deck/actions/runs/14245134517/job/39966070393?pr=1585) to a failing job)
The same is not present in Kong Enterprise GW.

So, I've separated the tests, and included the new property in the konnect tests.