### PR TITLE
fix: validate basicauth with konnect

### DIFF
--- a/tests/integration/testdata/validate/kong-basic-auth.yaml
+++ b/tests/integration/testdata/validate/kong-basic-auth.yaml
@@ -1,0 +1,7 @@
+_format_version: "3.0"
+
+consumers:
+  - username: user
+    basicauth_credentials:
+      - username: user
+        password: pass

--- a/tests/integration/testdata/validate/konnect-basic-auth.yaml
+++ b/tests/integration/testdata/validate/konnect-basic-auth.yaml
@@ -1,0 +1,9 @@
+_format_version: "3.0"
+_konnect:
+  control_plane_name: default
+
+consumers:
+  - username: user
+    basicauth_credentials:
+      - username: user
+        password: pass

--- a/tests/integration/validate_test.go
+++ b/tests/integration/validate_test.go
@@ -33,6 +33,12 @@ func Test_Validate_Konnect(t *testing.T) {
 			errorExpected:  false,
 		},
 		{
+			name:           "validate with konnect basic auth",
+			stateFile:      "testdata/validate/konnect-basic-auth.yaml",
+			additionalArgs: []string{},
+			errorExpected:  false,
+		},
+		{
 			name:           "validate with --konnect-compatibility",
 			stateFile:      "testdata/validate/konnect.yaml",
 			additionalArgs: []string{"--konnect-compatibility"},
@@ -178,6 +184,12 @@ func Test_Validate_Gateway(t *testing.T) {
 			name:           "validate format version 1.1",
 			stateFile:      "testdata/validate/kong.yaml",
 			additionalArgs: []string{},
+		},
+		{
+			name:           "validate with kong basic auth",
+			stateFile:      "testdata/validate/kong-basic-auth.yaml",
+			additionalArgs: []string{},
+			errorExpected:  false,
 		},
 		{
 			name:           "validate format version 3.0",

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -114,6 +114,27 @@ func (v *Validator) validateEntity(entityType string, entity interface{}) (bool,
 	return resp.StatusCode == http.StatusOK, nil
 }
 
+func getEmbeddedTypeFromWrappedType(wrappedType interface{}, entityType string) interface{} {
+	switch entityType {
+	case "basicauth_credentials":
+		if wrappedType == nil {
+			return wrappedType
+		}
+		// Prefer the pointer case (most common)
+		if baPtr, ok := wrappedType.(*state.BasicAuth); ok && baPtr != nil {
+			return &baPtr.BasicAuth
+		}
+		// Also handle a value (non-pointer) just in case
+		if baVal, ok := wrappedType.(state.BasicAuth); ok {
+			return &baVal.BasicAuth
+		}
+		// Fallback: unknown shape, return as-is to avoid panics
+		return wrappedType
+	}
+
+	return wrappedType
+}
+
 func (v *Validator) entities(obj interface{}, entityType string) []error {
 	entities, err := reconcilerUtils.CallGetAll(obj)
 	if err != nil {
@@ -138,7 +159,9 @@ func (v *Validator) entities(obj interface{}, entityType string) []error {
 			defer wg.Done()
 			// release a slot when completed
 			defer func() { <-chanBuff }()
-			_, err := v.validateEntity(entityType, entities.Index(i).Interface())
+			entity := entities.Index(i).Interface()
+			embeddedEntity := getEmbeddedTypeFromWrappedType(entity, entityType)
+			_, err := v.validateEntity(entityType, embeddedEntity)
 			if err != nil {
 				mu.Lock()
 				errors = append(errors, err)


### PR DESCRIPTION
In `gateway validate`, we take the state, and pass on entities from it to the schema validation endpoint on kong/konnect.

In https://github.com/Kong/go-database-reconciler/pull/342, we introduced a new field `SkipHash` in the state type for Basic Auth - which is being sent to the schema validation endpoint, and since it is invalid, the validation fails (on both kong and konnect).

Fix: use the embedded type (go-kong `type` instead of GDR `type`) for basic auth - since it is the only affected entity.

Fixes https://github.com/Kong/deck/issues/1957