### PR TITLE
fix: consumer lookups while using default lookup tags for consumer-goups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/google/go-cmp v0.7.0
 	github.com/kong/go-apiops v0.1.49
-	github.com/kong/go-database-reconciler v1.27.1-0.20250916081703-5aa27ee92256
+	github.com/kong/go-database-reconciler v1.27.1
 	github.com/kong/go-kong v0.68.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.9.1

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,8 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/google/go-cmp v0.7.0
 	github.com/kong/go-apiops v0.1.49
-	github.com/kong/go-database-reconciler v1.26.0
-	github.com/kong/go-kong v0.67.0
+	github.com/kong/go-database-reconciler v1.27.1-0.20250916081703-5aa27ee92256
+	github.com/kong/go-kong v0.68.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
@@ -53,7 +53,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
-	github.com/go-viper/mapstructure/v2 v2.3.0 // indirect
+	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect

--- a/go.sum
+++ b/go.sum
@@ -244,8 +244,8 @@ github.com/klauspost/cpuid/v2 v2.2.5 h1:0E5MSMDEoAulmXNFquVs//DdoomxaoTY1kUhbc/q
 github.com/klauspost/cpuid/v2 v2.2.5/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/kong/go-apiops v0.1.49 h1:/gjzH31qUUxvmg/lkePrh2b6trI5lrv7jJD2w9I7JPg=
 github.com/kong/go-apiops v0.1.49/go.mod h1:yPwbl3P2eQinVGAEA0d3legaYmzPJ+WtJf9fSeGF4b8=
-github.com/kong/go-database-reconciler v1.27.1-0.20250916081703-5aa27ee92256 h1:QNm3X7jyNnEbOOyZ+QKFnE0qqh+CUa9GdjeHXMf/GP4=
-github.com/kong/go-database-reconciler v1.27.1-0.20250916081703-5aa27ee92256/go.mod h1:6EnCqJqkYWwf9UjkiIKXCv29kapPFUBQ2+FVjR9ZslE=
+github.com/kong/go-database-reconciler v1.27.1 h1:a5EyqQsY5BF2p964J2PQW9BMIMvTz30A2FInIAf1TcA=
+github.com/kong/go-database-reconciler v1.27.1/go.mod h1:6EnCqJqkYWwf9UjkiIKXCv29kapPFUBQ2+FVjR9ZslE=
 github.com/kong/go-kong v0.68.0 h1:rQrLYRKXD6/xf41GBXj9Ns+woAH9p6a4VvcXNMiPZPI=
 github.com/kong/go-kong v0.68.0/go.mod h1:J0vGB3wsZ2i99zly1zTRe3v7rOKpkhQZRwbcTFP76qM=
 github.com/kong/go-slugify v1.0.0 h1:vCFAyf2sdoSlBtLcrmDWUFn0ohlpKiKvQfXZkO5vSKY=

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8Wd
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
-github.com/go-viper/mapstructure/v2 v2.3.0 h1:27XbWsHIqhbdR5TIC911OfYvgSaW93HM+dX7970Q7jk=
-github.com/go-viper/mapstructure/v2 v2.3.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
+github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -244,10 +244,10 @@ github.com/klauspost/cpuid/v2 v2.2.5 h1:0E5MSMDEoAulmXNFquVs//DdoomxaoTY1kUhbc/q
 github.com/klauspost/cpuid/v2 v2.2.5/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/kong/go-apiops v0.1.49 h1:/gjzH31qUUxvmg/lkePrh2b6trI5lrv7jJD2w9I7JPg=
 github.com/kong/go-apiops v0.1.49/go.mod h1:yPwbl3P2eQinVGAEA0d3legaYmzPJ+WtJf9fSeGF4b8=
