### PR TITLE
Support nested ssl_verify fields

### DIFF
--- a/convert/plugin_names.go
+++ b/convert/plugin_names.go
@@ -10,6 +10,7 @@ const (
 	graphqlProxyCacheAdvancedPluginName   = "graphql-proxy-cache-advanced"
 	graphqlRateLimitingAdvancedPluginName = "graphql-rate-limiting-advanced"
 	proxyCacheAdvancedPluginName          = "proxy-cache-advanced"
+	redisPartialsPluginName               = "redis-partials"
 	aiProxyPluginName                     = "ai-proxy"
 	aiProxyAdvancedPluginName             = "ai-proxy-advanced"
 	aiRagInjectorPluginName               = "ai-rag-injector"

--- a/convert/plugin_updates_314.go
+++ b/convert/plugin_updates_314.go
@@ -20,52 +20,134 @@ var hideCredentialsPlugins = map[string]bool{
 	ldapAuthAdvancedPluginName:    true,
 }
 
-// sslVerifyPlugins is the list of plugins where ssl_verify default
-// changed from false to true in Kong Gateway 3.14 (due to the global
-// tls_certificate_verify changing from off to on).
-var sslVerifyPlugins = map[string]bool{
-	acePluginName:                         true,
-	acmePluginName:                        true,
-	aiAwsGuardrailPluginName:              true,
-	aiAzureContentSafetyPluginName:        true,
-	aiLlmAsJudgePluginName:                true,
-	aiProxyAdvancedPluginName:             true,
-	aiRagInjectorPluginName:               true,
-	aiRateLimitingAdvancedPluginName:      true,
-	aiRequestTransformerPluginName:        true,
-	aiResponseTransformerPluginName:       true,
-	aiSemanticCachePluginName:             true,
-	aiSemanticPromptGuardPluginName:       true,
-	aiSemanticResponseGuardPluginName:     true,
-	awsLambdaPluginName:                   true,
-	azureFunctionsPluginName:              true,
-	basicAuthPluginName:                   true,
-	confluentPluginName:                   true,
-	confluentConsumePluginName:            true,
-	datakitPluginName:                     true,
-	forwardProxyPluginName:                true,
-	graphqlProxyCacheAdvancedPluginName:   true,
-	graphqlRateLimitingAdvancedPluginName: true,
-	headerCertAuthPluginName:              true,
-	httpLogPluginName:                     true,
-	jwtSignerPluginName:                   true,
-	kafkaConsumePluginName:                true,
-	kafkaLogPluginName:                    true,
-	kafkaUpstreamPluginName:               true,
-	ldapAuthPluginName:                    true,
-	ldapAuthAdvancedPluginName:            true,
-	mtlsAuthPluginName:                    true,
-	opaPluginName:                         true,
-	openidConnectPluginName:               true,
-	proxyCacheAdvancedPluginName:          true,
-	rateLimitingPluginName:                true,
-	rateLimitingAdvancedPluginName:        true,
-	requestCalloutPluginName:              true,
-	responseRateLimitingPluginName:        true,
-	samlPluginName:                        true,
-	serviceProtectionPluginName:           true,
-	tcpLogPluginName:                      true,
-	upstreamOauthPluginName:               true,
+type pluginConfigDefaultSetter struct {
+	fieldName string
+	set       func(kong.Configuration) bool
+}
+
+// sslVerifyPluginConfigSetters maps plugins to the specific config fields whose
+// TLS verification defaults changed in Kong Gateway 3.14.
+var sslVerifyPluginConfigSetters = map[string][]pluginConfigDefaultSetter{
+	acePluginName: {
+		newNestedBoolDefaultSetter("rate_limiting.redis.ssl_verify"),
+	},
+	acmePluginName: {
+		newNestedBoolDefaultSetter("storage_config.redis.ssl_verify"),
+	},
+	aiAwsGuardrailPluginName: {
+		newNestedBoolDefaultSetter("ssl_verify"),
+	},
+	aiAzureContentSafetyPluginName: {
+		newNestedBoolDefaultSetter("ssl_verify"),
+	},
+	aiProxyAdvancedPluginName: aiVectorDBSSLVerifySetters(),
+	aiRagInjectorPluginName:   aiVectorDBSSLVerifySetters(),
+	aiRateLimitingAdvancedPluginName: {
+		newNestedBoolDefaultSetter("redis.ssl_verify"),
+	},
+	aiSemanticCachePluginName:         aiVectorDBSSLVerifySetters(),
+	aiSemanticPromptGuardPluginName:   aiVectorDBSSLVerifySetters(),
+	aiSemanticResponseGuardPluginName: aiVectorDBSSLVerifySetters(),
+	awsLambdaPluginName: {
+		newNestedBoolDefaultSetter("ssl_verify"),
+	},
+	azureFunctionsPluginName: {
+		newNestedBoolDefaultSetter("https_verify"),
+	},
+	basicAuthPluginName: {
+		newNestedBoolDefaultSetter("brute_force_protection.redis.ssl_verify"),
+	},
+	confluentPluginName: {
+		newNestedBoolDefaultSetter("security.ssl_verify"),
+		newNestedBoolDefaultSetter("schema_registry.confluent.authentication.oauth2_client.ssl_verify"),
+	},
+	confluentConsumePluginName: {
+		newNestedBoolDefaultSetter("security.ssl_verify"),
+		newNestedBoolDefaultSetter("schema_registry.confluent.authentication.oauth2_client.ssl_verify"),
+	},
+	datakitPluginName: {
+		newDatakitNodeSSLVerifySetter(),
+		newNestedBoolDefaultSetter("resources.cache.redis.ssl_verify"),
+	},
+	forwardProxyPluginName: {
+		newNestedBoolDefaultSetter("https_verify"),
+	},
+	graphqlProxyCacheAdvancedPluginName: {
+		newNestedBoolDefaultSetter("redis.ssl_verify"),
+	},
+	graphqlRateLimitingAdvancedPluginName: {
+		newNestedBoolDefaultSetter("redis.ssl_verify"),
+	},
+	headerCertAuthPluginName: {
+		newNestedBoolDefaultSetter("ssl_verify"),
+	},
+	httpLogPluginName: {
+		newNestedBoolDefaultSetter("ssl_verify"),
+	},
+	jwtSignerPluginName: {
+		newNestedBoolDefaultSetter("access_token_endpoints_ssl_verify"),
+		newNestedBoolDefaultSetter("channel_token_endpoints_ssl_verify"),
+	},
+	kafkaConsumePluginName: {
+		newNestedBoolDefaultSetter("security.ssl_verify"),
+		newNestedBoolDefaultSetter("schema_registry.confluent.authentication.oauth2_client.ssl_verify"),
+		newNestedBoolDefaultSetter("topics.schema_registry.confluent.authentication.oauth2_client.ssl_verify"),
+	},
+	kafkaLogPluginName: {
+		newNestedBoolDefaultSetter("security.ssl_verify"),
+		newNestedBoolDefaultSetter("schema_registry.confluent.authentication.oauth2_client.ssl_verify"),
+	},
+	kafkaUpstreamPluginName: {
+		newNestedBoolDefaultSetter("security.ssl_verify"),
+		newNestedBoolDefaultSetter("schema_registry.confluent.authentication.oauth2_client.ssl_verify"),
+	},
+	ldapAuthPluginName: {
+		newNestedBoolDefaultSetter("verify_ldap_host"),
+	},
+	ldapAuthAdvancedPluginName: {
+		newNestedBoolDefaultSetter("verify_ldap_host"),
+	},
+	mtlsAuthPluginName: {
+		newNestedBoolDefaultSetter("ssl_verify"),
+	},
+	openidConnectPluginName: {
+		newNestedBoolDefaultSetter("ssl_verify"),
+		newNestedBoolDefaultSetter("cluster_cache_redis.ssl_verify"),
+		newNestedBoolDefaultSetter("redis.ssl_verify"),
+		newNestedBoolDefaultSetter("session_memcached_ssl_verify"),
+	},
+	proxyCacheAdvancedPluginName: {
+		newNestedBoolDefaultSetter("redis.ssl_verify"),
+	},
+	rateLimitingPluginName: {
+		newNestedBoolDefaultSetter("redis.ssl_verify"),
+	},
+	rateLimitingAdvancedPluginName: {
+		newNestedBoolDefaultSetter("redis.ssl_verify"),
+	},
+	redisPartialsPluginName: {
+		newNestedBoolDefaultSetter("ssl_verify"),
+	},
+	requestCalloutPluginName: {
+		newNestedBoolDefaultSetter("cache.redis.ssl_verify"),
+		newNestedBoolDefaultSetter("callouts.request.http_opts.ssl_verify"),
+	},
+	responseRateLimitingPluginName: {
+		newNestedBoolDefaultSetter("redis.ssl_verify"),
+	},
+	samlPluginName: {
+		newNestedBoolDefaultSetter("redis.ssl_verify"),
+	},
+	serviceProtectionPluginName: {
+		newNestedBoolDefaultSetter("redis.ssl_verify"),
+	},
+	tcpLogPluginName: {
+		newNestedBoolDefaultSetter("ssl_verify"),
+	},
+	upstreamOauthPluginName: {
+		newNestedBoolDefaultSetter("client.ssl_verify"),
+		newNestedBoolDefaultSetter("cache.redis.ssl_verify"),
+	},
 }
 
 func updatePluginsFor314(content *file.Content) {
@@ -133,13 +215,114 @@ func updateLegacyPluginConfigFor314(plugin *file.FPlugin) {
 		}
 	}
 
-	// Handle ssl_verify default change (false -> true)
-	if sslVerifyPlugins[pluginName] {
-		if _, exists := plugin.Config["ssl_verify"]; !exists {
-			plugin.Config["ssl_verify"] = false
-			cprint.UpdatePrintf(
-				"Plugin '%s': setting ssl_verify to false "+
-					"(old default, 3.14 defaults to true)\n", pluginName)
+	// Handle plugin-specific TLS verification default changes (false -> true)
+	if setters, ok := sslVerifyPluginConfigSetters[pluginName]; ok {
+		for _, setter := range setters {
+			if setter.set(plugin.Config) {
+				cprint.UpdatePrintf(
+					"Plugin '%s': setting %s to false "+
+						"(old default, 3.14 defaults to true)\n", pluginName, setter.fieldName)
+			}
 		}
 	}
+}
+
+func aiVectorDBSSLVerifySetters() []pluginConfigDefaultSetter {
+	return []pluginConfigDefaultSetter{
+		newNestedBoolDefaultSetter("vectordb.pgvector.ssl_verify"),
+		newNestedBoolDefaultSetter("vectordb.redis.ssl_verify"),
+	}
+}
+
+func newNestedBoolDefaultSetter(path string) pluginConfigDefaultSetter {
+	return pluginConfigDefaultSetter{
+		fieldName: path,
+		set: func(config kong.Configuration) bool {
+			return setNestedBoolDefault(config, splitPath(path))
+		},
+	}
+}
+
+func newDatakitNodeSSLVerifySetter() pluginConfigDefaultSetter {
+	return pluginConfigDefaultSetter{
+		fieldName: "nodes[].ssl_verify",
+		set: func(config kong.Configuration) bool {
+			nodes, ok := config["nodes"].([]interface{})
+			if !ok {
+				return false
+			}
+
+			updated := false
+			for _, rawNode := range nodes {
+				node, ok := asConfigMap(rawNode)
+				if !ok || node["type"] != "call" {
+					continue
+				}
+
+				if _, exists := node["ssl_verify"]; exists {
+					continue
+				}
+
+				node["ssl_verify"] = false
+				updated = true
+			}
+
+			return updated
+		},
+	}
+}
+
+func setNestedBoolDefault(config kong.Configuration, path []string) bool {
+	if len(path) == 0 {
+		return false
+	}
+
+	current := map[string]interface{}(config)
+	for _, segment := range path[:len(path)-1] {
+		next, exists := current[segment]
+		if !exists || next == nil {
+			return false
+		}
+
+		child, ok := asConfigMap(next)
+		if !ok {
+			return false
+		}
+
+		current = child
+	}
+
+	leaf := path[len(path)-1]
+	if _, exists := current[leaf]; exists {
+		return false
+	}
+
+	current[leaf] = false
+	return true
+}
+
+func asConfigMap(value interface{}) (map[string]interface{}, bool) {
+	switch v := value.(type) {
+	case kong.Configuration:
+		return map[string]interface{}(v), true
+	case map[string]interface{}:
+		return v, true
+	default:
+		return nil, false
+	}
+}
+
+func splitPath(path string) []string {
+	segments := make([]string, 0, len(path))
+	start := 0
+	for i := 0; i < len(path); i++ {
+		if path[i] != '.' {
+			continue
+		}
+
+		segments = append(segments, path[start:i])
+		start = i + 1
+	}
+
+	return append(segments, path[start:])
 }

--- a/convert/plugin_updates_314_test.go
+++ b/convert/plugin_updates_314_test.go
@@ -1,0 +1,179 @@
+package convert
+
+import (
+	"testing"
+
+	"github.com/kong/go-database-reconciler/pkg/file"
+	"github.com/kong/go-kong/kong"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdateLegacyPluginConfigFor314_SSLVerifyFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		plugin   *file.FPlugin
+		expected kong.Configuration
+	}{
+		{
+			name: "sets nested basic-auth redis ssl_verify",
+			plugin: &file.FPlugin{Plugin: kong.Plugin{
+				Name: kong.String(basicAuthPluginName),
+				Config: kong.Configuration{
+					"brute_force_protection": map[string]interface{}{
+						"redis": map[string]interface{}{},
+					},
+				},
+			}},
+			expected: kong.Configuration{
+				"hide_credentials": false,
+				"brute_force_protection": map[string]interface{}{
+					"redis": map[string]interface{}{
+						"ssl_verify": false,
+					},
+				},
+			},
+		},
+		{
+			name: "sets acme redis ssl_verify only when redis config exists",
+			plugin: &file.FPlugin{Plugin: kong.Plugin{
+				Name: kong.String(acmePluginName),
+				Config: kong.Configuration{
+					"storage_config": map[string]interface{}{
+						"redis": map[string]interface{}{},
+					},
+				},
+			}},
+			expected: kong.Configuration{
+				"storage_config": map[string]interface{}{
+					"redis": map[string]interface{}{
+						"ssl_verify": false,
+					},
+				},
+			},
+		},
+		{
+			name: "does not invent missing nested acme config",
+			plugin: &file.FPlugin{Plugin: kong.Plugin{
+				Name:   kong.String(acmePluginName),
+				Config: kong.Configuration{},
+			}},
+			expected: kong.Configuration{},
+		},
+		{
+			name: "sets openid-connect nested and top-level fields",
+			plugin: &file.FPlugin{Plugin: kong.Plugin{
+				Name: kong.String(openidConnectPluginName),
+				Config: kong.Configuration{
+					"cluster_cache_redis": map[string]interface{}{},
+					"redis":               map[string]interface{}{},
+				},
+			}},
+			expected: kong.Configuration{
+				"ssl_verify":                   false,
+				"session_memcached_ssl_verify": false,
+				"cluster_cache_redis": map[string]interface{}{
+					"ssl_verify": false,
+				},
+				"redis": map[string]interface{}{
+					"ssl_verify": false,
+				},
+			},
+		},
+		{
+			name: "sets datakit call nodes and redis cache ssl_verify",
+			plugin: &file.FPlugin{Plugin: kong.Plugin{
+				Name: kong.String(datakitPluginName),
+				Config: kong.Configuration{
+					"nodes": []interface{}{
+						map[string]interface{}{"type": "call", "name": "a"},
+						map[string]interface{}{"type": "branch", "name": "b"},
+					},
+					"resources": map[string]interface{}{
+						"cache": map[string]interface{}{
+							"redis": map[string]interface{}{},
+						},
+					},
+				},
+			}},
+			expected: kong.Configuration{
+				"nodes": []interface{}{
+					map[string]interface{}{"type": "call", "name": "a", "ssl_verify": false},
+					map[string]interface{}{"type": "branch", "name": "b"},
+				},
+				"resources": map[string]interface{}{
+					"cache": map[string]interface{}{
+						"redis": map[string]interface{}{"ssl_verify": false},
+					},
+				},
+			},
+		},
+		{
+			name: "sets request-callout nested fields",
+			plugin: &file.FPlugin{Plugin: kong.Plugin{
+				Name: kong.String(requestCalloutPluginName),
+				Config: kong.Configuration{
+					"cache": map[string]interface{}{
+						"redis": map[string]interface{}{},
+					},
+					"callouts": map[string]interface{}{
+						"request": map[string]interface{}{
+							"http_opts": map[string]interface{}{},
+						},
+					},
+				},
+			}},
+			expected: kong.Configuration{
+				"cache": map[string]interface{}{
+					"redis": map[string]interface{}{"ssl_verify": false},
+				},
+				"callouts": map[string]interface{}{
+					"request": map[string]interface{}{
+						"http_opts": map[string]interface{}{"ssl_verify": false},
+					},
+				},
+			},
+		},
+		{
+			name: "uses plugin-specific field names for azure and ldap",
+			plugin: &file.FPlugin{Plugin: kong.Plugin{
+				Name:   kong.String(azureFunctionsPluginName),
+				Config: kong.Configuration{},
+			}},
+			expected: kong.Configuration{
+				"https_verify": false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updateLegacyPluginConfigFor314(tt.plugin)
+			assert.Equal(t, tt.expected, tt.plugin.Config)
+		})
+	}
+}
+
+func TestUpdateLegacyPluginConfigFor314_LDAPVerifyHost(t *testing.T) {
+	plugin := &file.FPlugin{Plugin: kong.Plugin{
+		Name:   kong.String(ldapAuthPluginName),
+		Config: kong.Configuration{},
+	}}
+
+	updateLegacyPluginConfigFor314(plugin)
+
+	assert.Equal(t, kong.Configuration{
+		"hide_credentials": false,
+		"verify_ldap_host": false,
+	}, plugin.Config)
+}
+
+func TestUpdateLegacyPluginConfigFor314_LeavesUnsupportedPluginUnchanged(t *testing.T) {
+	plugin := &file.FPlugin{Plugin: kong.Plugin{
+		Name:   kong.String(aiLlmAsJudgePluginName),
+		Config: kong.Configuration{"foo": "bar"},
+	}}
+
+	updateLegacyPluginConfigFor314(plugin)
+
+	assert.Equal(t, kong.Configuration{"foo": "bar"}, plugin.Config)
+}

--- a/convert/rulesets/310-to-314/entrypoint.yaml
+++ b/convert/rulesets/310-to-314/entrypoint.yaml
@@ -57,19 +57,88 @@ rules:
   ssl-verify-plugin-check:
     description: >-
       In Kong Gateway 3.14, the global tls_certificate_verify changed from off to on,
-      which affects the ssl_verify behavior for many plugins.
+      which affects ssl_verify behavior for many plugins, including nested config fields.
     given:
-      - $.plugins[?(@.name == 'ace' || @.name == 'acme' || @.name == 'ai-aws-guardrail' || @.name == 'ai-azure-content-safety' || @.name == 'ai-llm-as-judge' || @.name == 'ai-proxy-advanced' || @.name == 'ai-rag-injector' || @.name == 'ai-rate-limiting-advanced' || @.name == 'ai-request-transformer' || @.name == 'ai-response-transformer' || @.name == 'ai-semantic-cache' || @.name == 'ai-semantic-prompt-guard' || @.name == 'ai-semantic-response-guard' || @.name == 'aws-lambda' || @.name == 'azure-functions' || @.name == 'basic-auth' || @.name == 'confluent' || @.name == 'confluent-consume' || @.name == 'datakit' || @.name == 'forward-proxy' || @.name == 'graphql-proxy-cache-advanced' || @.name == 'graphql-rate-limiting-advanced' || @.name == 'header-cert-auth' || @.name == 'http-log' || @.name == 'jwt-signer' || @.name == 'kafka-consume' || @.name == 'kafka-log' || @.name == 'kafka-upstream' || @.name == 'ldap-auth' || @.name == 'ldap-auth-advanced' || @.name == 'mtls-auth' || @.name == 'opa' || @.name == 'openid-connect' || @.name == 'proxy-cache-advanced' || @.name == 'rate-limiting' || @.name == 'rate-limiting-advanced' || @.name == 'request-callout' || @.name == 'response-ratelimiting' || @.name == 'saml' || @.name == 'service-protection' || @.name == 'tcp-log' || @.name == 'upstream-oauth')].config
-      - $.services[*].plugins[?(@.name == 'ace' || @.name == 'acme' || @.name == 'ai-aws-guardrail' || @.name == 'ai-azure-content-safety' || @.name == 'ai-llm-as-judge' || @.name == 'ai-proxy-advanced' || @.name == 'ai-rag-injector' || @.name == 'ai-rate-limiting-advanced' || @.name == 'ai-request-transformer' || @.name == 'ai-response-transformer' || @.name == 'ai-semantic-cache' || @.name == 'ai-semantic-prompt-guard' || @.name == 'ai-semantic-response-guard' || @.name == 'aws-lambda' || @.name == 'azure-functions' || @.name == 'basic-auth' || @.name == 'confluent' || @.name == 'confluent-consume' || @.name == 'datakit' || @.name == 'forward-proxy' || @.name == 'graphql-proxy-cache-advanced' || @.name == 'graphql-rate-limiting-advanced' || @.name == 'header-cert-auth' || @.name == 'http-log' || @.name == 'jwt-signer' || @.name == 'kafka-consume' || @.name == 'kafka-log' || @.name == 'kafka-upstream' || @.name == 'ldap-auth' || @.name == 'ldap-auth-advanced' || @.name == 'mtls-auth' || @.name == 'opa' || @.name == 'openid-connect' || @.name == 'proxy-cache-advanced' || @.name == 'rate-limiting' || @.name == 'rate-limiting-advanced' || @.name == 'request-callout' || @.name == 'response-ratelimiting' || @.name == 'saml' || @.name == 'service-protection' || @.name == 'tcp-log' || @.name == 'upstream-oauth')].config
-      - $.routes[*].plugins[?(@.name == 'ace' || @.name == 'acme' || @.name == 'ai-aws-guardrail' || @.name == 'ai-azure-content-safety' || @.name == 'ai-llm-as-judge' || @.name == 'ai-proxy-advanced' || @.name == 'ai-rag-injector' || @.name == 'ai-rate-limiting-advanced' || @.name == 'ai-request-transformer' || @.name == 'ai-response-transformer' || @.name == 'ai-semantic-cache' || @.name == 'ai-semantic-prompt-guard' || @.name == 'ai-semantic-response-guard' || @.name == 'aws-lambda' || @.name == 'azure-functions' || @.name == 'basic-auth' || @.name == 'confluent' || @.name == 'confluent-consume' || @.name == 'datakit' || @.name == 'forward-proxy' || @.name == 'graphql-proxy-cache-advanced' || @.name == 'graphql-rate-limiting-advanced' || @.name == 'header-cert-auth' || @.name == 'http-log' || @.name == 'jwt-signer' || @.name == 'kafka-consume' || @.name == 'kafka-log' || @.name == 'kafka-upstream' || @.name == 'ldap-auth' || @.name == 'ldap-auth-advanced' || @.name == 'mtls-auth' || @.name == 'opa' || @.name == 'openid-connect' || @.name == 'proxy-cache-advanced' || @.name == 'rate-limiting' || @.name == 'rate-limiting-advanced' || @.name == 'request-callout' || @.name == 'response-ratelimiting' || @.name == 'saml' || @.name == 'service-protection' || @.name == 'tcp-log' || @.name == 'upstream-oauth')].config
-      - $.services[*].routes[*].plugins[?(@.name == 'ace' || @.name == 'acme' || @.name == 'ai-aws-guardrail' || @.name == 'ai-azure-content-safety' || @.name == 'ai-llm-as-judge' || @.name == 'ai-proxy-advanced' || @.name == 'ai-rag-injector' || @.name == 'ai-rate-limiting-advanced' || @.name == 'ai-request-transformer' || @.name == 'ai-response-transformer' || @.name == 'ai-semantic-cache' || @.name == 'ai-semantic-prompt-guard' || @.name == 'ai-semantic-response-guard' || @.name == 'aws-lambda' || @.name == 'azure-functions' || @.name == 'basic-auth' || @.name == 'confluent' || @.name == 'confluent-consume' || @.name == 'datakit' || @.name == 'forward-proxy' || @.name == 'graphql-proxy-cache-advanced' || @.name == 'graphql-rate-limiting-advanced' || @.name == 'header-cert-auth' || @.name == 'http-log' || @.name == 'jwt-signer' || @.name == 'kafka-consume' || @.name == 'kafka-log' || @.name == 'kafka-upstream' || @.name == 'ldap-auth' || @.name == 'ldap-auth-advanced' || @.name == 'mtls-auth' || @.name == 'opa' || @.name == 'openid-connect' || @.name == 'proxy-cache-advanced' || @.name == 'rate-limiting' || @.name == 'rate-limiting-advanced' || @.name == 'request-callout' || @.name == 'response-ratelimiting' || @.name == 'saml' || @.name == 'service-protection' || @.name == 'tcp-log' || @.name == 'upstream-oauth')].config
-      - $.consumers[*].plugins[?(@.name == 'ace' || @.name == 'acme' || @.name == 'ai-aws-guardrail' || @.name == 'ai-azure-content-safety' || @.name == 'ai-llm-as-judge' || @.name == 'ai-proxy-advanced' || @.name == 'ai-rag-injector' || @.name == 'ai-rate-limiting-advanced' || @.name == 'ai-request-transformer' || @.name == 'ai-response-transformer' || @.name == 'ai-semantic-cache' || @.name == 'ai-semantic-prompt-guard' || @.name == 'ai-semantic-response-guard' || @.name == 'aws-lambda' || @.name == 'azure-functions' || @.name == 'basic-auth' || @.name == 'confluent' || @.name == 'confluent-consume' || @.name == 'datakit' || @.name == 'forward-proxy' || @.name == 'graphql-proxy-cache-advanced' || @.name == 'graphql-rate-limiting-advanced' || @.name == 'header-cert-auth' || @.name == 'http-log' || @.name == 'jwt-signer' || @.name == 'kafka-consume' || @.name == 'kafka-log' || @.name == 'kafka-upstream' || @.name == 'ldap-auth' || @.name == 'ldap-auth-advanced' || @.name == 'mtls-auth' || @.name == 'opa' || @.name == 'openid-connect' || @.name == 'proxy-cache-advanced' || @.name == 'rate-limiting' || @.name == 'rate-limiting-advanced' || @.name == 'request-callout' || @.name == 'response-ratelimiting' || @.name == 'saml' || @.name == 'service-protection' || @.name == 'tcp-log' || @.name == 'upstream-oauth')].config
+      - $..plugins[?(@.name == 'ai-aws-guardrail' || @.name == 'ai-azure-content-safety' || @.name == 'aws-lambda' || @.name == 'header-cert-auth' || @.name == 'http-log' || @.name == 'mtls-auth' || @.name == 'tcp-log')].config
+      - $..plugins[?(@.name == 'ace')].config.rate_limiting.redis
+      - $..plugins[?(@.name == 'acme')].config.storage_config.redis
+      - $..plugins[?(@.name == 'ai-proxy-advanced' || @.name == 'ai-rag-injector' || @.name == 'ai-semantic-cache' || @.name == 'ai-semantic-prompt-guard' || @.name == 'ai-semantic-response-guard')].config.vectordb.pgvector
+      - $..plugins[?(@.name == 'ai-proxy-advanced' || @.name == 'ai-rag-injector' || @.name == 'ai-rate-limiting-advanced' || @.name == 'ai-semantic-cache' || @.name == 'ai-semantic-prompt-guard' || @.name == 'ai-semantic-response-guard' || @.name == 'graphql-proxy-cache-advanced' || @.name == 'graphql-rate-limiting-advanced' || @.name == 'openid-connect' || @.name == 'proxy-cache-advanced' || @.name == 'rate-limiting' || @.name == 'rate-limiting-advanced' || @.name == 'response-ratelimiting' || @.name == 'saml' || @.name == 'service-protection')].config.redis
+      - $..plugins[?(@.name == 'basic-auth')].config.brute_force_protection.redis
+      - $..plugins[?(@.name == 'confluent' || @.name == 'confluent-consume' || @.name == 'kafka-consume' || @.name == 'kafka-log' || @.name == 'kafka-upstream')].config.security
+      - $..plugins[?(@.name == 'confluent' || @.name == 'confluent-consume' || @.name == 'kafka-consume' || @.name == 'kafka-log' || @.name == 'kafka-upstream')].config.schema_registry.confluent.authentication.oauth2_client
+      - $..plugins[?(@.name == 'kafka-consume')].config.topics.schema_registry.confluent.authentication.oauth2_client
+      - $..plugins[?(@.name == 'datakit')].config.resources.cache.redis
+      - $..plugins[?(@.name == 'datakit')].config.nodes[?(@.type == 'call')]
+      - $..plugins[?(@.name == 'openid-connect')].config.cluster_cache_redis
+      - $..plugins[?(@.name == 'redis-partials')].config
+      - $..plugins[?(@.name == 'request-callout')].config.cache.redis
+      - $..plugins[?(@.name == 'request-callout')].config.callouts.request.http_opts
+      - $..plugins[?(@.name == 'upstream-oauth')].config.client
+      - $..plugins[?(@.name == 'upstream-oauth')].config.cache.redis
     message: >-
       Kong Gateway 3.14 enables TLS certificate verification by default. Plugins that connect
       to external services over TLS without explicit ssl_verify settings will now verify
-      certificates. Set ssl_verify to false explicitly if your external services do not
-      have valid TLS certificates.
+      certificates. Set the affected ssl_verify field to false explicitly if your external
+      service does not have a valid TLS certificate.
     severity: warn
     then:
       - field: ssl_verify
+        function: defined
+
+  https-verify-plugin-check:
+    description: >-
+      In Kong Gateway 3.14, TLS verification is enabled by default for plugin HTTP clients
+      that use https_verify.
+    given:
+      - $..plugins[?(@.name == 'azure-functions' || @.name == 'forward-proxy')].config
+    message: >-
+      Kong Gateway 3.14 enables TLS certificate verification by default. Plugins that use
+      https_verify will now verify certificates unless you set https_verify to false explicitly.
+    severity: warn
+    then:
+      - field: https_verify
+        function: defined
+
+  verify-ldap-host-plugin-check:
+    description: >-
+      In Kong Gateway 3.14, LDAP plugins verify upstream TLS certificates by default through
+      verify_ldap_host.
+    given:
+      - $..plugins[?(@.name == 'ldap-auth' || @.name == 'ldap-auth-advanced')].config
+    message: >-
+      Kong Gateway 3.14 enables TLS certificate verification by default. LDAP plugins will now
+      verify certificates unless you set verify_ldap_host to false explicitly.
+    severity: warn
+    then:
+      - field: verify_ldap_host
+        function: defined
+
+  jwt-signer-ssl-verify-plugin-check:
+    description: >-
+      In Kong Gateway 3.14, JWT Signer endpoint TLS verification defaults changed to enabled.
+    given:
+      - $..plugins[?(@.name == 'jwt-signer')].config
+    message: >-
+      Kong Gateway 3.14 enables TLS certificate verification by default. JWT Signer endpoint
+      clients will now verify certificates unless you set the affected ssl_verify fields to false.
+    severity: warn
+    then:
+      - field: access_token_endpoints_ssl_verify
+        function: defined
+      - field: channel_token_endpoints_ssl_verify
+        function: defined
+
+  openid-connect-session-memcached-ssl-verify-plugin-check:
+    description: >-
+      In Kong Gateway 3.14, OpenID Connect session Memcached TLS verification defaults changed
+      to enabled.
+    given:
+      - $..plugins[?(@.name == 'openid-connect')].config
+    message: >-
+      Kong Gateway 3.14 enables TLS certificate verification by default. OpenID Connect will now
+      verify Memcached certificates unless you set session_memcached_ssl_verify to false explicitly.
+    severity: warn
+    then:
+      - field: session_memcached_ssl_verify
         function: defined

--- a/convert/testdata/11/output-expected.yaml
+++ b/convert/testdata/11/output-expected.yaml
@@ -6,7 +6,6 @@ consumers:
     name: key-auth
   - config:
       hide_credentials: false
-      ssl_verify: false
     name: basic-auth
   username: c1
 plugins:
@@ -18,7 +17,6 @@ plugins:
   name: key-auth-enc
 - config:
     hide_credentials: false
-    ssl_verify: false
   name: basic-auth
 - config:
     hide_credentials: false
@@ -26,7 +24,7 @@ plugins:
 - config:
     hide_credentials: false
     ldap_host: ldap.example.com
-    ssl_verify: false
+    verify_ldap_host: false
   name: ldap-auth
 - config:
     hide_credentials: false
@@ -41,7 +39,7 @@ plugins:
 - config:
     hide_credentials: false
     ldap_host: ldap.example.com
-    ssl_verify: false
+    verify_ldap_host: false
   name: ldap-auth-advanced
 - config:
     hide_credentials: true
@@ -56,11 +54,11 @@ plugins:
   name: http-log
 - config:
     issuer: https://auth.example.com
+    session_memcached_ssl_verify: false
     ssl_verify: false
   name: openid-connect
 - config:
     account_email: test@example.com
-    ssl_verify: false
   name: acme
 - config:
     http_endpoint: https://log.example.com
@@ -73,11 +71,9 @@ routes:
   plugins:
   - config:
       hide_credentials: false
-      ssl_verify: false
     name: basic-auth
   - config:
       account_email: test@example.com
-      ssl_verify: false
     name: acme
   protocols:
   - http


### PR DESCRIPTION
The previous implementation assumed that `ssl_verify` was at the top level of all configurations. This isn't true - the new implementation fixes nested values as expected.