### PR TITLE
ci: parallelise validation workflow

### DIFF
--- a/.github/workflows/validate-kong-release.yaml
+++ b/.github/workflows/validate-kong-release.yaml
@@ -1,6 +1,6 @@
 name: Validate Kong Gateway Release
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ inputs.kong_image }}-${{ inputs.branch }}
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Validation workflow runs on dispatch and uses a kong image to instantiate a 
kong container and a DB and then runs the integration test over it. 
We do not need to keep it serial as there are no chances of conflicts.

This change ensures that concurrency groups are different for the 
validation workflow so that >1 jobs can run in parallel.