### PR TITLE
Chore: bump go version to 1.24.6

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - uses: golangci/golangci-lint-action@v8.0.0
+      - uses: golangci/golangci-lint-action@v6.2.0
 
   build:
     timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.1 AS build
+FROM golang:1.24.6 AS build
 WORKDIR /deck
 COPY go.mod ./
 COPY go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/deck
 
-go 1.25.1
+go 1.24.6
 
 replace github.com/yudai/gojsondiff v1.0.0 => github.com/Kong/gojsondiff v1.3.0
 


### PR DESCRIPTION
This fixes https://github.com/advisories/GHSA-gwrf-jf3h-w649 reported in https://konghq.atlassian.net/browse/FTI-6967

Why not v1.25.1?
Needs golangci-lint v2.x (major bump), which needs us to migrate the linting config, and has a bunch of errors once done.
To be picked up in https://github.com/Kong/deck/issues/1762