### PR TITLE
chore: release prep for v1.49.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [v1.49.2](#v1492)
 - [v1.49.1](#v1491)
 - [v1.49.0](#v1490)
 - [v1.48.0](#v1480)
@@ -117,6 +118,23 @@
 - [v0.3.0](#v030)
 - [v0.2.0](#v020)
 - [v0.1.0](#v010)
+
+## [v1.49.2]
+> Release date: 2025/07/30
+
+### Fixed
+- Fixed partial apply failure for nested routes, consumers.
+[#1691](https://github.com/Kong/deck/pull/1691)
+[go-database-reconciler #309](https://github.com/Kong/go-database-reconciler/pull/309)
+- Fixed panic while running `deck file openapi2kong` command with `--generate-security` flag.
+[#1695](https://github.com/Kong/deck/pull/1695)
+[go-apiops #274](https://github.com/Kong/go-apiops/pull/274)
+- Fixed false diff on consumer_groups created via AdminAPI/Kong Manager.
+[go-database-reconciler #307](https://github.com/Kong/go-database-reconciler/pull/307)
+
+### Chores
+- Bump golang version to v1.24.4 to resolve CVE-2025-228774
+[#1705](https://github.com/Kong/deck/pull/1705)
 
 ## [v1.49.1]
 > Release date: 2025/06/27
@@ -2213,6 +2231,7 @@ No breaking changes have been introduced in this release.
 
 Debut release of decK
 
+[v1.49.2]: https://github.com/Kong/deck/compare/v1.49.1...v1.49.2
 [v1.49.1]: https://github.com/Kong/deck/compare/v1.49.0...v1.49.1
 [v1.49.0]: https://github.com/Kong/deck/compare/v1.48.0...v1.49.0
 [v1.48.0]: https://github.com/Kong/deck/compare/v1.47.1...v1.48.0

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ the GitHub [release page](https://github.com/kong/deck/releases)
 or install by downloading the binary:
 
 ```shell
-$ curl -sL https://github.com/kong/deck/releases/download/v1.49.1/deck_1.49.1_linux_amd64.tar.gz -o deck.tar.gz
+$ curl -sL https://github.com/kong/deck/releases/download/v1.49.2/deck_1.49.2_linux_amd64.tar.gz -o deck.tar.gz
 $ tar -xf deck.tar.gz -C /tmp
 $ sudo cp /tmp/deck /usr/local/bin/
 ```
@@ -84,7 +84,7 @@ If you are on Windows, you can download the binary from the GitHub
 [release page](https://github.com/kong/deck/releases) or via PowerShell:
 
 ```shell
-$ curl -sL https://github.com/kong/deck/releases/download/v1.49.1/deck_1.49.1_windows_amd64.tar.gz -o deck.tar.gz
+$ curl -sL https://github.com/kong/deck/releases/download/v1.49.2/deck_1.49.2_windows_amd64.tar.gz -o deck.tar.gz
 $ tar -xzvf deck.tar.gz
 ```
 


### PR DESCRIPTION
This release will fix the following issues:
https://github.com/Kong/deck/issues/1693
https://github.com/Kong/deck/issues/1620
https://github.com/Kong/deck/issues/1674
https://github.com/Kong/deck/issues/1688

Changes:
deck: https://github.com/Kong/deck/compare/v1.49.1...main
gdr: https://github.com/Kong/go-database-reconciler/compare/v1.24.2...v1.24.3
go-apiops: https://github.com/Kong/go-apiops/compare/v0.1.46...v0.1.47