### PR TITLE
chore: add check on branch for tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,23 @@ on:
       - 'v*.*'
 
 jobs:
+  check-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Verify tag is on main
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor ${{ github.sha }} origin/main; then
+            echo "::error::Tag must be on the main branch"
+            exit 1
+          fi
+
   goreleaser:
+    needs: check-branch
     timeout-minutes: ${{ fromJSON(vars.DECK_WORKFLOW_RELEASE_TIMEOUT || '20') }}
     runs-on: ubuntu-latest
     permissions:
@@ -40,6 +56,7 @@ jobs:
           path: dist/*
 
   build-push-images:
+    needs: check-branch
     timeout-minutes: 120
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Prevents release when wrong branch gets tagged, and ensures all tags remain on `main`.

https://kongstrong.slack.com/archives/C07AQH7SAF8/p1775674728426559