### PR TITLE
chore: update go version to 1.25.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.25.3
+ARG GO_VERSION=1.25.5
 FROM golang:${GO_VERSION} AS build
 WORKDIR /deck
 COPY go.mod ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/deck
 
-go 1.25.3
+go 1.25.5
 
 replace github.com/yudai/gojsondiff v1.0.0 => github.com/Kong/gojsondiff v1.3.0
 


### PR DESCRIPTION
We need an update for addressing a CVE affecting the standard go package - crypto.
Refer: https://kongstrong.slack.com/archives/C04349E4KRC/p1765493594552399