### PR TITLE
chore: updated golang to v1.24.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.0 AS build
+FROM golang:1.24.3 AS build
 WORKDIR /deck
 COPY go.mod ./
 COPY go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/deck
 
-go 1.23.5
+go 1.24.3
 
 replace github.com/yudai/gojsondiff v1.0.0 => github.com/Kong/gojsondiff v1.3.0
 


### PR DESCRIPTION
This change would also ensure
that we account for CVEs
https://nvd.nist.gov/vuln/detail/cve-2025-22871
and https://nvd.nist.gov/vuln/detail/CVE-2025-22866