### PR TITLE
chore: updated timeout for goreleaser workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   goreleaser:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
go-releaser is taking 10 minutes and timing out before uploading assets. Thus, increasing the timeout period to avoid operation cancellation as it prevents us from releasing the cli.
Approval to increase timeout period: https://kongstrong.slack.com/archives/C027PKSNBC5/p1756369785658399?thread_ts=1756369711.863809&cid=C027PKSNBC5