### PR TITLE
chore: release prep for v1.51.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [v1.51.1](#v1511)
 - [v1.51.0](#v1510)
 - [v1.50.0](#v1500)
 - [v1.49.2](#v1492)
@@ -120,6 +121,20 @@
 - [v0.3.0](#v030)
 - [v0.2.0](#v020)
 - [v0.1.0](#v010)
+
+## [v1.51.1]
+> Release date: 2025/09/19
+
+### Fixed
+- Fixed consumer lookups while using default lookup tags for consumer-goups.
+[#1749](https://github.com/Kong/deck/pull/1749)
+[go-database-reconciler #336](https://github.com/Kong/go-database-reconciler/pull/336)
+- Fixed output of `deck file kong2tf` by replacing unsupported characters in resource names with underscores.
+[#1756](https://github.com/Kong/deck/pull/1756)
+
+### Chores
+- Switched to the new API endpoint for updating Upstream Targets.
+[go-database-reconciler #323](https://github.com/Kong/go-database-reconciler/pull/323)
 
 ## [v1.51.0]
 > Release date: 2025/08/28
@@ -2276,6 +2291,7 @@ No breaking changes have been introduced in this release.
 
 Debut release of decK
 
+[v1.51.1]: https://github.com/Kong/deck/compare/v1.51.0...v1.51.1
 [v1.51.0]: https://github.com/Kong/deck/compare/v1.50.0...v1.51.0
 [v1.50.0]: https://github.com/Kong/deck/compare/v1.49.2...v1.50.0
 [v1.49.2]: https://github.com/Kong/deck/compare/v1.49.1...v1.49.2

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ the GitHub [release page](https://github.com/kong/deck/releases)
 or install by downloading the binary:
 
 ```shell
-$ curl -sL https://github.com/kong/deck/releases/download/v1.51.0/deck_1.51.0_linux_amd64.tar.gz -o deck.tar.gz
+$ curl -sL https://github.com/kong/deck/releases/download/v1.51.1/deck_1.51.1_linux_amd64.tar.gz -o deck.tar.gz
 $ tar -xf deck.tar.gz -C /tmp
 $ sudo cp /tmp/deck /usr/local/bin/
 ```
@@ -84,7 +84,7 @@ If you are on Windows, you can download the binary from the GitHub
 [release page](https://github.com/kong/deck/releases) or via PowerShell:
 
 ```shell
-$ curl -sL https://github.com/kong/deck/releases/download/v1.51.0/deck_1.51.0_windows_amd64.tar.gz -o deck.tar.gz
+$ curl -sL https://github.com/kong/deck/releases/download/v1.51.1/deck_1.51.1_windows_amd64.tar.gz -o deck.tar.gz
 $ tar -xzvf deck.tar.gz
 ```
 


### PR DESCRIPTION
Changes:
Deck: https://github.com/Kong/deck/compare/v1.51.0...main
GDR: https://github.com/Kong/go-database-reconciler/compare/v1.26.0...v1.27.1
Go-Kong: https://github.com/Kong/go-kong/compare/v0.67.0...v0.68.0
