### PR TITLE
tests: add tests for custom entity partial apply

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/google/go-cmp v0.7.0
 	github.com/kong/go-apiops v0.1.42
-	github.com/kong/go-database-reconciler v1.22.6
+	github.com/kong/go-database-reconciler v1.22.7-0.20250509051435-c0c4bfd03aed
 	github.com/kong/go-kong v0.65.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/google/go-cmp v0.7.0
 	github.com/kong/go-apiops v0.1.42
-	github.com/kong/go-database-reconciler v1.22.7-0.20250509051435-c0c4bfd03aed
+	github.com/kong/go-database-reconciler v1.22.7
 	github.com/kong/go-kong v0.65.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -246,10 +246,8 @@ github.com/klauspost/cpuid/v2 v2.2.5 h1:0E5MSMDEoAulmXNFquVs//DdoomxaoTY1kUhbc/q
 github.com/klauspost/cpuid/v2 v2.2.5/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/kong/go-apiops v0.1.42 h1:GF9KV1D06p/Ux2F5Dc4UJzGKFOeMzynpUWiAZwyEqxE=
 github.com/kong/go-apiops v0.1.42/go.mod h1:hKnHJ3UyeuG932SkI/yMpuT/PqSqGXNTS1zhno1lDqg=
-github.com/kong/go-database-reconciler v1.22.6 h1:G8rjG7057aVHem4q6tyyzEyJo3hH2weL0U9JAZk4H/0=
-github.com/kong/go-database-reconciler v1.22.6/go.mod h1:hLtPRsuxqTYv1rt6h/YrimjDQzkxlAFSIWoG1jEjWKE=
-github.com/kong/go-database-reconciler v1.22.7-0.20250509051435-c0c4bfd03aed h1:0XfYIOOIhHPOj/8O9sGGrOjCNY/xiq21oOFfRmtJQQ4=
-github.com/kong/go-database-reconciler v1.22.7-0.20250509051435-c0c4bfd03aed/go.mod h1:hLtPRsuxqTYv1rt6h/YrimjDQzkxlAFSIWoG1jEjWKE=
+github.com/kong/go-database-reconciler v1.22.7 h1:7sjQBpGvL46pHpEdjLRUX9+D7fjk2lUsPgBTob6UguM=
+github.com/kong/go-database-reconciler v1.22.7/go.mod h1:hLtPRsuxqTYv1rt6h/YrimjDQzkxlAFSIWoG1jEjWKE=
 github.com/kong/go-kong v0.65.1 h1:CM+8NlF+VbJckTxP2hGmSPKhA1GMliitXjQ7vJiPkaE=
 github.com/kong/go-kong v0.65.1/go.mod h1:sqdysTKrXIJ6mpxHwTwjgZhLW7jR1/puczTXHLUwJaE=
 github.com/kong/go-slugify v1.0.0 h1:vCFAyf2sdoSlBtLcrmDWUFn0ohlpKiKvQfXZkO5vSKY=

--- a/go.sum
+++ b/go.sum
@@ -248,6 +248,8 @@ github.com/kong/go-apiops v0.1.42 h1:GF9KV1D06p/Ux2F5Dc4UJzGKFOeMzynpUWiAZwyEqxE
 github.com/kong/go-apiops v0.1.42/go.mod h1:hKnHJ3UyeuG932SkI/yMpuT/PqSqGXNTS1zhno1lDqg=
 github.com/kong/go-database-reconciler v1.22.6 h1:G8rjG7057aVHem4q6tyyzEyJo3hH2weL0U9JAZk4H/0=
 github.com/kong/go-database-reconciler v1.22.6/go.mod h1:hLtPRsuxqTYv1rt6h/YrimjDQzkxlAFSIWoG1jEjWKE=
+github.com/kong/go-database-reconciler v1.22.7-0.20250509051435-c0c4bfd03aed h1:0XfYIOOIhHPOj/8O9sGGrOjCNY/xiq21oOFfRmtJQQ4=
+github.com/kong/go-database-reconciler v1.22.7-0.20250509051435-c0c4bfd03aed/go.mod h1:hLtPRsuxqTYv1rt6h/YrimjDQzkxlAFSIWoG1jEjWKE=
 github.com/kong/go-kong v0.65.1 h1:CM+8NlF+VbJckTxP2hGmSPKhA1GMliitXjQ7vJiPkaE=
 github.com/kong/go-kong v0.65.1/go.mod h1:sqdysTKrXIJ6mpxHwTwjgZhLW7jR1/puczTXHLUwJaE=
 github.com/kong/go-slugify v1.0.0 h1:vCFAyf2sdoSlBtLcrmDWUFn0ohlpKiKvQfXZkO5vSKY=

--- a/tests/integration/apply_test.go
+++ b/tests/integration/apply_test.go
@@ -107,3 +107,70 @@ func Test_Apply_3x(t *testing.T) {
 		assert.Equal(t, expectedChanged, outChanged)
 	})
 }
