### PR TITLE
docs: changelog for releasing v1.61.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Table of Contents
 
-- [v1.60.0](#v160)
+- [v1.61.0](#v1610)
+- [v1.60.0](#v1600)
 - [v1.59.1](#v1591)
 - [v1.59.0](#v1590)
 - [v1.58.0](#v1580)
@@ -138,6 +139,17 @@
 - [v0.3.0](#v030)
 - [v0.2.0](#v020)
 - [v0.1.0](#v010)
+
+## [v1.61.0]
+> Release date: 2026/05/21
+
+### Added
+- Added support for `--skip-consumers-with-consumer-groups` flag for Konnect. [#2042](https://github.com/Kong/deck/pull/2042)
+- Added `-W` and `-E` flags to allow users to control error severity. [#2049](https://github.com/Kong/deck/pull/2049) [go-database-reconciler #466](https://github.com/Kong/go-database-reconciler/pull/466)
+
+### Chores
+- Upgraded go version to `v1.26.3`
+[#1997](https://github.com/Kong/deck/pull/1997)
 
 ## [v1.60.0]
 > Release date: 2026/05/08
@@ -2588,6 +2600,7 @@ No breaking changes have been introduced in this release.
 ### Summary
 
 Debut release of decK
+[v1.61.0]: https://github.com/Kong/deck/compare/v1.60.0...v1.61.0  
 [v1.60.0]: https://github.com/Kong/deck/compare/v1.59.1...v1.60.0
 [v1.59.1]: https://github.com/Kong/deck/compare/v1.59.0...v1.59.1
 [v1.59.0]: https://github.com/Kong/deck/compare/v1.58.0...v1.59.0

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ the GitHub [release page](https://github.com/kong/deck/releases)
 or install by downloading the binary:
 
 ```shell
-$ curl -sL https://github.com/kong/deck/releases/download/v1.60.0/deck_1.60.0_linux_amd64.tar.gz -o deck.tar.gz
+$ curl -sL https://github.com/kong/deck/releases/download/v1.61.0/deck_1.61.0_linux_amd64.tar.gz -o deck.tar.gz
 $ tar -xf deck.tar.gz -C /tmp
 $ sudo cp /tmp/deck /usr/local/bin/
 ```
@@ -84,7 +84,7 @@ If you are on Windows, you can download the binary from the GitHub
 [release page](https://github.com/kong/deck/releases) or via PowerShell:
 
 ```shell
-$ curl -sL https://github.com/kong/deck/releases/download/v1.60.0/deck_1.60.0_windows_amd64.tar.gz -o deck.tar.gz
+$ curl -sL https://github.com/kong/deck/releases/download/v1.61.0/deck_1.61.0_windows_amd64.tar.gz -o deck.tar.gz
 $ tar -xzvf deck.tar.gz
 ```
 


### PR DESCRIPTION
Changelog update for releasing v1.61.0

Changes included:
decK: https://github.com/Kong/deck/compare/v1.60.0...main
go-database-reconciler: https://github.com/Kong/go-database-reconciler/compare/v1.37.0...v1.38.0