### PR TITLE
chore: release prep for v1.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [v1.47.0](#v1470)
 - [v1.46.3](#v1463)
 - [v1.46.2](#v1462)
 - [v1.46.1](#v1461)
@@ -112,6 +113,31 @@
 - [v0.3.0](#v030)
 - [v0.2.0](#v020)
 - [v0.1.0](#v010)
+
+## [v1.47.0]
+> Release date: 2025/04/29
+
+### Added
+- Extended `deck file convert` command to be used for configuration
+migrations between LTS versions `2.8` and `3.4`. The command can
+auto-fix the possible configurations and gives appropriate errors
+or warnings for the others.
+This is how it can be used: `deck file convert --from 2.8 --to 3.4
+--input-file kong-28x.yaml -o kong-34x.yaml`
+[#1610](https://github.com/Kong/deck/pull/1610)
+- `_format_version` string can be parametrised now and works well with
+`deck file merge` command as well as others.
+[#1605](https://github.com/Kong/deck/pull/1605)
+[go-apiops #259](https://github.com/Kong/go-apiops/pull/259)
+
+### Fixed
+- ID existence checks are limited to certificates now,
+restoring sync performance.
+[#1608](https://github.com/Kong/deck/pull/1608)
+[go-database-reconciler #254](https://github.com/Kong/go-database-reconciler/pull/254)
+- Bumped `golang.org/x/net` from 0.36.0 to 0.38.0 to account
+for [CVE-2025-22872](https://github.com/advisories/GHSA-vvgc-356p-c3xw)
+[#1601](https://github.com/Kong/deck/pull/1601)
 
 ## [v1.46.3]
 > Release date: 2025/04/10
@@ -2093,6 +2119,7 @@ No breaking changes have been introduced in this release.
 
 Debut release of decK
 
+[v1.47.0]: https://github.com/Kong/deck/compare/v1.46.3...v1.47.0
 [v1.46.3]: https://github.com/Kong/deck/compare/v1.46.2...v1.46.3
 [v1.46.2]: https://github.com/Kong/deck/compare/v1.46.1...v1.46.2
 [v1.46.1]: https://github.com/Kong/deck/compare/v1.46.0...v1.46.1

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ the GitHub [release page](https://github.com/kong/deck/releases)
 or install by downloading the binary:
 
 ```shell
-$ curl -sL https://github.com/kong/deck/releases/download/v1.46.3/deck_1.46.3_linux_amd64.tar.gz -o deck.tar.gz
+$ curl -sL https://github.com/kong/deck/releases/download/v1.47.0/deck_1.47.0_linux_amd64.tar.gz -o deck.tar.gz
 $ tar -xf deck.tar.gz -C /tmp
 $ sudo cp /tmp/deck /usr/local/bin/
 ```
@@ -84,7 +84,7 @@ If you are on Windows, you can download the binary from the GitHub
 [release page](https://github.com/kong/deck/releases) or via PowerShell:
 
 ```shell
-$ curl -sL https://github.com/kong/deck/releases/download/v1.46.3/deck_1.46.3_windows_amd64.tar.gz -o deck.tar.gz
+$ curl -sL https://github.com/kong/deck/releases/download/v1.47.0/deck_1.47.0_windows_amd64.tar.gz -o deck.tar.gz
 $ tar -xzvf deck.tar.gz
 ```
 


### PR DESCRIPTION
All Changes:

go-apiops: https://github.com/Kong/go-apiops/compare/v0.1.41...v0.1.42
gdr: https://github.com/Kong/go-database-reconciler/compare/v1.22.4...v1.22.5
deck: https://github.com/Kong/deck/compare/v1.46.3...main