### PR TITLE
fix: allow empty string as path param, and prevent extra service creation in openapi2kong

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/daveshanley/vacuum v0.9.15
 	github.com/fatih/color v1.18.0
 	github.com/google/go-cmp v0.7.0
-	github.com/kong/go-apiops v0.1.43
+	github.com/kong/go-apiops v0.1.45
 	github.com/kong/go-database-reconciler v1.24.0
 	github.com/kong/go-kong v0.66.1
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -240,8 +240,8 @@ github.com/klauspost/cpuid/v2 v2.0.10/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuOb
 github.com/klauspost/cpuid/v2 v2.0.12/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=
 github.com/klauspost/cpuid/v2 v2.2.5 h1:0E5MSMDEoAulmXNFquVs//DdoomxaoTY1kUhbc/qbZg=
 github.com/klauspost/cpuid/v2 v2.2.5/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
-github.com/kong/go-apiops v0.1.43 h1:0CYgjJnKbyQQf3j3kGTBXmeo6AoPXl4cgKl67SI16Ks=
-github.com/kong/go-apiops v0.1.43/go.mod h1:hKnHJ3UyeuG932SkI/yMpuT/PqSqGXNTS1zhno1lDqg=
+github.com/kong/go-apiops v0.1.45 h1:hZxIE9FSC9D5IqBIORKXBaNA8udXRkBajbnNzQU47hM=
+github.com/kong/go-apiops v0.1.45/go.mod h1:hKnHJ3UyeuG932SkI/yMpuT/PqSqGXNTS1zhno1lDqg=
 github.com/kong/go-database-reconciler v1.24.0 h1:jTLXoGpUYCvyUe8BsgtxRGGQVVH0/zpF9FsWcdoGnBs=
 github.com/kong/go-database-reconciler v1.24.0/go.mod h1:bUANvxp2by0tybm3rno4a+AqLwWGotTYHIqbTaz4uo0=
 github.com/kong/go-kong v0.66.1 h1:UVdemzcCpfXEl6O/VHdf0rT2bXdIO5ykuJbf2z1JTko=


### PR DESCRIPTION
PR on go-apiops: https://github.com/Kong/go-apiops/pull/271 and https://github.com/Kong/go-apiops/pull/270
Fixes https://github.com/Kong/go-apiops/issues/269 and https://github.com/Kong/deck/issues/1640