-github.com/kong/go-database-reconciler v1.26.0 h1:x074dbSwYbTaUVmrCbDy1z9dy2oWu/XTbpxFJ/YEccQ=
-github.com/kong/go-database-reconciler v1.26.0/go.mod h1:wq48xbXrcs1NCm7MlPhOIuYFjw66NR0zu+du+Br9q0I=
-github.com/kong/go-kong v0.67.0 h1:54zXKc58IZpZdlJCv8p95SJjejTxT+cwbWXw97icCak=
-github.com/kong/go-kong v0.67.0/go.mod h1:J0vGB3wsZ2i99zly1zTRe3v7rOKpkhQZRwbcTFP76qM=
+github.com/kong/go-database-reconciler v1.27.1-0.20250916081703-5aa27ee92256 h1:QNm3X7jyNnEbOOyZ+QKFnE0qqh+CUa9GdjeHXMf/GP4=
+github.com/kong/go-database-reconciler v1.27.1-0.20250916081703-5aa27ee92256/go.mod h1:6EnCqJqkYWwf9UjkiIKXCv29kapPFUBQ2+FVjR9ZslE=
+github.com/kong/go-kong v0.68.0 h1:rQrLYRKXD6/xf41GBXj9Ns+woAH9p6a4VvcXNMiPZPI=
+github.com/kong/go-kong v0.68.0/go.mod h1:J0vGB3wsZ2i99zly1zTRe3v7rOKpkhQZRwbcTFP76qM=
 github.com/kong/go-slugify v1.0.0 h1:vCFAyf2sdoSlBtLcrmDWUFn0ohlpKiKvQfXZkO5vSKY=
 github.com/kong/go-slugify v1.0.0/go.mod h1:dbR2h3J2QKXQ1k0aww6cN7o4cIcwlWflr6RKRdcoaiw=
 github.com/kong/kubernetes-configuration v1.4.2 h1:/OafLbl2NucvgQV7Xf/uneIgjxmPPUeE92BrssfVAQY=

--- a/tests/integration/diff_test.go
+++ b/tests/integration/diff_test.go
@@ -839,3 +839,39 @@ func Test_Diff_NoDiffCompressedTarget(t *testing.T) {
 	assert.Equal(t, emptyOutput, out)
 	reset(t)
 }
