### PR TITLE
tests: Add a simple regression test for sync performance

### DIFF
--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -1,0 +1,50 @@
+name: Performance Test
+
+concurrency:
+  # Run only for most recent commit in PRs but for all tags and commits on main
+  # Ref: https://docs.github.com/en/actions/using-jobs/using-concurrency
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+    - main
+  pull_request: {}
+
+jobs:
+  performance:
+    timeout-minutes: 5
+    strategy:
+      matrix:
+        kong_image:
+        - 'kong/kong-gateway:3.10'
+    env:
+      KONG_ANONYMOUS_REPORTS: "off"
+      KONG_IMAGE: ${{ matrix.kong_image }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{secrets.DOCKERHUB_PULL_USERNAME}}
+          password: ${{secrets.DOCKERHUB_PULL_TOKEN}}
+      - uses: Kong/kong-license@master
+        id: license
+        with:
+          op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      - name: Setup Kong
+        env:
+          KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
+        run: make setup-kong-ee
+      - name: Run performance tests
+        env:
+          KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
+        run: make test-performance

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,13 @@ test-integration:
 		$(GOTESTFLAGS) \
 		./tests/integration/...
 
+.PHONY: test-performance
+test-performance:
+	go test -v -count=1 -tags=performance \
+		-race \
+		$(GOTESTFLAGS) \
+		./tests/performance/...
+
 .PHONY: clean
 clean:
 	bash .ci/clean_kong.sh

--- a/tests/performance/sync_test.go
+++ b/tests/performance/sync_test.go
@@ -22,7 +22,7 @@ func Test_Sync_Execution_Duration_Simple(t *testing.T) {
 			// Note that real world latency for http response will be about 10x of local instance (which is used in testing)
 			// so keeping the acceptable duration low.
 			stateFile:                   "testdata/sync/regression-entities-with-id.yaml",
-			acceptableExecutionDuration: int64(1000), // 1s
+			acceptableExecutionDuration: int64(5000), // 5s
 		},
 	}
 

--- a/tests/performance/sync_test.go
+++ b/tests/performance/sync_test.go
@@ -1,0 +1,41 @@
+//go:build performance
+
+package performance
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Sync_Execution_Duration_Simple(t *testing.T) {
+	tests := []struct {
+		name                        string
+		stateFile                   string
+		acceptableExecutionDuration int64
+	}{
+		{
+			name: "Entities with UUIDs",
+			// This file contains 100 services, 10 consumer groups, and 100 consumers in total.
+			// Note that real world latency for http response will be about 10x of local instance (which is used in testing)
+			// so keeping the acceptable duration low.
+			stateFile:                   "testdata/sync/regression-entities-with-id.yaml",
+			acceptableExecutionDuration: int64(1000), // 1s
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setup(t)
+			start := time.Now()
+			err := sync(context.Background(), tc.stateFile)
+			elapsed := time.Since(start)
+			require.NoError(t, err)
+			if elapsed.Milliseconds() > tc.acceptableExecutionDuration {
+				t.Errorf("expected execution time for sync to be < %d ms", tc.acceptableExecutionDuration)
+			}
+		})
+	}
+}

