### PR TITLE
tests: removed unrelated tests from konnect test suite

### DIFF
--- a/tests/integration/diagnostic_policy_test.go
+++ b/tests/integration/diagnostic_policy_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func Test_RenderDiagnosticSeverityOverrides_RouteRegexWarningAsError(t *testing.T) {
+	skipWhenKonnect(t)
 	_, err := render(
 		"testdata/render/005-diagnostics/route-regex.yaml",
 		"-E", "route-regex-path-format",
@@ -17,6 +18,7 @@ func Test_RenderDiagnosticSeverityOverrides_RouteRegexWarningAsError(t *testing.
 }
 
 func Test_RenderDiagnosticSeverityOverrides_OIDCSeverityOverrides(t *testing.T) {
+	skipWhenKonnect(t)
 	t.Run("defaults to hard error", func(t *testing.T) {
 		_, err := render("testdata/render/005-diagnostics/oidc-missing-config.yaml")
 		require.Error(t, err)
@@ -44,12 +46,14 @@ func Test_RenderDiagnosticSeverityOverrides_OIDCSeverityOverrides(t *testing.T) 
 }
 
 func Test_RenderDiagnosticSeverityOverrides_DefaultWarningsRemainWarnings(t *testing.T) {
+	skipWhenKonnect(t)
 	output, err := render("testdata/render/005-diagnostics/route-regex.yaml")
 	require.NoError(t, err)
 	assert.Contains(t, output, "svc-route-regex")
 }
 
 func Test_RenderDiagnosticSeverityOverrides_InvalidCode(t *testing.T) {
+	skipWhenKonnect(t)
 	_, err := render(
 		"testdata/render/005-diagnostics/route-regex.yaml",
 		"-E", "not-a-real-code",

--- a/tests/integration/file_convert_test.go
+++ b/tests/integration/file_convert_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func Test_FileConvert(t *testing.T) {
+	skipWhenKonnect(t)
 	tests := []struct {
 		name                        string
 		convertCmdSourceFormat      string
@@ -75,6 +76,7 @@ func Test_FileConvert(t *testing.T) {
 }
 
 func Test_FileConvert_NoExpandEnvVars(t *testing.T) {
+	skipWhenKonnect(t)
 	tests := []struct {
 		name               string
 		additionalArgs     []string
@@ -124,6 +126,7 @@ func Test_FileConvert_NoExpandEnvVars(t *testing.T) {
 }
 
 func Test_FileConvert_28xTo34x(t *testing.T) {
+	skipWhenKonnect(t)
 	originalCwd, err := os.Getwd()
 	require.NoError(t, err)
 	defer func() {

--- a/tests/integration/lint_test.go
+++ b/tests/integration/lint_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func Test_LintPlain(t *testing.T) {
+	skipWhenKonnect(t)
 	tests := []struct {
 		name        string
 		stateFile   string
@@ -50,6 +51,7 @@ type lintErrors struct {
 }
 
 func Test_LintStructured(t *testing.T) {
+	skipWhenKonnect(t)
 	tests := []struct {
 		name                string
 		stateFile           string

--- a/tests/integration/render_test.go
+++ b/tests/integration/render_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func Test_RenderPlain(t *testing.T) {
+	skipWhenKonnect(t)
 	tests := []struct {
 		name           string
 		stateFile      string

--- a/tests/integration/validate_test.go
+++ b/tests/integration/validate_test.go
@@ -123,6 +123,7 @@ func Test_Validate_Konnect(t *testing.T) {
 }
 
 func Test_Validate_File(t *testing.T) {
+	skipWhenKonnect(t)
 	setup(t)
 
 	tests := []struct {


### PR DESCRIPTION
Konnect CI takes >20 minutes. To avoid random timeouts, and reduce time-to-merge, some tests that make no sense to be tested against Konnect are skipped here. This would give a little buffer to avoid timeouts.
A proper fix for this increased CI time would be to split testing across multiple orgs. While we do not implement that, we wish to keep the CI time under 25 minutes. Hence, the buffer.