### PR TITLE
ci: removed docker login from validate workflow

### DIFF
--- a/.github/workflows/validate-kong-release.yaml
+++ b/.github/workflows/validate-kong-release.yaml
@@ -25,11 +25,6 @@ jobs:
         run: |
           echo "Kong Gateway Image = ${{ inputs.kong_image }}"
           echo "decK Branch = ${{ inputs.branch }}"
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{secrets.DOCKERHUB_PULL_USERNAME}}
-          password: ${{secrets.DOCKERHUB_PULL_TOKEN}}
       - name: Checkout repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
`kong/kong-gateway-dev` and `kong/kong-dev` are public repos and thus don't require docker logins.
This worked till now but I believe the docker user we were using was getting access denied with recent images.
For now, removing the docker login as it isn't not required.
Confirmed here: https://kongstrong.slack.com/archives/C027PKSNBC5/p1750151682471579?thread_ts=1750148184.011979&cid=C027PKSNBC5