--- a/tests/performance/testdata/sync/regression-entities-with-id.yaml
+++ b/tests/performance/testdata/sync/regression-entities-with-id.yaml
@@ -1,0 +1,3224 @@
+_format_version: "3.0"
+consumer_groups:
+- id: de678836-4611-4724-a60b-52761945577e
+  name: group-0
+- id: 84610ae4-d1b2-4444-918e-e3de0462a0e2
+  name: group-1
+- id: 328abd28-1e6c-45c1-8b65-b924005cca49
+  name: group-2
+- id: a540a82f-73fb-439b-a321-6f210ea4e3f5
+  name: group-3
+- id: e210f4bf-83ba-46fa-8298-277f10e7684f
+  name: group-4
+- id: 96dacb17-70f1-47db-a8a2-624e7388a94c
+  name: group-5
+- id: 9fc88cab-6752-4028-80b8-f3f3b0910f5a
+  name: group-6
+- id: b05d04be-b925-41bb-9f1a-2c0dce1bdcd5
+  name: group-7
+- id: ae5f4275-72ab-425b-a5fe-f5ccdec657ac
+  name: group-8
+- id: 72e55b4b-faa9-41ee-b094-7e1c5591b864
+  name: group-9
+consumers:
+- custom_id: id-0-0
+  groups:
+  - id: de678836-4611-4724-a60b-52761945577e
+    name: group-0
+  id: 4e5da706-5da7-4b93-a708-da7dbcce0d4d
+  username: consumer-0-0
+- custom_id: id-0-1
+  groups:
+  - id: de678836-4611-4724-a60b-52761945577e
+    name: group-0
+  id: f3426850-6c4d-491e-a008-c24fb8e59a08
+  username: consumer-0-1
+- custom_id: id-0-2
+  groups:
+  - id: de678836-4611-4724-a60b-52761945577e
+    name: group-0
+  id: 65ac6ba9-07d0-4ba1-9c53-68e5fca44904
+  username: consumer-0-2
+- custom_id: id-0-3
+  groups:
+  - id: de678836-4611-4724-a60b-52761945577e
+    name: group-0
+  id: 54b3db09-c3bc-4da0-a5ca-ca9ab36d6c79
+  username: consumer-0-3
+- custom_id: id-0-4
+  groups:
+  - id: de678836-4611-4724-a60b-52761945577e
+    name: group-0
+  id: 25c16782-7983-4e69-8f07-64709d483c0d
+  username: consumer-0-4
+- custom_id: id-0-5
+  groups:
+  - id: de678836-4611-4724-a60b-52761945577e
+    name: group-0
+  id: a18bb4af-a1a1-48cd-8da1-c333ba280755
+  username: consumer-0-5
+- custom_id: id-0-6
+  groups:
+  - id: de678836-4611-4724-a60b-52761945577e
+    name: group-0
+  id: 75c1cb90-d8bf-49aa-aacf-486d4bdfebb1
+  username: consumer-0-6
+- custom_id: id-0-7
+  groups:
+  - id: de678836-4611-4724-a60b-52761945577e
+    name: group-0
+  id: af614279-dc96-401f-bc31-a619588f1324
+  username: consumer-0-7
+- custom_id: id-0-8
+  groups:
+  - id: de678836-4611-4724-a60b-52761945577e
+    name: group-0
+  id: 5e720620-3b2e-4b66-9bb5-404e8b062602
+  username: consumer-0-8
+- custom_id: id-0-9
+  groups:
+  - id: de678836-4611-4724-a60b-52761945577e
+    name: group-0
+  id: 2f253a27-fefc-4f33-b98d-cecb6d63ff99
+  username: consumer-0-9
+- custom_id: id-1-0
+  groups:
+  - id: 84610ae4-d1b2-4444-918e-e3de0462a0e2
+    name: group-1
+  id: 3a7e9d0b-5edb-45ab-b3f1-530846096f31
+  username: consumer-1-0
+- custom_id: id-1-1
+  groups:
+  - id: 84610ae4-d1b2-4444-918e-e3de0462a0e2
+    name: group-1
+  id: 6845f755-ed76-4ad1-8142-d96f3f801d55
+  username: consumer-1-1
+- custom_id: id-1-2
+  groups:
+  - id: 84610ae4-d1b2-4444-918e-e3de0462a0e2
+    name: group-1
+  id: 846f01f2-0e14-4327-a79e-e2a52ed62121
+  username: consumer-1-2
+- custom_id: id-1-3
+  groups:
+  - id: 84610ae4-d1b2-4444-918e-e3de0462a0e2
+    name: group-1
+  id: 2c97e7a0-2771-4bd1-82e3-f8b15819c453
+  username: consumer-1-3
+- custom_id: id-1-4
+  groups:
+  - id: 84610ae4-d1b2-4444-918e-e3de0462a0e2
+    name: group-1
+  id: 84a6dfa2-89e0-4ee9-a999-5725520e41e8
+  username: consumer-1-4
+- custom_id: id-1-5
+  groups:
+  - id: 84610ae4-d1b2-4444-918e-e3de0462a0e2
+    name: group-1
+  id: 1aaf081b-8874-4435-b274-9f19ace69a6f
+  username: consumer-1-5
+- custom_id: id-1-6
+  groups:
+  - id: 84610ae4-d1b2-4444-918e-e3de0462a0e2
+    name: group-1
+  id: d51ace8b-b6dc-4434-9d30-1564ff1e7223
+  username: consumer-1-6
+- custom_id: id-1-7
+  groups:
+  - id: 84610ae4-d1b2-4444-918e-e3de0462a0e2
+    name: group-1
+  id: 93b912bf-a01c-4dbe-88ab-4beb81abe912
+  username: consumer-1-7
+- custom_id: id-1-8
+  groups:
+  - id: 84610ae4-d1b2-4444-918e-e3de0462a0e2
+    name: group-1
+  id: 503ddcc2-8510-436d-b505-62d58beb3b46
+  username: consumer-1-8
+- custom_id: id-1-9
+  groups:
+  - id: 84610ae4-d1b2-4444-918e-e3de0462a0e2
+    name: group-1
+  id: 3bf5b7d3-13f4-4415-96ca-598685eab682
+  username: consumer-1-9
+- custom_id: id-2-0
+  groups:
+  - id: 328abd28-1e6c-45c1-8b65-b924005cca49
+    name: group-2
+  id: adf8a4ab-720f-47cc-a51d-79c067613eb0
+  username: consumer-2-0
+- custom_id: id-2-1
+  groups:
+  - id: 328abd28-1e6c-45c1-8b65-b924005cca49
+    name: group-2
+  id: b823a28c-139a-47f2-bd4b-741fc36fa57b
+  username: consumer-2-1
+- custom_id: id-2-2
+  groups:
+  - id: 328abd28-1e6c-45c1-8b65-b924005cca49
+    name: group-2
+  id: f88ceacb-97be-460c-8996-3248610283af
+  username: consumer-2-2
+- custom_id: id-2-3
+  groups:
+  - id: 328abd28-1e6c-45c1-8b65-b924005cca49
+    name: group-2
+  id: ad7b0ad4-7ebc-45a8-8fa2-e26f3afb08ee
+  username: consumer-2-3
+- custom_id: id-2-4
+  groups:
+  - id: 328abd28-1e6c-45c1-8b65-b924005cca49
+    name: group-2
+  id: eb456727-bc03-4616-84c6-f86e2196ffc7
+  username: consumer-2-4
+- custom_id: id-2-5
+  groups:
+  - id: 328abd28-1e6c-45c1-8b65-b924005cca49
+    name: group-2
+  id: d4e17b8e-cb7f-4b70-b76d-b7111a586a25
+  username: consumer-2-5
+- custom_id: id-2-6
+  groups:
+  - id: 328abd28-1e6c-45c1-8b65-b924005cca49
+    name: group-2
+  id: 53739867-bfab-421b-8f91-c972a663f99b
+  username: consumer-2-6
+- custom_id: id-2-7
+  groups:
+  - id: 328abd28-1e6c-45c1-8b65-b924005cca49
+    name: group-2
+  id: 3c6c1949-b10e-4e19-bf35-09b907f41bf1
+  username: consumer-2-7
+- custom_id: id-2-8
+  groups:
+  - id: 328abd28-1e6c-45c1-8b65-b924005cca49
+    name: group-2
+  id: d291a10e-3566-4aa2-bde1-aa74c6f6b458
+  username: consumer-2-8
+- custom_id: id-2-9
+  groups:
+  - id: 328abd28-1e6c-45c1-8b65-b924005cca49
+    name: group-2
+  id: 1a5560c9-c789-4283-8ed9-85733df53381
+  username: consumer-2-9
+- custom_id: id-3-0
+  groups:
+  - id: a540a82f-73fb-439b-a321-6f210ea4e3f5
+    name: group-3
+  id: 1d966711-d891-4cb3-8645-101c2f7cbd18
+  username: consumer-3-0
+- custom_id: id-3-1
+  groups:
+  - id: a540a82f-73fb-439b-a321-6f210ea4e3f5
+    name: group-3
+  id: 3e49dcb9-473a-4d43-beaf-7fccd24a8dfe
+  username: consumer-3-1
+- custom_id: id-3-2
+  groups:
+  - id: a540a82f-73fb-439b-a321-6f210ea4e3f5
+    name: group-3
+  id: 5f0739f6-b2d2-4896-a01b-e578f67f8951
+  username: consumer-3-2
+- custom_id: id-3-3
+  groups:
+  - id: a540a82f-73fb-439b-a321-6f210ea4e3f5
+    name: group-3
+  id: 75dc8aac-3951-476b-89cc-7891f5cf46a9
+  username: consumer-3-3
+- custom_id: id-3-4
+  groups:
+  - id: a540a82f-73fb-439b-a321-6f210ea4e3f5
+    name: group-3
+  id: 1ee5e729-843f-4499-8849-0edf2d4bc563
+  username: consumer-3-4
+- custom_id: id-3-5
+  groups:
+  - id: a540a82f-73fb-439b-a321-6f210ea4e3f5
+    name: group-3
+  id: f156b88b-799b-4255-b023-1b939f72a915
+  username: consumer-3-5
+- custom_id: id-3-6
+  groups:
+  - id: a540a82f-73fb-439b-a321-6f210ea4e3f5
+    name: group-3
+  id: b7d75090-50fc-46f9-ae75-6de16236f495
+  username: consumer-3-6
+- custom_id: id-3-7
+  groups:
+  - id: a540a82f-73fb-439b-a321-6f210ea4e3f5
+    name: group-3
+  id: 93d54583-1301-4606-8f1a-5e3c0ad02c99
+  username: consumer-3-7
+- custom_id: id-3-8
+  groups:
+  - id: a540a82f-73fb-439b-a321-6f210ea4e3f5
+    name: group-3
+  id: 0926c07d-1c6f-47c7-84d7-86af85e97497
+  username: consumer-3-8
+- custom_id: id-3-9
+  groups:
+  - id: a540a82f-73fb-439b-a321-6f210ea4e3f5
+    name: group-3
+  id: 92a105fa-e260-4fe2-96fc-f2b3ac23cdf2
+  username: consumer-3-9
+- custom_id: id-4-0
+  groups:
+  - id: e210f4bf-83ba-46fa-8298-277f10e7684f
+    name: group-4
+  id: 17fddd66-ae53-48f9-aab0-9eeb8370e866
+  username: consumer-4-0
+- custom_id: id-4-1
+  groups:
+  - id: e210f4bf-83ba-46fa-8298-277f10e7684f
+    name: group-4
+  id: b9978534-3b3c-4d69-a762-b6c3da5f753c
+  username: consumer-4-1
+- custom_id: id-4-2
+  groups:
+  - id: e210f4bf-83ba-46fa-8298-277f10e7684f
+    name: group-4
+  id: a08b7dea-4b21-4bb5-8f7c-e12d08794056
+  username: consumer-4-2
+- custom_id: id-4-3
+  groups:
+  - id: e210f4bf-83ba-46fa-8298-277f10e7684f
+    name: group-4
+  id: 65079e8a-a97f-446d-a1cd-2e6730f212ca
+  username: consumer-4-3
+- custom_id: id-4-4
+  groups:
+  - id: e210f4bf-83ba-46fa-8298-277f10e7684f
+    name: group-4
+  id: 98f2afbb-60d8-4c62-884d-05d691b6f5cb
+  username: consumer-4-4
+- custom_id: id-4-5
+  groups:
+  - id: e210f4bf-83ba-46fa-8298-277f10e7684f
+    name: group-4
+  id: 29c8a7ff-3a0a-4ebc-ba30-04c020ff6dcf
+  username: consumer-4-5
+- custom_id: id-4-6
+  groups:
+  - id: e210f4bf-83ba-46fa-8298-277f10e7684f
+    name: group-4
+  id: 8950243e-0bd9-487b-abfc-4ee8378cdc57
+  username: consumer-4-6
+- custom_id: id-4-7
+  groups:
+  - id: e210f4bf-83ba-46fa-8298-277f10e7684f
+    name: group-4
+  id: 00c14529-ab37-4c21-a939-b9606d29312c
+  username: consumer-4-7
+- custom_id: id-4-8
+  groups:
+  - id: e210f4bf-83ba-46fa-8298-277f10e7684f
+    name: group-4
+  id: eccf31b3-6cba-4a39-8fe2-deba4f103c14
+  username: consumer-4-8
+- custom_id: id-4-9
+  groups:
+  - id: e210f4bf-83ba-46fa-8298-277f10e7684f
+    name: group-4
+  id: 8063c735-f917-4354-8777-6804edfbd7f8
+  username: consumer-4-9
+- custom_id: id-5-0
+  groups:
+  - id: 96dacb17-70f1-47db-a8a2-624e7388a94c
+    name: group-5
+  id: 6850933c-7fc2-44c9-845f-a11b333870aa
+  username: consumer-5-0
+- custom_id: id-5-1
+  groups:
+  - id: 96dacb17-70f1-47db-a8a2-624e7388a94c
+    name: group-5
+  id: b7f695d3-a66d-49a3-9e27-430c304ffabf
+  username: consumer-5-1
+- custom_id: id-5-2
+  groups:
+  - id: 96dacb17-70f1-47db-a8a2-624e7388a94c
+    name: group-5
+  id: 0f0c35b2-91a8-4aa1-a3b4-665a93bff2bd
+  username: consumer-5-2
+- custom_id: id-5-3
+  groups:
+  - id: 96dacb17-70f1-47db-a8a2-624e7388a94c
+    name: group-5
+  id: f5eae98a-5810-497e-b17d-4391886ff27c
+  username: consumer-5-3
+- custom_id: id-5-4
+  groups:
+  - id: 96dacb17-70f1-47db-a8a2-624e7388a94c
+    name: group-5
+  id: 0c7dfa72-943a-4a2f-b8c3-bb622f1e333c
+  username: consumer-5-4
+- custom_id: id-5-5
+  groups:
+  - id: 96dacb17-70f1-47db-a8a2-624e7388a94c
+    name: group-5
+  id: eb8f1dbd-5022-44d7-9863-151715d2147e
+  username: consumer-5-5
+- custom_id: id-5-6
+  groups:
+  - id: 96dacb17-70f1-47db-a8a2-624e7388a94c
+    name: group-5
+  id: b2e0c9e4-3fd2-4902-8c8b-4e059a58b3de
+  username: consumer-5-6
+- custom_id: id-5-7
+  groups:
+  - id: 96dacb17-70f1-47db-a8a2-624e7388a94c
+    name: group-5
+  id: 14ed3206-ab80-4c92-b205-1d9e3626455b
+  username: consumer-5-7
+- custom_id: id-5-8
+  groups:
+  - id: 96dacb17-70f1-47db-a8a2-624e7388a94c
+    name: group-5
+  id: fe4004e5-8dc6-4da2-b340-394a837fdf73
+  username: consumer-5-8
+- custom_id: id-5-9
+  groups:
+  - id: 96dacb17-70f1-47db-a8a2-624e7388a94c
+    name: group-5
+  id: 52424816-bcdd-487c-96c9-146ca57755cd
+  username: consumer-5-9
+- custom_id: id-6-0
+  groups:
+  - id: 9fc88cab-6752-4028-80b8-f3f3b0910f5a
+    name: group-6
+  id: c18e22ac-0c20-48b6-a6df-d5300b809e4a
+  username: consumer-6-0
+- custom_id: id-6-1
+  groups:
+  - id: 9fc88cab-6752-4028-80b8-f3f3b0910f5a
+    name: group-6
+  id: e1837c84-22b5-4f38-a2aa-7689d150971a
+  username: consumer-6-1
+- custom_id: id-6-2
+  groups:
+  - id: 9fc88cab-6752-4028-80b8-f3f3b0910f5a
+    name: group-6
+  id: 1d400be1-9afd-4582-91f1-b41bf044dd1d
+  username: consumer-6-2
+- custom_id: id-6-3
+  groups:
+  - id: 9fc88cab-6752-4028-80b8-f3f3b0910f5a
+    name: group-6
+  id: 1a6f13e6-1f93-4315-8b42-6da76f22a5f2
+  username: consumer-6-3
+- custom_id: id-6-4
+  groups:
+  - id: 9fc88cab-6752-4028-80b8-f3f3b0910f5a
+    name: group-6
+  id: 9ce60095-c0bf-4a51-b604-5fef488222f7
+  username: consumer-6-4
+- custom_id: id-6-5
+  groups:
+  - id: 9fc88cab-6752-4028-80b8-f3f3b0910f5a
+    name: group-6
+  id: 4128c790-c602-4838-810a-d81b9fcf235f
+  username: consumer-6-5
+- custom_id: id-6-6
+  groups:
+  - id: 9fc88cab-6752-4028-80b8-f3f3b0910f5a
+    name: group-6
+  id: 04bd4b87-563d-4e3e-af38-368221f1ac6d
+  username: consumer-6-6
+- custom_id: id-6-7
+  groups:
+  - id: 9fc88cab-6752-4028-80b8-f3f3b0910f5a
+    name: group-6
+  id: 655aec1b-2856-4ea7-9a1a-7f10327b6810
+  username: consumer-6-7
+- custom_id: id-6-8
+  groups:
+  - id: 9fc88cab-6752-4028-80b8-f3f3b0910f5a
+    name: group-6
+  id: 4c1f49d6-44d8-4556-805b-1fff93ffb753
+  username: consumer-6-8
+- custom_id: id-6-9
+  groups:
+  - id: 9fc88cab-6752-4028-80b8-f3f3b0910f5a
+    name: group-6
+  id: 9e2b1f0e-1228-49ff-8e0b-14369babf07d
+  username: consumer-6-9
+- custom_id: id-7-0
+  groups:
+  - id: b05d04be-b925-41bb-9f1a-2c0dce1bdcd5
+    name: group-7
+  id: 01e3e25a-867e-4e8c-821b-6996b83d5b73
+  username: consumer-7-0
+- custom_id: id-7-1
+  groups:
+  - id: b05d04be-b925-41bb-9f1a-2c0dce1bdcd5
+    name: group-7
+  id: e3a74f3c-2727-4d83-8c77-08d923f155b9
+  username: consumer-7-1
+- custom_id: id-7-2
+  groups:
+  - id: b05d04be-b925-41bb-9f1a-2c0dce1bdcd5
+    name: group-7
+  id: 425f7320-8f8a-49a2-ae9e-4f855bb6bb8c
+  username: consumer-7-2
+- custom_id: id-7-3
+  groups:
+  - id: b05d04be-b925-41bb-9f1a-2c0dce1bdcd5
+    name: group-7
+  id: c88cfd6c-4053-4c80-b19d-bbd75cb006a8
+  username: consumer-7-3
+- custom_id: id-7-4
+  groups:
+  - id: b05d04be-b925-41bb-9f1a-2c0dce1bdcd5
+    name: group-7
+  id: c7563695-1f24-458b-8740-ee9119751ccc
+  username: consumer-7-4
+- custom_id: id-7-5
+  groups:
+  - id: b05d04be-b925-41bb-9f1a-2c0dce1bdcd5
+    name: group-7
+  id: 58cdc4a7-eab7-4049-b474-9f82b2bedb26
+  username: consumer-7-5
+- custom_id: id-7-6
+  groups:
+  - id: b05d04be-b925-41bb-9f1a-2c0dce1bdcd5
+    name: group-7
+  id: 33f82c3d-d140-463a-aebb-9ef1bf640773
+  username: consumer-7-6
+- custom_id: id-7-7
+  groups:
+  - id: b05d04be-b925-41bb-9f1a-2c0dce1bdcd5
+    name: group-7
+  id: a4479f7f-5ec3-46d3-a511-5f23ed481a8f
+  username: consumer-7-7
+- custom_id: id-7-8
+  groups:
+  - id: b05d04be-b925-41bb-9f1a-2c0dce1bdcd5
+    name: group-7
+  id: a1ea3b9f-0227-4676-8781-a6036d6d31a0
+  username: consumer-7-8
+- custom_id: id-7-9
+  groups:
+  - id: b05d04be-b925-41bb-9f1a-2c0dce1bdcd5
+    name: group-7
+  id: ab8fff3a-70e9-4cb9-878c-36ba7a9f7d2a
+  username: consumer-7-9
+- custom_id: id-8-0
+  groups:
+  - id: ae5f4275-72ab-425b-a5fe-f5ccdec657ac
+    name: group-8
+  id: 2251759f-0e22-419a-836e-1b10aafd1652
+  username: consumer-8-0
+- custom_id: id-8-1
+  groups:
+  - id: ae5f4275-72ab-425b-a5fe-f5ccdec657ac
+    name: group-8
+  id: cfc751af-4746-4627-9732-3e9599147761
+  username: consumer-8-1
+- custom_id: id-8-2
+  groups:
+  - id: ae5f4275-72ab-425b-a5fe-f5ccdec657ac
+    name: group-8
+  id: 64724ceb-9759-4b5d-a7a8-8ad9d512edf5
+  username: consumer-8-2
+- custom_id: id-8-3
+  groups:
+  - id: ae5f4275-72ab-425b-a5fe-f5ccdec657ac
+    name: group-8
+  id: 0f79a38b-065f-4256-a025-35963365fffb
+  username: consumer-8-3
+- custom_id: id-8-4
+  groups:
+  - id: ae5f4275-72ab-425b-a5fe-f5ccdec657ac
+    name: group-8
+  id: c7aedf9c-43ae-4895-93ad-c02c7dca6f4a
+  username: consumer-8-4
+- custom_id: id-8-5
+  groups:
+  - id: ae5f4275-72ab-425b-a5fe-f5ccdec657ac
+    name: group-8
+  id: 30fd55a9-6011-43f2-9624-e10310139339
+  username: consumer-8-5
+- custom_id: id-8-6
+  groups:
+  - id: ae5f4275-72ab-425b-a5fe-f5ccdec657ac
+    name: group-8
+  id: 6fd9a546-2df7-4bcd-b47e-a3521c318b34
+  username: consumer-8-6
+- custom_id: id-8-7
+  groups:
+  - id: ae5f4275-72ab-425b-a5fe-f5ccdec657ac
+    name: group-8
+  id: c0d429c9-a589-436e-8cf9-7ad5e338f4b9
+  username: consumer-8-7
+- custom_id: id-8-8
+  groups:
+  - id: ae5f4275-72ab-425b-a5fe-f5ccdec657ac
+    name: group-8
+  id: e37467ad-4437-499c-80c0-e97010836ff1
+  username: consumer-8-8
+- custom_id: id-8-9
+  groups:
+  - id: ae5f4275-72ab-425b-a5fe-f5ccdec657ac
+    name: group-8
+  id: 44f0d8fb-49f8-4c9e-8775-130e4e26aae6
+  username: consumer-8-9
+- custom_id: id-9-0
+  groups:
+  - id: 72e55b4b-faa9-41ee-b094-7e1c5591b864
+    name: group-9
+  id: 8a5474f7-2f76-4284-8f76-88be031d0907
+  username: consumer-9-0
+- custom_id: id-9-1
+  groups:
+  - id: 72e55b4b-faa9-41ee-b094-7e1c5591b864
+    name: group-9
+  id: 7f153b62-ee1b-408e-a59c-095086830082
+  username: consumer-9-1
+- custom_id: id-9-2
+  groups:
+  - id: 72e55b4b-faa9-41ee-b094-7e1c5591b864
+    name: group-9
+  id: b9fc117c-ca03-4e82-9c41-a2007cb2875a
+  username: consumer-9-2
+- custom_id: id-9-3
+  groups:
+  - id: 72e55b4b-faa9-41ee-b094-7e1c5591b864
+    name: group-9
+  id: 8874bc05-90b7-4587-92f1-1387dc6b18d3
+  username: consumer-9-3
+- custom_id: id-9-4
+  groups:
+  - id: 72e55b4b-faa9-41ee-b094-7e1c5591b864
+    name: group-9
+  id: 618d9cae-7203-40c8-82e6-26eb4d4faa62
+  username: consumer-9-4
+- custom_id: id-9-5
+  groups:
+  - id: 72e55b4b-faa9-41ee-b094-7e1c5591b864
+    name: group-9
+  id: 741f2d80-f533-4a72-bd06-1882d367f878
+  username: consumer-9-5
+- custom_id: id-9-6
+  groups:
+  - id: 72e55b4b-faa9-41ee-b094-7e1c5591b864
+    name: group-9
+  id: 7a48d4d8-8321-4b90-af78-8a8fae0ecc8a
+  username: consumer-9-6
+- custom_id: id-9-7
+  groups:
+  - id: 72e55b4b-faa9-41ee-b094-7e1c5591b864
+    name: group-9
+  id: 7cb49cda-a3fb-4a00-a519-7821d6facd4b
+  username: consumer-9-7
+- custom_id: id-9-8
+  groups:
+  - id: 72e55b4b-faa9-41ee-b094-7e1c5591b864
+    name: group-9
+  id: 7687bf4f-c01b-4185-907e-97d9000ce88c
+  username: consumer-9-8
+- custom_id: id-9-9
+  groups:
+  - id: 72e55b4b-faa9-41ee-b094-7e1c5591b864
+    name: group-9
+  id: a77f5a69-1e38-4f37-9958-208ff31fa92d
+  username: consumer-9-9
+services:
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 5d95691a-002d-472a-bfa1-826802f788b3
+  name: service-0
+  path: /0
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 679aa428-dff4-4303-af55-105cbd7eeec5
+    name: route-0
+    path_handling: v0
+    paths:
+    - /route0
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 55de3896-e887-4d76-b999-220c21782b49
+  name: service-1
+  path: /1
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 81da8bf5-6f5a-46f9-b173-78b54c5ce575
+    name: route-1
+    path_handling: v0
+    paths:
+    - /route1
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 43333020-467e-480e-a064-21e89e09406c
+  name: service-10
+  path: /10
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 24b8a64c-86db-43e6-8b27-b27c78df41d3
+    name: route-10
+    path_handling: v0
+    paths:
+    - /route10
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 7084f122-c264-4456-8675-db775c30b8c2
+  name: service-11
+  path: /11
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 549acbab-3ce4-47b7-b5c5-4b0953d2cc1d
+    name: route-11
+    path_handling: v0
+    paths:
+    - /route11
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 710167a2-8d09-42d6-b6f9-c13f30e4bd2d
+  name: service-12
+  path: /12
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 0145c8db-253e-4068-ab8a-8ccb8e2f01d9
+    name: route-12
+    path_handling: v0
+    paths:
+    - /route12
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 4480b450-f1a8-4730-89ff-a202b6d7534c
+  name: service-13
+  path: /13
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 77b7acc6-3f33-4113-9593-7095ef1d2dd5
+    name: route-13
+    path_handling: v0
+    paths:
+    - /route13
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 63ab38f1-c608-4157-aa0a-bc8e706cfccb
+  name: service-14
+  path: /14
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 32b85f2b-4d94-4f26-9779-bd169baaea91
+    name: route-14
+    path_handling: v0
+    paths:
+    - /route14
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 45658477-df62-4a99-b23e-8a802e9e64e0
+  name: service-15
+  path: /15
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 1d9db3c2-0362-405b-bad4-a13a6f5e0435
+    name: route-15
+    path_handling: v0
+    paths:
+    - /route15
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 01ac3fb0-d6b7-48f0-8e66-eace946989cb
+  name: service-16
+  path: /16
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 689ef291-70ee-41c6-9f55-beb4663322d8
+    name: route-16
+    path_handling: v0
+    paths:
+    - /route16
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 7d979624-d72a-42ec-a27d-447155fa5d99
+  name: service-17
+  path: /17
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 622badf9-683c-42a8-a553-f7765fded8e1
+    name: route-17
+    path_handling: v0
+    paths:
+    - /route17
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 0eeb4687-2a91-45aa-8c16-ed940d1f81a1
+  name: service-18
+  path: /18
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: c8d3d90a-ed4a-4467-9a90-d0103e83be69
+    name: route-18
+    path_handling: v0
+    paths:
+    - /route18
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: a3e94474-4bce-4eff-8f85-8fdb4ca3e93c
+  name: service-19
+  path: /19
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 02e12090-347e-4aed-a870-acdbd6b9b539
+    name: route-19
+    path_handling: v0
+    paths:
+    - /route19
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: e0f54aff-30c9-4b4a-907c-c7f786f10c8e
+  name: service-2
+  path: /2
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 5f3a67b5-4b8a-41d8-8308-28ee2ba6d6a4
+    name: route-2
+    path_handling: v0
+    paths:
+    - /route2
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: ea0ce30e-e4df-4f00-bd20-b1fc3449b329
+  name: service-20
+  path: /20
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: b74e5ea8-4ae8-4b7e-8019-7de9aeb379c8
+    name: route-20
+    path_handling: v0
+    paths:
+    - /route20
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 2c5f8997-5e37-492e-9b6b-09151670ecf8
+  name: service-21
+  path: /21
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: b86da6aa-f955-4628-871e-ef6ff4b74e7c
+    name: route-21
+    path_handling: v0
+    paths:
+    - /route21
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 82692704-6aba-4397-80f5-ac90885e76d2
+  name: service-22
+  path: /22
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 60c7023d-880e-471c-8075-a13e2ec885f8
+    name: route-22
+    path_handling: v0
+    paths:
+    - /route22
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 9ec8940f-5150-4831-a3ed-bab392f0291c
+  name: service-23
+  path: /23
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 3b56be12-5b4a-4efd-a9e0-22873fb7cd0d
+    name: route-23
+    path_handling: v0
+    paths:
+    - /route23
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: bb49ba49-d76d-4ce4-9292-752ba60e280a
+  name: service-24
+  path: /24
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 4af11d06-6f8a-4388-b3a2-93f3b2539c8a
+    name: route-24
+    path_handling: v0
+    paths:
+    - /route24
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 8e098ad7-a9fb-4ac1-9e62-9a070ed6b6d2
+  name: service-25
+  path: /25
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 9499c3e8-b907-4e53-b266-216f488accfb
+    name: route-25
+    path_handling: v0
+    paths:
+    - /route25
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 803db2c8-8307-448d-9511-3d22f4cefb71
+  name: service-26
+  path: /26
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: a187d85f-f188-47f6-a7d5-f92edc371797
+    name: route-26
+    path_handling: v0
+    paths:
+    - /route26
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 2c5a560e-56fa-4a99-bb24-058b66e3f2af
+  name: service-27
+  path: /27
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: ec1d3496-f2a7-424d-8a5d-79ed1b6e62ea
+    name: route-27
+    path_handling: v0
+    paths:
+    - /route27
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: d0cf283d-3351-4dec-aef2-579fd1eebc23
+  name: service-28
+  path: /28
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 553c88fb-2bb0-49e0-8123-8c3170d1afb2
+    name: route-28
+    path_handling: v0
+    paths:
+    - /route28
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 6efa8cbd-bf1d-4eeb-a8c4-2d9739cc73f4
+  name: service-29
+  path: /29
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 73ae3049-2648-4178-91ea-dd6d189f25fa
+    name: route-29
+    path_handling: v0
+    paths:
+    - /route29
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 8878ec30-98f7-4f13-be1a-2baafe04e11f
+  name: service-3
+  path: /3
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: f61d6e7c-22a0-42a1-8322-45bf4e1e4d7a
+    name: route-3
+    path_handling: v0
+    paths:
+    - /route3
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 88526c1e-29e6-43b3-a363-4c1044d9911c
+  name: service-30
+  path: /30
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 45ed00ae-eec2-43d1-a8dd-5cdc30d96587
+    name: route-30
+    path_handling: v0
+    paths:
+    - /route30
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 74f34e3c-2644-47c4-9725-b11a5f5dc1e0
+  name: service-31
+  path: /31
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 3d3400ae-9c37-4075-b5bc-15982ceaf795
+    name: route-31
+    path_handling: v0
+    paths:
+    - /route31
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: e4f27654-76ca-446d-ae2c-bdbca826275b
+  name: service-32
+  path: /32
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: ddf5a598-1975-4ef1-b41c-3e30d4a16c7a
+    name: route-32
+    path_handling: v0
+    paths:
+    - /route32
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 5561bffa-2e3f-4964-b77d-60ed5837255a
+  name: service-33
+  path: /33
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 56d6dad0-bb23-4451-ab1c-bbcedbaccd86
+    name: route-33
+    path_handling: v0
+    paths:
+    - /route33
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 2743ad3a-cedc-41e2-b025-94d2e8a901bf
+  name: service-34
+  path: /34
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: d8a8bdd7-bf27-44d6-865d-cffd3a3bc0ad
+    name: route-34
+    path_handling: v0
+    paths:
+    - /route34
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 9c5d506e-657c-4192-af47-53af79e9380f
+  name: service-35
+  path: /35
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 5c35ff9d-d645-45af-943e-0f5853c0793b
+    name: route-35
+    path_handling: v0
+    paths:
+    - /route35
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: da03516f-03ab-4f0f-9ae5-7a7aaf0311ae
+  name: service-36
+  path: /36
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 09d3697b-251a-46d1-9652-48b03e42861c
+    name: route-36
+    path_handling: v0
+    paths:
+    - /route36
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 1e82bff6-595f-4e37-b28c-35c7808d924a
+  name: service-37
+  path: /37
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 658ed111-00bc-4066-8368-0283ed842e44
+    name: route-37
+    path_handling: v0
+    paths:
+    - /route37
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 6b8d1291-fd89-4457-9965-3da40b1cf899
+  name: service-38
+  path: /38
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: e2f7429d-006e-46af-843c-37f5c162e52c
+    name: route-38
+    path_handling: v0
+    paths:
+    - /route38
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 3a4ec170-1f4c-4bac-b0b4-58125e34598d
+  name: service-39
+  path: /39
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: d163e682-2444-4ae1-bc07-8c3b4d0e25c9
+    name: route-39
+    path_handling: v0
+    paths:
+    - /route39
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: dc909a9a-ec17-4caf-9a2e-62f5e58afc05
+  name: service-4
+  path: /4
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 094e983e-3f04-4977-b234-73560e576e92
+    name: route-4
+    path_handling: v0
+    paths:
+    - /route4
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 826cf2b0-91b1-4879-8810-20a47b06dd5d
+  name: service-40
+  path: /40
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: cf00d45f-ea7c-43ce-b916-86801f5e8128
+    name: route-40
+    path_handling: v0
+    paths:
+    - /route40
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: b6a01c46-7edb-4caa-a70f-0c6cb840ed11
+  name: service-41
+  path: /41
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: a6caa17c-255b-4f26-a362-6552bd30492f
+    name: route-41
+    path_handling: v0
+    paths:
+    - /route41
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: fe9a24c7-f4bc-4ea4-916d-70a5a6a0df8a
+  name: service-42
+  path: /42
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: bcf96e2a-7d19-4d95-8431-cd0efeedef96
+    name: route-42
+    path_handling: v0
+    paths:
+    - /route42
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 33fba3dc-c594-4dac-9cad-41bdebec3fbf
+  name: service-43
+  path: /43
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: ef4082fd-0bdf-4598-8186-68fd8929d8cf
+    name: route-43
+    path_handling: v0
+    paths:
+    - /route43
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 65ff13ec-7d70-44a8-888c-249aa6ed89f4
+  name: service-44
+  path: /44
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 27cb298c-ba0c-41ed-8abf-4cc7582f148d
+    name: route-44
+    path_handling: v0
+    paths:
+    - /route44
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: f5d2b71a-0be0-4949-9338-3846edb8de01
+  name: service-45
+  path: /45
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 92ae3b12-5d53-4d83-9a84-04597cfb8f9f
+    name: route-45
+    path_handling: v0
+    paths:
+    - /route45
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 39f8cbe3-e7ba-414f-857d-732c5d8263bb
+  name: service-46
+  path: /46
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: a2ae602b-04b0-4401-b9f5-578125726f77
+    name: route-46
+    path_handling: v0
+    paths:
+    - /route46
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 5d7b3697-4b4b-4a43-ade7-b5fff85ba576
+  name: service-47
+  path: /47
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 3c40474a-aa33-4ef2-aec7-8b3095a58867
+    name: route-47
+    path_handling: v0
+    paths:
+    - /route47
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 2aef9ca0-95fb-4e92-bc42-01bd7d1ddec1
+  name: service-48
+  path: /48
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: a4c7b39f-6dac-4171-9148-7b22c90206cc
+    name: route-48
+    path_handling: v0
+    paths:
+    - /route48
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 94ab00c3-6a15-4072-a2b5-713576d2a6ae
+  name: service-49
+  path: /49
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: bccdf44c-f8b0-499d-a50e-4059eea3354a
+    name: route-49
+    path_handling: v0
+    paths:
+    - /route49
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 8ff2eb2c-9ff2-43f7-8cfd-b83963bd24db
+  name: service-5
+  path: /5
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 17f1599e-1a22-45f6-aff3-6dda5cb103b1
+    name: route-5
+    path_handling: v0
+    paths:
+    - /route5
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: a0db32e5-e208-4c97-bd82-a9fde86bc248
+  name: service-50
+  path: /50
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 59dee924-7dcd-4a2d-aa0e-bf8ea8bf50d4
+    name: route-50
+    path_handling: v0
+    paths:
+    - /route50
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: e1469a00-d15f-43fb-8fe5-2cc4d5a6df39
+  name: service-51
+  path: /51
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: a7a60f51-8835-427c-aeef-6056a45114ec
+    name: route-51
+    path_handling: v0
+    paths:
+    - /route51
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 7798b0d2-d7ff-4738-83a9-011f8644c2a4
+  name: service-52
+  path: /52
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: a095ed6a-7e68-4732-95b4-6782f3a9dffb
+    name: route-52
+    path_handling: v0
+    paths:
+    - /route52
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: ffc17c40-08c0-4f6f-842a-e129c3dde5d2
+  name: service-53
+  path: /53
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 91170201-b994-4104-a193-2c9c7fc733b9
+    name: route-53
+    path_handling: v0
+    paths:
+    - /route53
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: a07bd69d-13fe-494d-ae61-9d4e066e9b42
+  name: service-54
+  path: /54
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 5c30aa66-7bbe-4bd4-855e-ae599aed6d32
+    name: route-54
+    path_handling: v0
+    paths:
+    - /route54
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: c691cd38-a5ec-4886-a2cb-91a1aeb13c8e
+  name: service-55
+  path: /55
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: ba872272-724b-4701-93eb-715a0e76304a
+    name: route-55
+    path_handling: v0
+    paths:
+    - /route55
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: e2ea9f56-0762-4b21-aa8a-66f66ecddd68
+  name: service-56
+  path: /56
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: ba52d5cd-d97a-4ba7-93c2-d4a84df8e2b9
+    name: route-56
+    path_handling: v0
+    paths:
+    - /route56
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 820daf20-250b-4d10-84b5-0797f7002aeb
+  name: service-57
+  path: /57
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 47612057-1f76-4276-a916-ed3371292bca
+    name: route-57
+    path_handling: v0
+    paths:
+    - /route57
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 5bb07541-4e4d-4216-9b9f-c0cfc60bcd60
+  name: service-58
+  path: /58
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: bbef6286-0bb5-4dcd-a7ae-af3516a865b8
+    name: route-58
+    path_handling: v0
+    paths:
+    - /route58
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: d1d6f5ee-4912-4f66-93f3-0c9fcb965b04
+  name: service-59
+  path: /59
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 85451f0e-320a-4aff-b973-74b8331bd727
+    name: route-59
+    path_handling: v0
+    paths:
+    - /route59
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: f2c2046b-179a-4f25-bfdd-17bbd0db1b1f
+  name: service-6
+  path: /6
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 7f6d1110-f001-4a21-a357-400ff772e882
+    name: route-6
+    path_handling: v0
+    paths:
+    - /route6
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 57604608-bed0-485a-b94f-264df69f3184
+  name: service-60
+  path: /60
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: cfde8d51-2e76-47d1-b3f0-2aff4fcede83
+    name: route-60
+    path_handling: v0
+    paths:
+    - /route60
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: c3e53fb1-cafb-428f-8eee-89536630918c
+  name: service-61
+  path: /61
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: a1323531-ded5-4a25-a35e-bef3cec00303
+    name: route-61
+    path_handling: v0
+    paths:
+    - /route61
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 54c98710-40eb-4e30-bddd-af049ccb68b3
+  name: service-62
+  path: /62
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: c9473a20-b999-49eb-be73-99050908738a
+    name: route-62
+    path_handling: v0
+    paths:
+    - /route62
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 1cc94260-3e25-4b6f-89bf-89a222cd9588
+  name: service-63
+  path: /63
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 9fd7d782-c335-489b-b605-754e2474f80e
+    name: route-63
+    path_handling: v0
+    paths:
+    - /route63
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 6ac7bf37-f7ed-4f49-9e74-e653842e7dee
+  name: service-64
+  path: /64
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 732ea820-aaea-447f-b58c-7a3950c195cf
+    name: route-64
+    path_handling: v0
+    paths:
+    - /route64
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 10a8ba31-4df3-4560-814a-e02cb9c45040
+  name: service-65
+  path: /65
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 73159cdb-74e5-4054-9881-04bfeb03041f
+    name: route-65
+    path_handling: v0
+    paths:
+    - /route65
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 5d34f641-65f1-4a70-be11-71472257cc0f
+  name: service-66
+  path: /66
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: b0ea4ece-5076-4bbd-9312-acd4441f7266
+    name: route-66
+    path_handling: v0
+    paths:
+    - /route66
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 6adc8293-6c5c-4e32-bb78-3467c88cc555
+  name: service-67
+  path: /67
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: eb4cfa3b-356b-4471-a8cc-b0ee2ca0c2a0
+    name: route-67
+    path_handling: v0
+    paths:
+    - /route67
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 22769ca6-1e89-4566-bbd1-92b29b82f7a7
+  name: service-68
+  path: /68
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 07d2287c-d0e3-490a-bdfc-6d00f1511d7e
+    name: route-68
+    path_handling: v0
+    paths:
+    - /route68
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: da6ace69-2fcc-4079-a438-aa2ba5ac8b90
+  name: service-69
+  path: /69
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: e3831640-22d6-46fd-8f5f-f7306e665e71
+    name: route-69
+    path_handling: v0
+    paths:
+    - /route69
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 286e101d-5927-467c-9b84-53bd1a6fb174
+  name: service-7
+  path: /7
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 97eb1100-350b-41fd-9af4-6f05f959ca0a
+    name: route-7
+    path_handling: v0
+    paths:
+    - /route7
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 5d86b3de-beca-493f-a81d-3eb80949533a
+  name: service-70
+  path: /70
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: ee6d68bd-896f-4fbe-8284-2c24fec313c9
+    name: route-70
+    path_handling: v0
+    paths:
+    - /route70
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: fae1be77-ede7-4c87-b0b8-ddf06973a60f
+  name: service-71
+  path: /71
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 8fd2d72b-6766-4192-bbf3-2bbb0c6dd897
+    name: route-71
+    path_handling: v0
+    paths:
+    - /route71
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: aaea5fc0-a9b5-48b3-a1a3-0b6bc12ecc3b
+  name: service-72
+  path: /72
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: d84bca7b-986b-480f-9db0-71933e295844
+    name: route-72
+    path_handling: v0
+    paths:
+    - /route72
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: a1735625-216b-43ec-9fab-c87cb862c5bd
+  name: service-73
+  path: /73
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 3d033f80-199c-4929-9b5e-e6c3fa0bb166
+    name: route-73
+    path_handling: v0
+    paths:
+    - /route73
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 80e75317-6e41-4507-ad1e-9906fe9f6fe2
+  name: service-74
+  path: /74
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 31abbb35-ae99-447a-895e-864b10d56a13
+    name: route-74
+    path_handling: v0
+    paths:
+    - /route74
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: b9dea499-aedc-47b8-8441-a0cf402a6b8e
+  name: service-75
+  path: /75
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: ef649fa5-ea53-49b9-819b-7cfd023c96e8
+    name: route-75
+    path_handling: v0
+    paths:
+    - /route75
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 542f1538-d609-4602-b2ec-0b5d5b6aef02
+  name: service-76
+  path: /76
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 6207a7d6-ae46-4250-9354-f4b55b04409a
+    name: route-76
+    path_handling: v0
+    paths:
+    - /route76
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 0eb7f749-e84c-4452-ae46-77e918f7fe61
+  name: service-77
+  path: /77
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 0de079ac-63c2-422c-ab26-c608120c3766
+    name: route-77
+    path_handling: v0
+    paths:
+    - /route77
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: a34382b4-f369-447b-bbb7-a2aba17aa6ce
+  name: service-78
+  path: /78
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 723496d5-2e0b-4bd7-a0bb-09fbc2e70425
+    name: route-78
+    path_handling: v0
+    paths:
+    - /route78
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: eb2fbbc5-ead3-4099-9bd9-5f00aaca7782
+  name: service-79
+  path: /79
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: d5a7814d-7c9c-4d1d-abda-a4d63e3881b8
+    name: route-79
+    path_handling: v0
+    paths:
+    - /route79
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: a1164cdc-24dd-4503-a0b4-c4c4d2324246
+  name: service-8
+  path: /8
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 504b5015-acac-451b-9d23-598c9774d200
+    name: route-8
+    path_handling: v0
+    paths:
+    - /route8
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 47019729-26d8-4dd5-acf1-aca64451464b
+  name: service-80
+  path: /80
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: bfbd3662-3a49-4c78-82b7-b73cddab0250
+    name: route-80
+    path_handling: v0
+    paths:
+    - /route80
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 5f4f714d-0b9a-4918-9ada-fcb89f7696b2
+  name: service-81
+  path: /81
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: dfd205f3-1181-4044-9164-d4f3e9df1972
+    name: route-81
+    path_handling: v0
+    paths:
+    - /route81
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 0148d04c-f8e0-4429-a0ab-4ac00f1b4402
+  name: service-82
+  path: /82
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: d74674f2-c9d5-47a8-bb8d-37dad23059d2
+    name: route-82
+    path_handling: v0
+    paths:
+    - /route82
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 42cd22e2-47e6-40bc-a556-e81d300e0b01
+  name: service-83
+  path: /83
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 671826e9-30f3-4baf-85ef-1dba3e60f90a
+    name: route-83
+    path_handling: v0
+    paths:
+    - /route83
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 5aa842d7-a10e-4720-9aa2-ff4811ca5112
+  name: service-84
+  path: /84
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: eab2aa83-29e7-4eeb-a6e0-b94eaeb782e1
+    name: route-84
+    path_handling: v0
+    paths:
+    - /route84
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 12111ef9-1ec6-4ec0-aa84-6665e011d997
+  name: service-85
+  path: /85
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 58aa724e-4700-44aa-89ca-384a8d1e5df8
+    name: route-85
+    path_handling: v0
+    paths:
+    - /route85
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: ed23fcc7-d953-4298-b3af-d668dc366e90
+  name: service-86
+  path: /86
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 8cbdda01-98de-449b-b59d-8ef18c9cca28
+    name: route-86
+    path_handling: v0
+    paths:
+    - /route86
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: e1b200d6-33dd-4e5b-81d4-ac2fd315cda2
+  name: service-87
+  path: /87
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 98500f1f-4f19-48ea-bc01-ac83e15c56ce
+    name: route-87
+    path_handling: v0
+    paths:
+    - /route87
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 67dccd71-7e5b-4a6e-a246-e1727fcdf2a6
+  name: service-88
+  path: /88
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: e2d3523d-16bb-4f03-ad44-7d36d59b4274
+    name: route-88
+    path_handling: v0
+    paths:
+    - /route88
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 2ef83e43-a602-4c68-b500-763e78053c24
+  name: service-89
+  path: /89
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 9c305dc3-5b60-405c-9388-2fc1745e2c62
+    name: route-89
+    path_handling: v0
+    paths:
+    - /route89
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: c8351a64-3e81-40bf-95d4-b63e48a86f94
+  name: service-9
+  path: /9
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 9b3cdb31-d3c6-49b8-8afc-4b6a263a6e78
+    name: route-9
+    path_handling: v0
+    paths:
+    - /route9
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 80fb156f-e3e9-434d-9a75-1091231aa3f7
+  name: service-90
+  path: /90
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 1c692f11-a3ff-40a8-a44e-902a630b6e73
+    name: route-90
+    path_handling: v0
+    paths:
+    - /route90
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 275d9fb6-e678-4653-8cf8-ca0cd4144861
+  name: service-91
+  path: /91
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: ea196148-9fda-41e0-b5fd-4596b7235f76
+    name: route-91
+    path_handling: v0
+    paths:
+    - /route91
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 6f27a4b0-e004-44fa-b216-b13bbdb744dc
+  name: service-92
+  path: /92
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 9cc415dc-01cf-453f-a16c-d3b20ede9a1a
+    name: route-92
+    path_handling: v0
+    paths:
+    - /route92
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: ad8b1400-66d1-4bd1-b84b-01d211d6558b
+  name: service-93
+  path: /93
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: ab3e7299-a1e7-4c36-8d13-22e6081cd778
+    name: route-93
+    path_handling: v0
+    paths:
+    - /route93
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: ac268361-be3d-4a48-8a36-20321879e2e8
+  name: service-94
+  path: /94
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 385ac77c-d7ac-4aaa-b8cc-f052b68eb6fa
+    name: route-94
+    path_handling: v0
+    paths:
+    - /route94
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 2aa28d5b-9f55-41eb-9d68-85cb1f61c047
+  name: service-95
+  path: /95
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 29f1887c-e4e2-4544-b602-74e03d44ccbf
+    name: route-95
+    path_handling: v0
+    paths:
+    - /route95
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: e9c90c22-9e8b-44dd-9cbe-8ea94a484604
+  name: service-96
+  path: /96
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 525c312b-1e26-4c48-915e-8faf03b91d7e
+    name: route-96
+    path_handling: v0
+    paths:
+    - /route96
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 4e75a60b-dbba-4317-b48a-2df5c2a8abfa
+  name: service-97
+  path: /97
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: b80f936f-1f22-448f-ba27-985ac73bb4fe
+    name: route-97
+    path_handling: v0
+    paths:
+    - /route97
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 5d6c4850-5e78-47f6-ad6d-0b3b2e7bea52
+  name: service-98
+  path: /98
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: 237331c7-c195-4269-b32d-11b66c3d02e8
+    name: route-98
+    path_handling: v0
+    paths:
+    - /route98
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  id: 996d9e8b-bc0a-42ec-b878-6dea5457ea15
+  name: service-99
+  path: /99
+  port: 80
+  protocol: http
+  read_timeout: 60000
+  retries: 5
+  routes:
+  - https_redirect_status_code: 426
+    id: f36b7887-4e88-4607-b298-08f022961753
+    name: route-99
+    path_handling: v0
+    paths:
+    - /route99
+    preserve_host: false
+    protocols:
+    - http
+    - https
+    regex_priority: 0
+    request_buffering: true
+    response_buffering: true
+    strip_path: true
+  write_timeout: 60000

