### PR TITLE
fix: fixed foreign key reference under plugin config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/google/go-cmp v0.7.0
 	github.com/kong/go-apiops v0.1.41
-	github.com/kong/go-database-reconciler v1.22.3
-	github.com/kong/go-kong v0.65.0
+	github.com/kong/go-database-reconciler v1.22.4
+	github.com/kong/go-kong v0.65.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.6

--- a/go.sum
+++ b/go.sum
@@ -246,10 +246,10 @@ github.com/klauspost/cpuid/v2 v2.2.5 h1:0E5MSMDEoAulmXNFquVs//DdoomxaoTY1kUhbc/q
 github.com/klauspost/cpuid/v2 v2.2.5/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/kong/go-apiops v0.1.41 h1:1KXbQqyhO2E4nEnXJNqUDmHZU/LQ1U7Zoi+MAlcM2P0=
 github.com/kong/go-apiops v0.1.41/go.mod h1:sATq9Tz+ivzHKZU+tDXkRtEZnf64xroU3lgv3yXqP4I=
-github.com/kong/go-database-reconciler v1.22.3 h1:H7austovtuMGWnRgpP8pQPAJXknSCnTHgwRyO6ilWJg=
-github.com/kong/go-database-reconciler v1.22.3/go.mod h1:Jlo4eEe0/PHd2dIkWTH9tFfShydRwRxY09dZvKZBelU=
-github.com/kong/go-kong v0.65.0 h1:dZT+hiMhy7CQsrc9W5nHv3cFJGBGTrwlZhC5MLuf9H8=
-github.com/kong/go-kong v0.65.0/go.mod h1:sqdysTKrXIJ6mpxHwTwjgZhLW7jR1/puczTXHLUwJaE=
+github.com/kong/go-database-reconciler v1.22.4 h1:wTDmlDe1UdZrxjXN4D148HJ8cPkUJVjEk2EAgUwWAAY=
+github.com/kong/go-database-reconciler v1.22.4/go.mod h1:Usj3Eaj7H9WN2b5DQgaJQfg1mcbI0hBIY7fWc353jNg=
+github.com/kong/go-kong v0.65.1 h1:CM+8NlF+VbJckTxP2hGmSPKhA1GMliitXjQ7vJiPkaE=
+github.com/kong/go-kong v0.65.1/go.mod h1:sqdysTKrXIJ6mpxHwTwjgZhLW7jR1/puczTXHLUwJaE=
 github.com/kong/go-slugify v1.0.0 h1:vCFAyf2sdoSlBtLcrmDWUFn0ohlpKiKvQfXZkO5vSKY=
 github.com/kong/go-slugify v1.0.0/go.mod h1:dbR2h3J2QKXQ1k0aww6cN7o4cIcwlWflr6RKRdcoaiw=
 github.com/kong/kubernetes-configuration v1.1.0 h1:zCj7QlOiZgwQ2wSNlVNR0K6Z+plXTalfihtDzLXQWzs=

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -8441,3 +8441,146 @@ func Test_Sync_Avoid_Consumer_Group_Overwrite_On_Select_Tag_Mismatch_With_ID_Ent
 		})
 	}
 }
