### PR TITLE
fix: Added a cli flag for openapi2kong to skip header routes

### DIFF
--- a/cmd/file_openapi2kong.go
+++ b/cmd/file_openapi2kong.go
@@ -23,7 +23,7 @@ var (
 	cmdO2Ksecurity            bool
 	cmdO2KignoreSecurityError bool
 	cmdO2KignoreCircularRefs  bool
-	cmdO2KskipHeaderRoutes    bool
+	cmdO2KskipRouteByHeader   bool
 )
 
 // Executes the CLI command "openapi2kong"
@@ -49,7 +49,7 @@ func executeOpenapi2Kong(cmd *cobra.Command, _ []string) error {
 		OIDC:                 cmdO2Ksecurity,
 		IgnoreSecurityErrors: cmdO2KignoreSecurityError,
 		IgnoreCircularRefs:   cmdO2KignoreCircularRefs,
-		SkipRouteByHeader:    cmdO2KskipHeaderRoutes,
+		SkipRouteByHeader:    cmdO2KskipRouteByHeader,
 	}
 
 	trackInfo := deckformat.HistoryNewEntry("openapi2kong")
@@ -117,8 +117,8 @@ The output will be targeted at Kong version 3.x.
 		"ignore errors for unsupported security schemes")
 	openapi2kongCmd.Flags().BoolVar(&cmdO2KignoreCircularRefs, "ignore-circular-refs", false,
 		"ignore circular $ref errors in the OpenAPI spec (dangerous, use with caution)")
-	openapi2kongCmd.Flags().BoolVar(&cmdO2KskipHeaderRoutes, "skip-route-by-header", false,
-		"skip generation of separate routes for each header parameter enum value.\n"+
+	openapi2kongCmd.Flags().BoolVar(&cmdO2KskipRouteByHeader, "skip-route-by-header", false,
+		"skip generation of separate route for each required header parameter enum value.\n"+
 			"When set, generates a single route per operation.")
 
 	return openapi2kongCmd

--- a/cmd/file_openapi2kong.go
+++ b/cmd/file_openapi2kong.go
@@ -23,6 +23,7 @@ var (
 	cmdO2Ksecurity            bool
 	cmdO2KignoreSecurityError bool
 	cmdO2KignoreCircularRefs  bool
+	cmdO2KskipHeaderRoutes    bool
 )
 
 // Executes the CLI command "openapi2kong"
@@ -48,6 +49,7 @@ func executeOpenapi2Kong(cmd *cobra.Command, _ []string) error {
 		OIDC:                 cmdO2Ksecurity,
 		IgnoreSecurityErrors: cmdO2KignoreSecurityError,
 		IgnoreCircularRefs:   cmdO2KignoreCircularRefs,
+		SkipRouteByHeader:    cmdO2KskipHeaderRoutes,
 	}
 
 	trackInfo := deckformat.HistoryNewEntry("openapi2kong")
@@ -115,6 +117,9 @@ The output will be targeted at Kong version 3.x.
 		"ignore errors for unsupported security schemes")
 	openapi2kongCmd.Flags().BoolVar(&cmdO2KignoreCircularRefs, "ignore-circular-refs", false,
 		"ignore circular $ref errors in the OpenAPI spec (dangerous, use with caution)")
+	openapi2kongCmd.Flags().BoolVar(&cmdO2KskipHeaderRoutes, "skip-route-by-header", false,
+		"skip generation of separate routes for each header parameter enum value.\n"+
+			"When set, generates a single route per operation.")
 
 	return openapi2kongCmd
 }

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/ettle/strcase v0.2.0
 	github.com/fatih/color v1.19.0
 	github.com/google/go-cmp v0.7.0
-	github.com/kong/go-apiops v0.4.0
+	github.com/kong/go-apiops v0.4.1
 	github.com/kong/go-database-reconciler v1.36.2
 	github.com/kong/go-kong v0.75.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -223,8 +223,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/kong/go-apiops v0.4.0 h1:rXxdcE6VkDTOkhGt/ZytYqp8elw3SfrBQ/+r42lX2J4=
-github.com/kong/go-apiops v0.4.0/go.mod h1:Xt99d90LallLVwYJAGaufiNbBdsK0KKboe7gR4Ryths=
+github.com/kong/go-apiops v0.4.1 h1:jVE7O2wSwrmV/meppKRxst9ny+aASJlwj7zma+9pbzc=
+github.com/kong/go-apiops v0.4.1/go.mod h1:Xt99d90LallLVwYJAGaufiNbBdsK0KKboe7gR4Ryths=
 github.com/kong/go-database-reconciler v1.36.2 h1:fUKSWonpR1UmJdLumJ9CdD4cYQ2wDEF627hJoFr3OBI=
 github.com/kong/go-database-reconciler v1.36.2/go.mod h1:0UfhRA9oelppRbirZMp0EM9qTlxb7iu3gJd+WKzoC0w=
 github.com/kong/go-kong v0.75.0 h1:QXbujfCJc5TauYS0EhKde2hbOCDe0YZTRYIX+qa+Adc=


### PR DESCRIPTION
GH: https://github.com/Kong/deck/issues/2037
FTI: https://konghq.atlassian.net/browse/FTI-7492

Supporting PR:
https://github.com/Kong/go-apiops/pull/292