+
+// test scope:
+//   - enterprise: >=3.0.0
+func Test_Apply_Custom_Entities(t *testing.T) {
+	runWhen(t, "enterprise", ">=3.0.0")
+	setup(t)
+
+	ctx := context.Background()
+	tests := []struct {
+		name                   string
+		initialStateFile       string
+		targetPartialStateFile string
+	}{
+		{
+			name:                   "degraphql routes",
+			initialStateFile:       "testdata/apply/008-custom-entities/initial-state.yaml",
+			targetPartialStateFile: "testdata/apply/008-custom-entities/partial-update.yaml",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Cleanup(func() {
+				reset(t)
+			})
+			err := sync(ctx, tc.initialStateFile)
+			require.NoError(t, err)
+
+			err = apply(ctx, tc.targetPartialStateFile)
+			require.NoError(t, err)
+		})
+	}
+}
+
+// test scope:
+//   - konnect
+func Test_Apply_Custom_Entities_Konnect(t *testing.T) {
+	t.Setenv("DECK_KONNECT_CONTROL_PLANE_NAME", "default")
+	runWhen(t, "konnect", "")
+	setup(t)
+
+	ctx := context.Background()
+	tests := []struct {
+		name                   string
+		initialStateFile       string
+		targetPartialStateFile string
+	}{
+		{
+			name:                   "degraphql routes",
+			initialStateFile:       "testdata/apply/008-custom-entities/initial-state.yaml",
+			targetPartialStateFile: "testdata/apply/008-custom-entities/partial-update.yaml",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Cleanup(func() {
+				reset(t)
+			})
+			err := sync(ctx, tc.initialStateFile)
+			require.NoError(t, err)
+
+			err = apply(ctx, tc.targetPartialStateFile)
+			require.NoError(t, err)
+		})
+	}
+}

--- a/tests/integration/apply_test.go
+++ b/tests/integration/apply_test.go
@@ -110,42 +110,9 @@ func Test_Apply_3x(t *testing.T) {
 
 // test scope:
 //   - enterprise: >=3.0.0
-func Test_Apply_Custom_Entities(t *testing.T) {
-	runWhen(t, "enterprise", ">=3.0.0")
-	setup(t)
-
-	ctx := context.Background()
-	tests := []struct {
-		name                   string
-		initialStateFile       string
-		targetPartialStateFile string
-	}{
-		{
-			name:                   "degraphql routes",
-			initialStateFile:       "testdata/apply/008-custom-entities/initial-state.yaml",
-			targetPartialStateFile: "testdata/apply/008-custom-entities/partial-update.yaml",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Cleanup(func() {
-				reset(t)
-			})
-			err := sync(ctx, tc.initialStateFile)
-			require.NoError(t, err)
-
-			err = apply(ctx, tc.targetPartialStateFile)
-			require.NoError(t, err)
-		})
-	}
-}
-
-// test scope:
 //   - konnect
-func Test_Apply_Custom_Entities_Konnect(t *testing.T) {
-	t.Setenv("DECK_KONNECT_CONTROL_PLANE_NAME", "default")
-	runWhen(t, "konnect", "")
+func Test_Apply_Custom_Entities(t *testing.T) {
+	runWhenEnterpriseOrKonnect(t, ">=3.0.0")
 	setup(t)
 
 	ctx := context.Background()

--- a/tests/integration/testdata/apply/008-custom-entities/initial-state.yaml
+++ b/tests/integration/testdata/apply/008-custom-entities/initial-state.yaml
@@ -1,0 +1,23 @@
+_format_version: "3.0"
+services:
+- connect_timeout: 60000
+  enabled: true
+  host: example.com
+  name: example
+  plugins:
+  - config:
+      graphql_server_path: /graphql
+    enabled: true
+    name: degraphql
+    protocols:
+    - grpc
+    - grpcs
+    - http
+    - https
+  port: 443
+  protocol: https
+  read_timeout: 60000
+  retries: 5
+  write_timeout: 60000
+  tags:
+    - foo' 

--- a/tests/integration/testdata/apply/008-custom-entities/partial-update.yaml
+++ b/tests/integration/testdata/apply/008-custom-entities/partial-update.yaml
@@ -1,0 +1,10 @@
+_format_version: "3.0"
+custom_entities:
+- fields:
+    methods:
+    - GET
+    query: query { viewer { login } }
+    service:
+      name: example
+    uri: /me
+  type: degraphql_routes


### PR DESCRIPTION
### Summary

In this PR, we are bumping Go database reconciler and adding integrations tests to run `gateway apply` for custom entities.

PR on GDR: https://github.com/Kong/go-database-reconciler/pull/267

### Issues resolved
https://github.com/Kong/deck/issues/1568

### Testing

- [x] Integration tests
- [x] Manual testing on Kong
- [x] Manual testing on Konnect
