### PR TITLE
chore: release prep for v1.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [v1.50.0](#v1500)
 - [v1.49.2](#v1492)
 - [v1.49.1](#v1491)
 - [v1.49.0](#v1490)
@@ -118,6 +119,25 @@
 - [v0.3.0](#v030)
 - [v0.2.0](#v020)
 - [v0.1.0](#v010)
+
+## [v1.50.0]
+> Release date: 2025/08/20
+
+### Added
+- Added sanitization for configurations via `deck gateway dump`
+command, using `--sanitize` flag.
+[#1721](https://github.com/Kong/deck/pull/1721)
+[#1719](https://github.com/Kong/deck/pull/1719)
+[#1724](https://github.com/Kong/deck/pull/1724)
+[#1726](https://github.com/Kong/deck/pull/1726)
+[#1728](https://github.com/Kong/deck/pull/1728)
+[#1732](https://github.com/Kong/deck/pull/1732)
+[#1731](https://github.com/Kong/deck/pull/1731)
+[go-database-reconciler #313](https://github.com/Kong/go-database-reconciler/pull/313)
+- Added partial support to `deck file kong2tf` command
+[#1715](https://github.com/Kong/deck/pull/1715)
+- Added sticky sessions' config for upstream entity.
+[go-database-reconciler #328](https://github.com/Kong/go-database-reconciler/pull/328)
 
 ## [v1.49.2]
 > Release date: 2025/07/30
@@ -2231,6 +2251,7 @@ No breaking changes have been introduced in this release.
 
 Debut release of decK
 
+[v1.50.0]: https://github.com/Kong/deck/compare/v1.49.2...v1.50.0
 [v1.49.2]: https://github.com/Kong/deck/compare/v1.49.1...v1.49.2
 [v1.49.1]: https://github.com/Kong/deck/compare/v1.49.0...v1.49.1
 [v1.49.0]: https://github.com/Kong/deck/compare/v1.48.0...v1.49.0

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ the GitHub [release page](https://github.com/kong/deck/releases)
 or install by downloading the binary:
 
 ```shell
-$ curl -sL https://github.com/kong/deck/releases/download/v1.49.2/deck_1.49.2_linux_amd64.tar.gz -o deck.tar.gz
+$ curl -sL https://github.com/kong/deck/releases/download/v1.50.0/deck_1.50.0_linux_amd64.tar.gz -o deck.tar.gz
 $ tar -xf deck.tar.gz -C /tmp
 $ sudo cp /tmp/deck /usr/local/bin/
 ```
@@ -84,7 +84,7 @@ If you are on Windows, you can download the binary from the GitHub
 [release page](https://github.com/kong/deck/releases) or via PowerShell:
 
 ```shell
-$ curl -sL https://github.com/kong/deck/releases/download/v1.49.2/deck_1.49.2_windows_amd64.tar.gz -o deck.tar.gz
+$ curl -sL https://github.com/kong/deck/releases/download/v1.50.0/deck_1.50.0_windows_amd64.tar.gz -o deck.tar.gz
 $ tar -xzvf deck.tar.gz
 ```
 


### PR DESCRIPTION
Changes since last release:
deck: https://github.com/Kong/deck/compare/v1.49.2...main
gdr: https://github.com/Kong/go-database-reconciler/compare/v1.24.3...v1.26.0
go-kong: https://github.com/Kong/go-kong/compare/v0.66.1...v0.67.0
go-apiops: no change