### PR TITLE
chore: release prep for v1.49.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [v1.49.1](#v1491)
 - [v1.49.0](#v1490)
 - [v1.48.0](#v1480)
 - [v1.47.1](#v1471)
@@ -116,6 +117,24 @@
 - [v0.3.0](#v030)
 - [v0.2.0](#v020)
 - [v0.1.0](#v010)
+
+## [v1.49.1]
+> Release date: 2025/06/27
+
+### Fixed
+- Sync failures due to missing names for keys, keysets.
+[#1675](https://github.com/Kong/deck/pull/1675)
+[go-database-reconciler #301](https://github.com/Kong/go-database-reconciler/pull/301)
+- Fixed online validation for partials.
+[#1666](https://github.com/Kong/deck/pull/1666)
+- Fixed error message passed to end-users while using
+offline (file) validation with default_lookup_tags.
+[#1669](https://github.com/Kong/deck/pull/1669)
+- Fixed service configuration generation when no servers
+are present in an OAS document while using `deck file
+openapi2kong` command.
+[#1676](https://github.com/Kong/deck/pull/1676)
+[go-apiops #273](https://github.com/Kong/go-apiops/pull/273)
 
 ## [v1.49.0]
 > Release date: 2025/06/17
@@ -2194,6 +2213,7 @@ No breaking changes have been introduced in this release.
 
 Debut release of decK
 
+[v1.49.1]: https://github.com/Kong/deck/compare/v1.49.0...v1.49.1
 [v1.49.0]: https://github.com/Kong/deck/compare/v1.48.0...v1.49.0
 [v1.48.0]: https://github.com/Kong/deck/compare/v1.47.1...v1.48.0
 [v1.47.1]: https://github.com/Kong/deck/compare/v1.47.0...v1.47.1

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ the GitHub [release page](https://github.com/kong/deck/releases)
 or install by downloading the binary:
 
 ```shell
-$ curl -sL https://github.com/kong/deck/releases/download/v1.49.0/deck_1.49.0_linux_amd64.tar.gz -o deck.tar.gz
+$ curl -sL https://github.com/kong/deck/releases/download/v1.49.1/deck_1.49.1_linux_amd64.tar.gz -o deck.tar.gz
 $ tar -xf deck.tar.gz -C /tmp
 $ sudo cp /tmp/deck /usr/local/bin/
 ```
@@ -84,7 +84,7 @@ If you are on Windows, you can download the binary from the GitHub
 [release page](https://github.com/kong/deck/releases) or via PowerShell:
 
 ```shell
-$ curl -sL https://github.com/kong/deck/releases/download/v1.49.0/deck_1.49.0_windows_amd64.tar.gz -o deck.tar.gz
+$ curl -sL https://github.com/kong/deck/releases/download/v1.49.1/deck_1.49.1_windows_amd64.tar.gz -o deck.tar.gz
 $ tar -xzvf deck.tar.gz
 ```
 


### PR DESCRIPTION
Changes:
deck: https://github.com/Kong/deck/compare/v1.49.0...main
gdr: https://github.com/Kong/go-database-reconciler/compare/v1.24.1...v1.24.2
go-apiops: https://github.com/Kong/go-apiops/compare/v0.1.45...v0.1.46