+
+// test scope:
+//
+// - >=2.8.0 <3.0.0
+func Test_Sync_Plugins_Nested_Foreign_Keys(t *testing.T) {
+	runWhenKongOrKonnect(t, ">=2.8.0 <3.0.0")
+	setup(t)
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		stateFile string
+	}{
+		{
+			name:      "plugins with consumer reference - via name",
+			stateFile: "testdata/sync/041-plugins-nested-foreign-keys/1_1/kong-consumers-via-names.yaml",
+		},
+		{
+			name:      "plugins with consumer reference - via id",
+			stateFile: "testdata/sync/041-plugins-nested-foreign-keys/1_1/kong-consumers-via-ids.yaml",
+		},
+		{
+			name:      "plugins with route reference - via name",
+			stateFile: "testdata/sync/041-plugins-nested-foreign-keys/1_1/kong-routes-via-names.yaml",
+		},
+		{
+			name:      "plugins with route reference - via id",
+			stateFile: "testdata/sync/041-plugins-nested-foreign-keys/1_1/kong-routes-via-ids.yaml",
+		},
+		{
+			name:      "plugins with service reference - via name",
+			stateFile: "testdata/sync/041-plugins-nested-foreign-keys/1_1/kong-services-via-ids.yaml",
+		},
+		{
+			name:      "plugins with service reference - via id",
+			stateFile: "testdata/sync/041-plugins-nested-foreign-keys/1_1/kong-services-via-ids.yaml",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reset(t)
+			err := sync(ctx, tc.stateFile)
+			require.NoError(t, err)
+
+			// re-sync with no error
+			err = sync(ctx, tc.stateFile)
+			require.NoError(t, err)
+		})
+	}
+}
+
+// test scope:
+//
+// - >=3.0.0
+// - konnect
+func Test_Sync_Plugins_Nested_Foreign_Keys_3x(t *testing.T) {
+	runWhenKongOrKonnect(t, ">=3.0.0")
+	setup(t)
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		stateFile string
+	}{
+		{
+			name:      "plugins with consumer reference - via name",
+			stateFile: "testdata/sync/041-plugins-nested-foreign-keys/kong3x-consumers-via-names.yaml",
+		},
+		{
+			name:      "plugins with consumer reference - via id",
+			stateFile: "testdata/sync/041-plugins-nested-foreign-keys/kong3x-consumers-via-ids.yaml",
+		},
+		{
+			name:      "plugins with route reference - via name",
+			stateFile: "testdata/sync/041-plugins-nested-foreign-keys/kong3x-routes-via-names.yaml",
+		},
+		{
+			name:      "plugins with route reference - via id",
+			stateFile: "testdata/sync/041-plugins-nested-foreign-keys/kong3x-routes-via-ids.yaml",
+		},
+		{
+			name:      "plugins with service reference - via name",
+			stateFile: "testdata/sync/041-plugins-nested-foreign-keys/kong3x-services-via-ids.yaml",
+		},
+		{
+			name:      "plugins with service reference - via id",
+			stateFile: "testdata/sync/041-plugins-nested-foreign-keys/kong3x-services-via-ids.yaml",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reset(t)
+			err := sync(ctx, tc.stateFile)
+			require.NoError(t, err)
+
+			// re-sync with no error
+			err = sync(ctx, tc.stateFile)
+			require.NoError(t, err)
+		})
+	}
+}
+
+// test scope:
+//
+// - >=3.0.0+enterprise
+// - konnect
+func Test_Sync_Plugins_Nested_Foreign_Keys_EE_3x(t *testing.T) {
+	// prior versions don't support a consumer_group foreign key with a value
+	runWhenEnterpriseOrKonnect(t, ">=3.6.0")
+	setup(t)
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		stateFile string
+	}{
+		{
+			name:      "plugins with consumer-group reference - via name",
+			stateFile: "testdata/sync/041-plugins-nested-foreign-keys/kong3x-consumer-groups-via-names.yaml",
+		},
+		{
+			name:      "plugins with consumer-group reference - via id",
+			stateFile: "testdata/sync/041-plugins-nested-foreign-keys/kong3x-consumer-groups-via-ids.yaml",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reset(t)
+			err := sync(ctx, tc.stateFile)
+			require.NoError(t, err)
+
+			// re-sync with no error
+			err = sync(ctx, tc.stateFile)
+			require.NoError(t, err)
+		})
+	}
+}

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -8338,7 +8338,7 @@ func Test_Sync_Avoid_Consumer_Group_Overwrite_On_Select_Tag_Mismatch_With_ID_Ent
 //
 // - >=2.8.0 <3.0.0
 func Test_Sync_Plugins_Nested_Foreign_Keys(t *testing.T) {
-	runWhenKongOrKonnect(t, ">=2.8.0 <3.0.0")
+	runWhen(t, "kong", ">=2.8.0 <3.0.0")
 	setup(t)
 
 	ctx := context.Background()

--- a/tests/integration/testdata/diff/004-no-diff-plugin/protocol-initial-order-plugins.yaml
+++ b/tests/integration/testdata/diff/004-no-diff-plugin/protocol-initial-order-plugins.yaml
@@ -13,7 +13,6 @@ services:
     - grpc
     - https
   - name: prometheus
-    service: mockbin
     tags:
     - o11y
     config:

--- a/tests/integration/testdata/diff/004-no-diff-plugin/protocol-reordered-plugins.yaml
+++ b/tests/integration/testdata/diff/004-no-diff-plugin/protocol-reordered-plugins.yaml
@@ -13,7 +13,6 @@ services:
     - https
     - grpc
   - name: prometheus
-    service: mockbin
     tags:
     - o11y
     config:

--- a/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/1_1/kong-consumer-groups-via-ids.yaml
+++ b/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/1_1/kong-consumer-groups-via-ids.yaml
@@ -1,0 +1,44 @@
+_format_version: "1.1"
+
+consumer_groups:
+  - name: group-1
+    id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  - name: group-2
+    id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  routes:
+  - name: example-route-1
+    paths:
+    - /r1
+    plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer_group: 8ca63651-4068-4baa-b2b9-08dc99c296e0 # group-1's id
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http
+
+routes:
+- name: example-route-2
+  paths:
+  - /r2
+  service:
+    name: example-service
+  plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer_group: 8ca63651-4068-4baa-b2b9-08dc99c29666 # group-2's id
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http

--- a/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/1_1/kong-consumer-groups-via-names.yaml
+++ b/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/1_1/kong-consumer-groups-via-names.yaml
@@ -1,0 +1,44 @@
+_format_version: "1.1"
+
+consumer_groups:
+  - name: group-1
+    id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  - name: group-2
+    id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  routes:
+  - name: example-route-1
+    paths:
+    - /r1
+    plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer_group: group-1
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http
+
+routes:
+- name: example-route-2
+  paths:
+  - /r2
+  service:
+    name: example-service
+  plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer_group: group-2
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http

--- a/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/1_1/kong-consumers-via-ids.yaml
+++ b/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/1_1/kong-consumers-via-ids.yaml
@@ -1,0 +1,44 @@
+_format_version: "1.1"
+
+consumers:
+  - username: alice
+    id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  - username: bob
+    id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  routes:
+  - name: example-route-1
+    paths:
+    - /r1
+    plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer: 8ca63651-4068-4baa-b2b9-08dc99c296e0 # alice's id
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http
+
+routes:
+- name: example-route-2
+  paths:
+  - /r2
+  service:
+    name: example-service
+  plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer: 8ca63651-4068-4baa-b2b9-08dc99c29666 # bob's id
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http

--- a/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/1_1/kong-consumers-via-names.yaml
+++ b/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/1_1/kong-consumers-via-names.yaml
@@ -1,0 +1,44 @@
+_format_version: "1.1"
+
+consumers:
+  - username: alice
+    id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  - username: bob
+    id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  routes:
+  - name: example-route-1
+    paths:
+    - /r1
+    plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer: alice
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http
+
+routes:
+- name: example-route-2
+  paths:
+  - /r2
+  service:
+    name: example-service
+  plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer: bob
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http

--- a/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/1_1/kong-routes-via-ids.yaml
+++ b/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/1_1/kong-routes-via-ids.yaml
@@ -1,0 +1,38 @@
+_format_version: "1.1"
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  plugins:
+    - config:
+        minute: 100
+        policy: local
+      route: 8ca63651-4068-4baa-b2b9-08dc99c296e0 # example-route-1
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+    - config:
+        minute: 200
+        policy: local
+      route: 8ca63651-4068-4baa-b2b9-08dc99c29666 # example-route-2
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+
+routes:
+- name: example-route-1
+  id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  paths:
+  - /r1
+  service:
+    name: example-service
+- name: example-route-2
+  id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+  paths:
+  - /r2
+  service:
+    name: example-service

--- a/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/1_1/kong-routes-via-names.yaml
+++ b/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/1_1/kong-routes-via-names.yaml
@@ -1,0 +1,36 @@
+_format_version: "1.1"
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  plugins:
+    - config:
+        minute: 100
+        policy: local
+      route: example-route-1
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+    - config:
+        minute: 200
+        policy: local
+      route: example-route-2
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+
+routes:
+- name: example-route-1
+  paths:
+  - /r1
+  service:
+    name: example-service
+- name: example-route-2
+  paths:
+  - /r2
+  service:
+    name: example-service

--- a/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/1_1/kong-services-via-ids.yaml
+++ b/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/1_1/kong-services-via-ids.yaml
@@ -1,0 +1,24 @@
+_format_version: "1.1"
+
+services:
+- name: example-service
+  id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+  port: 3200
+  protocol: http
+  host: localhost
+
+routes:
+- name: example-route-1
+  paths:
+  - /r1
+  service:
+    name: example-service
+  plugins:
+    - config:
+        minute: 100
+        policy: local
+      service: 8ca63651-4068-4baa-b2b9-08dc99c29666
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http

--- a/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/1_1/kong-services-via-names.yaml
+++ b/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/1_1/kong-services-via-names.yaml
@@ -1,0 +1,23 @@
+_format_version: "1.1"
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+
+routes:
+- name: example-route-1
+  paths:
+  - /r1
+  service:
+    name: example-service
+  plugins:
+    - config:
+        minute: 100
+        policy: local
+      service: example-service
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http

--- a/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/kong3x-consumer-groups-via-ids.yaml
+++ b/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/kong3x-consumer-groups-via-ids.yaml
@@ -1,0 +1,44 @@
+_format_version: "3.0"
+
+consumer_groups:
+  - name: group-1
+    id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  - name: group-2
+    id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  routes:
+  - name: example-route-1
+    paths:
+    - ~/r1
+    plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer_group: 8ca63651-4068-4baa-b2b9-08dc99c296e0 # group-1's id
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http
+
+routes:
+- name: example-route-2
+  paths:
+  - ~/r2
+  service:
+    name: example-service
+  plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer_group: 8ca63651-4068-4baa-b2b9-08dc99c29666 # group-2's id
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http

--- a/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/kong3x-consumer-groups-via-names.yaml
+++ b/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/kong3x-consumer-groups-via-names.yaml
@@ -1,0 +1,44 @@
+_format_version: "3.0"
+
+consumer_groups:
+  - name: group-1
+    id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  - name: group-2
+    id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  routes:
+  - name: example-route-1
+    paths:
+    - ~/r1
+    plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer_group: group-1
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http
+
+routes:
+- name: example-route-2
+  paths:
+  - ~/r2
+  service:
+    name: example-service
+  plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer_group: group-2
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http

--- a/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/kong3x-consumers-via-ids.yaml
+++ b/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/kong3x-consumers-via-ids.yaml
@@ -1,0 +1,44 @@
+_format_version: "3.0"
+
+consumers:
+  - username: alice
+    id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  - username: bob
+    id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  routes:
+  - name: example-route-1
+    paths:
+    - ~/r1
+    plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer: 8ca63651-4068-4baa-b2b9-08dc99c296e0 # alice's id
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http
+
+routes:
+- name: example-route-2
+  paths:
+  - ~/r2
+  service:
+    name: example-service
+  plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer: 8ca63651-4068-4baa-b2b9-08dc99c29666 # bob's id
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http

--- a/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/kong3x-consumers-via-names.yaml
+++ b/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/kong3x-consumers-via-names.yaml
@@ -1,0 +1,44 @@
+_format_version: "3.0"
+
+consumers:
+  - username: alice
+    id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  - username: bob
+    id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  routes:
+  - name: example-route-1
+    paths:
+    - ~/r1
+    plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer: alice
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http
+
+routes:
+- name: example-route-2
+  paths:
+  - ~/r2
+  service:
+    name: example-service
+  plugins:
+      - config:
+          limit_by: consumer
+          minute: 6
+          policy: local
+        consumer: bob
+        enabled: true
+        name: rate-limiting
+        protocols:
+          - http

--- a/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/kong3x-routes-via-ids.yaml
+++ b/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/kong3x-routes-via-ids.yaml
@@ -1,0 +1,38 @@
+_format_version: "3.0"
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  plugins:
+    - config:
+        minute: 100
+        policy: local
+      route: 8ca63651-4068-4baa-b2b9-08dc99c296e0 # example-route-1
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+    - config:
+        minute: 200
+        policy: local
+      route: 8ca63651-4068-4baa-b2b9-08dc99c29666 # example-route-2
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+
+routes:
+- name: example-route-1
+  id: 8ca63651-4068-4baa-b2b9-08dc99c296e0
+  paths:
+  - ~/r1
+  service:
+    name: example-service
+- name: example-route-2
+  id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+  paths:
+  - ~/r2
+  service:
+    name: example-service

--- a/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/kong3x-routes-via-names.yaml
+++ b/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/kong3x-routes-via-names.yaml
@@ -1,0 +1,36 @@
+_format_version: "3.0"
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+  plugins:
+    - config:
+        minute: 100
+        policy: local
+      route: example-route-1
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+    - config:
+        minute: 200
+        policy: local
+      route: example-route-2
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http
+
+routes:
+- name: example-route-1
+  paths:
+  - ~/r1
+  service:
+    name: example-service
+- name: example-route-2
+  paths:
+  - ~/r2
+  service:
+    name: example-service

--- a/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/kong3x-services-via-ids.yaml
+++ b/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/kong3x-services-via-ids.yaml
@@ -1,0 +1,24 @@
+_format_version: "3.0"
+
+services:
+- name: example-service
+  id: 8ca63651-4068-4baa-b2b9-08dc99c29666
+  port: 3200
+  protocol: http
+  host: localhost
+
+routes:
+- name: example-route-1
+  paths:
+  - ~/r1
+  service:
+    name: example-service
+  plugins:
+    - config:
+        minute: 100
+        policy: local
+      service: 8ca63651-4068-4baa-b2b9-08dc99c29666
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http

--- a/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/kong3x-services-via-names.yaml
+++ b/tests/integration/testdata/sync/041-plugins-nested-foreign-keys/kong3x-services-via-names.yaml
@@ -1,0 +1,23 @@
+_format_version: "3.0"
+
+services:
+- name: example-service
+  port: 3200
+  protocol: http
+  host: localhost
+
+routes:
+- name: example-route-1
+  paths:
+  - ~/r1
+  service:
+    name: example-service
+  plugins:
+    - config:
+        minute: 100
+        policy: local
+      service: example-service
+      enabled: true
+      name: rate-limiting
+      protocols:
+        - http


### PR DESCRIPTION
This change updates gdr version to v1.22.4
Here, we have relaxed the restrictions
added in an earlier deck version to error
out in case of foreign keys under a plugin
config. Now, errors come up only if same
type of entity is nested under an entity.
This change has also fixed the resolution
of foreign keys in case names are used,
instead of IDs.