### PR TITLE
Update homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If you are on macOS, install decK using brew:
 
 ```shell
 $ brew tap kong/deck
-$ brew install deck
+$ brew install kong/deck/deck
 ```
 
 ### Linux


### PR DESCRIPTION
`brew install deck` did not work for me even immediately after `brew tap kong/deck`

I kept getting this:
<img width="619" height="384" alt="image" src="https://github.com/user-attachments/assets/825071f9-69c9-49d3-bbbc-17e17f727ca7" />