--- a/tests/performance/utils.go
+++ b/tests/performance/utils.go
@@ -1,0 +1,44 @@
+package performance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kong/deck/cmd"
+	"github.com/stretchr/testify/require"
+)
+
+// setup sets deck env variable to prevent analytics in tests and registers reset
+// command with t.Cleanup().
+//
+// NOTE: Can't be called with tests running t.Parallel() because of the usage
+// of t.Setenv().
+func setup(t *testing.T) {
+	// disable analytics for integration tests
+	t.Setenv("DECK_ANALYTICS", "off")
+	t.Cleanup(func() {
+		reset(t)
+	})
+}
+
+func sync(ctx context.Context, kongFile string, opts ...string) error {
+	deckCmd := cmd.NewRootCmd()
+	args := []string{"gateway", "sync", kongFile}
+	if len(opts) > 0 {
+		args = append(args, opts...)
+	}
+	deckCmd.SetArgs(args)
+	return deckCmd.ExecuteContext(ctx)
+}
+
+func reset(t *testing.T, opts ...string) {
+	t.Helper()
+
+	deckCmd := cmd.NewRootCmd()
+	args := []string{"gateway", "reset", "--force"}
+	if len(opts) > 0 {
+		args = append(args, opts...)
+	}
+	deckCmd.SetArgs(args)
+	require.NoError(t, deckCmd.Execute(), "failed to reset Kong's state")
+}


### PR DESCRIPTION
This PR contains a very basic implementation for performance - measuring duration of execution of sync command.
There is code duplication, and it's been implemented to run on only latest enterprise gateway - so needs polishing.

IMO, depending on duration could lead to flaky tests - as network latency is unpredictable.

Ideally, I'd want to have the following in a performance test:
1. No flakiness
2. Key performance indicators - CPU consumption, memory consumption, Network throughput, and execution time, for example
3. Representative state files to measure each - designed to stress each of the key performance indicators
4. Storing past metrics and easy comparison - for example, i'd want the execution time on `main` available to compare with my `feat/slow-feature` as a comment on my PR - so it's easy to compare what is changing.

Feedback and thoughts on how this can be improved welcome 🙏 

The test passes on this branch, I'll link another where it fails - based on v1.46.1