+
+func Test_Diff_Consumers_Default_Lookup_Tag(t *testing.T) {
+	runWhen(t, "enterprise", ">=2.8.0")
+	setup(t)
+
+	ctx := context.Background()
+
+	expectedDiff := `creating consumer user2
+creating consumer-group-consumer user2
+Summary:
+  Created: 2
+  Updated: 0
+  Deleted: 0
+`
+
+	// sync consumer-group and consumer-1 file
+	require.NoError(t, sync(ctx, "testdata/sync/015-consumer-groups/kong-cg.yaml"))
+	require.NoError(t, sync(ctx, "testdata/sync/015-consumer-groups/kong-consumer-1.yaml"))
+
+	out, err := diff("testdata/sync/015-consumer-groups/kong-consumer-2.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, expectedDiff, out)
+
+	// sync consumer file 2
+	require.NoError(t, sync(ctx, "testdata/sync/015-consumer-groups/kong-consumer-2.yaml"))
+
+	// diff consumer file 1 again to verify no diff
+	out, err = diff("testdata/sync/015-consumer-groups/kong-consumer-1.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, emptyOutput, out)
+
+	// finally sync consumer file 2 to verify no diff
+	out, err = diff("testdata/sync/015-consumer-groups/kong-consumer-2.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, emptyOutput, out)
+}

--- a/tests/integration/diff_test.go
+++ b/tests/integration/diff_test.go
@@ -841,7 +841,7 @@ func Test_Diff_NoDiffCompressedTarget(t *testing.T) {
 }
 
 func Test_Diff_Consumers_Default_Lookup_Tag(t *testing.T) {
-	runWhen(t, "enterprise", ">=2.8.0")
+	runWhenEnterpriseOrKonnect(t, ">=2.8.0")
 	setup(t)
 
 	ctx := context.Background()

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -8612,7 +8612,8 @@ func Test_Sync_Partials(t *testing.T) {
 
 func Test_Sync_Consumers_Default_Lookup_Tag(t *testing.T) {
 	runWhenEnterpriseOrKonnect(t, ">=2.8.0")
-
+	client, err := getTestClient()
+	require.NoError(t, err)
 	ctx := context.Background()
 
 	t.Run("no errors occur in case of subsequent syncs with distributed config and defaultLookupTags for consumer-group",
@@ -8649,6 +8650,47 @@ func Test_Sync_Consumers_Default_Lookup_Tag(t *testing.T) {
 			// sync again
 			err = sync(ctx, "testdata/sync/015-consumer-groups/kong-consumers-no-tag.yaml")
 			require.NoError(t, err)
+		})
+	t.Run("no errors occur in case of distributed config when >1 consumers are tagged with different tags",
+		func(t *testing.T) {
+			// sync consumer-group file first
+			err := sync(ctx, "testdata/sync/015-consumer-groups/kong-cg.yaml")
+			t.Cleanup(func() {
+				reset(t)
+			})
+			require.NoError(t, err)
+
+			// sync consumer file 1
+			err = sync(ctx, "testdata/sync/015-consumer-groups/kong-consumer-1.yaml")
+			require.NoError(t, err)
+
+			// sync consumer file 2
+			err = sync(ctx, "testdata/sync/015-consumer-groups/kong-consumer-2.yaml")
+			require.NoError(t, err)
+
+			// re-sync with no error
+			err = sync(ctx, "testdata/sync/015-consumer-groups/kong-consumer-1.yaml")
+			require.NoError(t, err)
+			err = sync(ctx, "testdata/sync/015-consumer-groups/kong-consumer-2.yaml")
+			require.NoError(t, err)
+
+			// check number of consumerGroupConsumers
+			currentState, err := fetchCurrentState(ctx, client, deckDump.Config{
+				LookUpSelectorTagsConsumerGroups: []string{"group-tag"},
+			}, t)
+			require.NoError(t, err)
+
+			consumerGroupConsumers, err := currentState.ConsumerGroupConsumers.GetAll()
+			require.NoError(t, err)
+			require.NotNil(t, consumerGroupConsumers)
+			require.Len(t, consumerGroupConsumers, 2)
+
+			consumerNames := []string{"user1", "user2"}
+
+			for _, consumerGroupConsumer := range consumerGroupConsumers {
+				assert.Contains(t, consumerNames, *consumerGroupConsumer.Consumer.Username)
+				assert.Equal(t, "foo-group", *consumerGroupConsumer.ConsumerGroup.Name)
+			}
 		})
 }
 

--- a/tests/integration/test_utils.go
+++ b/tests/integration/test_utils.go
@@ -361,7 +361,7 @@ func multiFileSync(ctx context.Context, kongFiles []string, opts ...string) erro
 
 func diff(kongFile string, opts ...string) (string, error) {
 	deckCmd := cmd.NewRootCmd()
-	args := []string{"diff", "-s", kongFile}
+	args := []string{"gateway", "diff", kongFile}
 	if len(opts) > 0 {
 		args = append(args, opts...)
 	}

--- a/tests/integration/testdata/sync/015-consumer-groups/kong-consumer-1.yaml
+++ b/tests/integration/testdata/sync/015-consumer-groups/kong-consumer-1.yaml
@@ -1,0 +1,15 @@
+# user1.yaml
+_format_version: "3.0"
+_info:
+  default_lookup_tags:
+    consumer_groups:
+     - group-tag 
+  select_tags:
+  - user1
+consumers:
+- custom_id: user1
+  username: user1
+  groups:
+  - name: foo-group
+    tags:
+    - group-tag

--- a/tests/integration/testdata/sync/015-consumer-groups/kong-consumer-2.yaml
+++ b/tests/integration/testdata/sync/015-consumer-groups/kong-consumer-2.yaml
@@ -1,0 +1,15 @@
+# user2.yaml
+_format_version: "3.0"
+_info:
+  default_lookup_tags:
+    consumer_groups:
+     - group-tag 
+  select_tags:
+  - user2
+consumers:
+- custom_id: user2
+  username: user2
+  groups:
+  - name: foo-group
+    tags:
+    - group-tag


### PR DESCRIPTION
Syncing and diffing with default_lookup_tags
for consumer-groups was errorneous. While
dumping config, we would dump all consumers
in case of default-lookup tags. Thus, in case of
serial syncing of consumers, previous consumers
would end up getting deleted.
This fix ensures that no unexpected deletions occur
while using consumer-group lookups. 

Issue is described in detail in
the doc and FTI below: 
- [Document](https://konghq.atlassian.net/wiki/spaces/~7120204d7e8997ba384e09b1eee597d986a1dc/pages/4618027031/Default+LookUp+Tags+for+Deck)
- [FTI](https://konghq.atlassian.net/browse/FTI-6754)