### PR TITLE
ci: override org-wide timeout with deck-specific repo variables

### DIFF
--- a/.github/workflows/integration-enterprise.yaml
+++ b/.github/workflows/integration-enterprise.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   integration:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: ${{ fromJSON(vars.DECK_WORKFLOW_GW_TIMEOUT) }}
     strategy:
       matrix:
         kong_image:

--- a/.github/workflows/integration-konnect.yaml
+++ b/.github/workflows/integration-konnect.yaml
@@ -12,7 +12,7 @@ on: [pull_request]
 
 jobs:
   integration:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: ${{ fromJSON(vars.DECK_WORKFLOW_KONNECT_TIMEOUT) }}
     env:
       KONG_ANONYMOUS_REPORTS: "off"
       DECK_KONNECT_EMAIL : ${{ secrets.DECK_KONNECT_EMAIL }}

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   integration:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: ${{ fromJSON(vars.DECK_WORKFLOW_GW_TIMEOUT) }}
     strategy:
       matrix:
         kong_image:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   goreleaser:
-    timeout-minutes: 20
+    timeout-minutes: ${{ fromJSON(vars.DECK_WORKFLOW_RELEASE_TIMEOUT) }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   test:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: ${{ fromJSON(vars.DECK_WORKFLOW_GW_TIMEOUT) }}
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner

--- a/.github/workflows/validate-kong-release.yaml
+++ b/.github/workflows/validate-kong-release.yaml
@@ -14,7 +14,7 @@ on:
         default: 'main'
 jobs:
   integration:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
+    timeout-minutes: ${{ fromJSON(vars.DECK_WORKFLOW_GW_TIMEOUT) }}
     name: "${{ inputs.kong_image }} against ${{ inputs.branch }}"
     env:
       KONG_ANONYMOUS_REPORTS: "off"


### PR DESCRIPTION
Konnect tests have started taking >10 minutes since a while. 
Thus, overriding all timeouts with deck-specific repo variable timeouts.
At the moment, GW_TIMEOUT are set as 10 minutes (same as org-level),
KONNECT_TIMEOUT is set as 15 minutes and release timeout as 20 minutes.