### PR TITLE
tests: add new field to fix basic auth plugin test

### DIFF
--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -217,6 +217,38 @@ var (
 		},
 	}
 
+	plugin313 = []*kong.Plugin{
+		{
+			Name: kong.String("basic-auth"),
+			Protocols: []*string{
+				kong.String("grpc"),
+				kong.String("grpcs"),
+				kong.String("http"),
+				kong.String("https"),
+			},
+			Enabled: kong.Bool(true),
+			Config: kong.Configuration{
+				"anonymous":        "58076db2-28b6-423b-ba39-a797193017f7",
+				"hide_credentials": false,
+				"realm":            string("service"),
+				"brute_force_protection": map[string]interface{}{
+					"redis": map[string]interface{}{
+						"database":    float64(0),
+						"host":        nil,
+						"password":    nil,
+						"port":        float64(6379),
+						"server_name": nil,
+						"ssl":         false,
+						"ssl_verify":  false,
+						"timeout":     float64(2000),
+						"username":    nil,
+					},
+					"strategy": string("off"),
+				},
+			},
+		},
+	}
+
 	plugin_on_entities = []*kong.Plugin{ //nolint:revive
 		{
 			Name: kong.String("prometheus"),
@@ -3040,7 +3072,7 @@ func Test_Sync_BasicAuth_Plugin_Konnect(t *testing.T) {
 			name:     "create a plugin",
 			kongFile: "testdata/sync/003-create-a-plugin/kong3x.yaml",
 			expectedState: utils.KongRawState{
-				Plugins: plugin36,
+				Plugins: plugin313,
 			},
 		},
 	}


### PR DESCRIPTION
A new field `brute_force_protection` is added to Plugin Basic Auth. This PR fixes the state comparison.