### PR TITLE
style: lint fix

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,7 +13,9 @@ import (
 )
 
 func registerSignalHandler() context.Context {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec
+	// cancel is called in signal handler goroutine, so it is not deferred here.
+	// hence, the linter warning is ignored.
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,4 +1,4 @@
-package utils //nolint:revive
+package utils
 
 const (
 	DefaultFormatVersion = "1.1"


### PR DESCRIPTION
golangci-lint v2.11.2 is failing the lint on two instances.
Fixed both here.