### PR TITLE
fix: fixed basic auth test failing in konnect ci

### DIFF
--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -333,6 +333,10 @@ var (
 					},
 					"strategy": string("off"),
 				},
+				"principals": map[string]interface{}{
+					"directory": string("default"),
+					"enabled":   bool(false),
+				},
 			},
 		},
 	}


### PR DESCRIPTION
https://github.com/Kong/deck/actions/runs/26738684421/job/78797317172
`Test_Sync_BasicAuth_Plugin_Konnect` was failing because `principals` field was missing.