### PR TITLE
feat: added custom-plugins definition support gated behind --include-plugin-definitions flag

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -914,7 +914,7 @@ func checkForPluginDefinitions(content reconcilerUtils.KongRawState, includePlug
 }
 
 func containsPluginDefinitions(content reconcilerUtils.KongRawState) bool {
-	return len(content.ClonedPluginDefinitions) != 0
+	return len(content.ClonedPluginDefinitions) != 0 || len(content.CustomPluginDefinitions) != 0
 }
 
 func sendAnalytics(cmd, kongVersion string, mode mode) error {

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/fatih/color v1.19.0
 	github.com/google/go-cmp v0.7.0
 	github.com/kong/go-apiops v0.4.2
-	github.com/kong/go-database-reconciler v1.39.1-0.20260603070506-f89ffcf707ac
+	github.com/kong/go-database-reconciler v1.39.1-0.20260603071722-e4632790d2a2
 	github.com/kong/go-kong v0.76.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.10.2

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/fatih/color v1.19.0
 	github.com/google/go-cmp v0.7.0
 	github.com/kong/go-apiops v0.4.2
-	github.com/kong/go-database-reconciler v1.39.1-0.20260602075514-8f3b326cd953
+	github.com/kong/go-database-reconciler v1.39.1-0.20260603070506-f89ffcf707ac
 	github.com/kong/go-kong v0.76.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -235,6 +235,8 @@ github.com/kong/go-database-reconciler v1.39.1-0.20260603030830-5a423173a3ef h1:
 github.com/kong/go-database-reconciler v1.39.1-0.20260603030830-5a423173a3ef/go.mod h1:LRJiDPjKQylRKXozJ/2svn6uJx5RcwGrBn448QHshTo=
 github.com/kong/go-database-reconciler v1.39.1-0.20260603070506-f89ffcf707ac h1:U5rbgNRhGjNUFMZk+ALCwPSEC0aPPd+ahX7Bs2n1VYk=
 github.com/kong/go-database-reconciler v1.39.1-0.20260603070506-f89ffcf707ac/go.mod h1:w4R1UNIsuGM/3rM/M8eqn03nSBKGoszz4WEW4rKhJOE=
+github.com/kong/go-database-reconciler v1.39.1-0.20260603071722-e4632790d2a2 h1:D5NcBJB6FJ5DkP8XButrXBOpeA/rtmQEegoQF1suHvs=
+github.com/kong/go-database-reconciler v1.39.1-0.20260603071722-e4632790d2a2/go.mod h1:w4R1UNIsuGM/3rM/M8eqn03nSBKGoszz4WEW4rKhJOE=
 github.com/kong/go-kong v0.76.0 h1:hMvr51RZh7zYfLPbRqXt6F30/HSvTuAFNXqqqSS3zzw=
 github.com/kong/go-kong v0.76.0/go.mod h1:Wx5aTcMjyUnIF94M5NYFWb/EnuEkqB5STrWvybFSYYQ=
 github.com/kong/go-slugify v1.0.0 h1:vCFAyf2sdoSlBtLcrmDWUFn0ohlpKiKvQfXZkO5vSKY=

--- a/go.sum
+++ b/go.sum
@@ -231,6 +231,10 @@ github.com/kong/go-database-reconciler v1.39.1-0.20260602074119-e4d7fe9da34e h1:
 github.com/kong/go-database-reconciler v1.39.1-0.20260602074119-e4d7fe9da34e/go.mod h1:LRJiDPjKQylRKXozJ/2svn6uJx5RcwGrBn448QHshTo=
 github.com/kong/go-database-reconciler v1.39.1-0.20260602075514-8f3b326cd953 h1:eZwpSwqAEH0tVVcOapZ1DSgYXLonnnuezCGZO1xq5Ow=
 github.com/kong/go-database-reconciler v1.39.1-0.20260602075514-8f3b326cd953/go.mod h1:LRJiDPjKQylRKXozJ/2svn6uJx5RcwGrBn448QHshTo=
+github.com/kong/go-database-reconciler v1.39.1-0.20260603030830-5a423173a3ef h1:2RKd1EApG0zVHvP5jjfX9l9sUkPMGHTpnOj7Edi/7+Q=
+github.com/kong/go-database-reconciler v1.39.1-0.20260603030830-5a423173a3ef/go.mod h1:LRJiDPjKQylRKXozJ/2svn6uJx5RcwGrBn448QHshTo=
+github.com/kong/go-database-reconciler v1.39.1-0.20260603070506-f89ffcf707ac h1:U5rbgNRhGjNUFMZk+ALCwPSEC0aPPd+ahX7Bs2n1VYk=
+github.com/kong/go-database-reconciler v1.39.1-0.20260603070506-f89ffcf707ac/go.mod h1:w4R1UNIsuGM/3rM/M8eqn03nSBKGoszz4WEW4rKhJOE=
 github.com/kong/go-kong v0.76.0 h1:hMvr51RZh7zYfLPbRqXt6F30/HSvTuAFNXqqqSS3zzw=
 github.com/kong/go-kong v0.76.0/go.mod h1:Wx5aTcMjyUnIF94M5NYFWb/EnuEkqB5STrWvybFSYYQ=
 github.com/kong/go-slugify v1.0.0 h1:vCFAyf2sdoSlBtLcrmDWUFn0ohlpKiKvQfXZkO5vSKY=

--- a/tests/integration/apply_test.go
+++ b/tests/integration/apply_test.go
@@ -971,3 +971,195 @@ func Test_Apply_ClonedPluginDefinitions(t *testing.T) {
 		})
 	}
 }
+
+func Test_Apply_CustomPluginDefinitions(t *testing.T) {
+	runWhen(t, "enterprise", ">=3.15.0")
+	setup(t)
+
+	client, err := getTestClient()
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	const cpdTestdata = "testdata/custom-plugin-definitions"
+	setHeaderHandler := mustReadFile(t, cpdTestdata+"/set-header.handler.lua")
+	setHeaderSchema := mustReadFile(t, cpdTestdata+"/set-header.schema.lua")
+	colDblessHandler := mustReadFile(t, cpdTestdata+"/col-dbless.handler.lua")
+	colDblessSchema := mustReadFile(t, cpdTestdata+"/col-dbless.schema.lua")
+
+	tests := []struct {
+		name          string
+		initialFile   string
+		updateFile    string
+		expectedState utils.KongRawState
+		ignoreFields  []cmp.Option
+	}{
+		{
+			name:        "updates custom plugin definition tags",
+			initialFile: "testdata/apply/014-custom-plugin-definitions/initial-cpd-only.yaml",
+			updateFile:  "testdata/apply/014-custom-plugin-definitions/update-cpd.yaml",
+			expectedState: utils.KongRawState{
+				CustomPluginDefinitions: []*kong.CustomPluginDefinition{
+					{
+						Name:    kong.String("col-dbless"),
+						Handler: kong.String(colDblessHandler),
+						Schema:  kong.String(colDblessSchema),
+						Tags:    kong.StringSlice("tag1", "tag2"),
+					},
+					{
+						Name:    kong.String("set-header"),
+						Handler: kong.String(setHeaderHandler),
+						Schema:  kong.String(setHeaderSchema),
+						Tags:    kong.StringSlice("select-me", "tag1", "tag2", "updated-tag"),
+					},
+				},
+			},
+		},
+		{
+			name:        "updates plugin config linked with custom plugin definitions",
+			initialFile: "testdata/apply/014-custom-plugin-definitions/initial-with-plugins.yaml",
+			updateFile:  "testdata/apply/014-custom-plugin-definitions/update-plugin-config.yaml",
+			expectedState: utils.KongRawState{
+				CustomPluginDefinitions: []*kong.CustomPluginDefinition{
+					{
+						Name:    kong.String("col-dbless"),
+						Handler: kong.String(colDblessHandler),
+						Schema:  kong.String(colDblessSchema),
+						Tags:    kong.StringSlice("tag1", "tag2"),
+					},
+					{
+						Name:    kong.String("set-header"),
+						Handler: kong.String(setHeaderHandler),
+						Schema:  kong.String(setHeaderSchema),
+						Tags:    kong.StringSlice("select-me", "tag1", "tag2"),
+					},
+				},
+				Plugins: []*kong.Plugin{
+					{
+						Name:    kong.String("set-header"),
+						Enabled: kong.Bool(true),
+						Tags:    kong.StringSlice("plugin-tag1", "plugin-tag2", "select-me"),
+						Config: kong.Configuration{
+							"name":  string("X-Custom-Header"),
+							"value": string("updated-world"),
+						},
+					},
+				},
+			},
+			ignoreFields: []cmp.Option{
+				cmpopts.IgnoreFields(kong.Plugin{}, "Protocols"),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reset(t)
+			require.NoError(t, sync(ctx, tc.initialFile, "--include-plugin-definitions"))
+			require.NoError(t, apply(ctx, tc.updateFile, "--include-plugin-definitions"))
+			testKongState(t, client, false, false, tc.expectedState, tc.ignoreFields)
+		})
+	}
+}
+
+// test scope:
+//   - konnect
+func Test_Apply_CustomPluginDefinitions_Konnect(t *testing.T) {
+	runDualTestWithSkipDefaults(t, "Test_Apply_CustomPluginDefinitions_Konnect",
+		testApplyCustomPluginDefinitionsKonnectImpl)
+}
+
+func testApplyCustomPluginDefinitionsKonnectImpl(t *testing.T) {
+	setDefaultKonnectControlPlane(t)
+	runWhenKonnect(t)
+	setup(t)
+
+	client, err := getTestClient()
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	const cpdTestdata = "testdata/custom-plugin-definitions"
+	setHeaderHandler := mustReadFile(t, cpdTestdata+"/set-header.handler.lua")
+	setHeaderSchema := mustReadFile(t, cpdTestdata+"/set-header.schema.lua")
+	colDblessHandler := mustReadFile(t, cpdTestdata+"/col-dbless.handler.lua")
+	colDblessSchema := mustReadFile(t, cpdTestdata+"/col-dbless.schema.lua")
+
+	tests := []struct {
+		name          string
+		initialFile   string
+		updateFile    string
+		expectedState utils.KongRawState
+		ignoreFields  []cmp.Option
+	}{
+		{
+			name:        "updates custom plugin definition tags",
+			initialFile: "testdata/apply/014-custom-plugin-definitions/initial-cpd-only.yaml",
+			updateFile:  "testdata/apply/014-custom-plugin-definitions/update-cpd.yaml",
+			expectedState: utils.KongRawState{
+				CustomPluginDefinitions: []*kong.CustomPluginDefinition{
+					{
+						Name:    kong.String("col-dbless"),
+						Handler: kong.String(colDblessHandler),
+						Schema:  kong.String(colDblessSchema),
+						Tags:    kong.StringSlice("tag1", "tag2"),
+					},
+					{
+						Name:    kong.String("set-header"),
+						Handler: kong.String(setHeaderHandler),
+						Schema:  kong.String(setHeaderSchema),
+						Tags:    kong.StringSlice("select-me", "tag1", "tag2", "updated-tag"),
+					},
+				},
+			},
+		},
+		{
+			name:        "updates plugin config linked with custom plugin definitions",
+			initialFile: "testdata/apply/014-custom-plugin-definitions/initial-with-plugins.yaml",
+			updateFile:  "testdata/apply/014-custom-plugin-definitions/update-plugin-config.yaml",
+			expectedState: utils.KongRawState{
+				CustomPluginDefinitions: []*kong.CustomPluginDefinition{
+					{
+						Name:    kong.String("col-dbless"),
+						Handler: kong.String(colDblessHandler),
+						Schema:  kong.String(colDblessSchema),
+						Tags:    kong.StringSlice("tag1", "tag2"),
+					},
+					{
+						Name:    kong.String("set-header"),
+						Handler: kong.String(setHeaderHandler),
+						Schema:  kong.String(setHeaderSchema),
+						Tags:    kong.StringSlice("select-me", "tag1", "tag2"),
+					},
+				},
+				Plugins: []*kong.Plugin{
+					{
+						Name:    kong.String("set-header"),
+						Enabled: kong.Bool(true),
+						Tags:    kong.StringSlice("plugin-tag1", "plugin-tag2", "select-me"),
+						Config: kong.Configuration{
+							"name":  string("X-Custom-Header"),
+							"value": string("updated-world"),
+						},
+					},
+				},
+			},
+			ignoreFields: []cmp.Option{
+				cmpopts.IgnoreFields(kong.Plugin{}, "Protocols"),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reset(t)
+			// In skip-defaults mode, deck fetches plugin schemas from Konnect to
+			// remove defaults. Custom plugin schemas are unavailable until their
+			// definitions are synced, so register CPDs first before any sync that
+			// includes plugin instances.
+			cpdOnlyFile := "testdata/apply/014-custom-plugin-definitions/initial-cpd-only.yaml"
+			require.NoError(t, sync(ctx, cpdOnlyFile, "--include-plugin-definitions"))
+			require.NoError(t, sync(ctx, tc.initialFile, "--include-plugin-definitions"))
+			require.NoError(t, apply(ctx, tc.updateFile, "--include-plugin-definitions"))
+			testKongState(t, client, true, false, tc.expectedState, tc.ignoreFields)
+		})
+	}
+}

--- a/tests/integration/dump_test.go
+++ b/tests/integration/dump_test.go
@@ -1569,11 +1569,11 @@ func Test_Dump_CustomPluginDefinitions(t *testing.T) {
 		},
 	}
 
-	reset(t)
-	require.NoError(t, sync(ctx, "testdata/sync/055-custom-plugin-definitions/kong.yaml", "--include-plugin-definitions"))
-
 	for _, tc := range tests {
 		t.Run(tc.name+" "+tc.runWhen+" "+tc.runWhenVersion, func(t *testing.T) {
+			reset(t)
+			require.NoError(t, sync(ctx, "testdata/sync/055-custom-plugin-definitions/kong.yaml", "--include-plugin-definitions"))
+
 			runWhen(t, tc.runWhen, tc.runWhenVersion)
 
 			output, err := dump(tc.dumpFlags...)

--- a/tests/integration/dump_test.go
+++ b/tests/integration/dump_test.go
@@ -1573,11 +1573,11 @@ func Test_Dump_CustomPluginDefinitions(t *testing.T) {
 		t.Run(tc.name+" "+tc.runWhen+" "+tc.runWhenVersion, func(t *testing.T) {
 			runWhen(t, tc.runWhen, tc.runWhenVersion)
 
-			output, err := dump(tc.dumpFlags...)
 			reset(t)
 			require.NoError(t, sync(ctx,
 				"testdata/sync/055-custom-plugin-definitions/kong.yaml", "--include-plugin-definitions"))
 
+			output, err := dump(tc.dumpFlags...)
 			require.NoError(t, err)
 
 			expected, err := readFile(tc.expectedFile)

--- a/tests/integration/dump_test.go
+++ b/tests/integration/dump_test.go
@@ -1572,7 +1572,8 @@ func Test_Dump_CustomPluginDefinitions(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name+" "+tc.runWhen+" "+tc.runWhenVersion, func(t *testing.T) {
 			reset(t)
-			require.NoError(t, sync(ctx, "testdata/sync/055-custom-plugin-definitions/kong.yaml", "--include-plugin-definitions"))
+			require.NoError(t, sync(ctx,
+				"testdata/sync/055-custom-plugin-definitions/kong.yaml", "--include-plugin-definitions"))
 
 			runWhen(t, tc.runWhen, tc.runWhenVersion)
 

--- a/tests/integration/dump_test.go
+++ b/tests/integration/dump_test.go
@@ -1573,7 +1573,7 @@ func Test_Dump_CustomPluginDefinitions(t *testing.T) {
 	require.NoError(t, sync(ctx, "testdata/sync/055-custom-plugin-definitions/kong.yaml", "--include-plugin-definitions"))
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name+" "+tc.runWhen+" "+tc.runWhenVersion, func(t *testing.T) {
 			runWhen(t, tc.runWhen, tc.runWhenVersion)
 
 			output, err := dump(tc.dumpFlags...)

--- a/tests/integration/dump_test.go
+++ b/tests/integration/dump_test.go
@@ -1571,13 +1571,13 @@ func Test_Dump_CustomPluginDefinitions(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name+" "+tc.runWhen+" "+tc.runWhenVersion, func(t *testing.T) {
+			runWhen(t, tc.runWhen, tc.runWhenVersion)
+
+			output, err := dump(tc.dumpFlags...)
 			reset(t)
 			require.NoError(t, sync(ctx,
 				"testdata/sync/055-custom-plugin-definitions/kong.yaml", "--include-plugin-definitions"))
 
-			runWhen(t, tc.runWhen, tc.runWhenVersion)
-
-			output, err := dump(tc.dumpFlags...)
 			require.NoError(t, err)
 
 			expected, err := readFile(tc.expectedFile)

--- a/tests/integration/dump_test.go
+++ b/tests/integration/dump_test.go
@@ -1529,3 +1529,59 @@ func Test_Dump_ClonedPluginDefinitions(t *testing.T) {
 		})
 	}
 }
+
+func Test_Dump_CustomPluginDefinitions(t *testing.T) {
+	setup(t)
+	ctx := t.Context()
+
+	tests := []struct {
+		name           string
+		dumpFlags      []string
+		expectedFile   string
+		runWhen        string
+		runWhenVersion string
+	}{
+		{
+			name:           "dump includes all custom plugin definitions",
+			dumpFlags:      []string{"-o", "-", "--include-plugin-definitions"},
+			expectedFile:   "testdata/dump/014-custom-plugin-definitions/expected.yaml",
+			runWhen:        "enterprise",
+			runWhenVersion: ">=3.15.0",
+		},
+		{
+			name:           "select tags filter custom plugin definitions",
+			dumpFlags:      []string{"--select-tag", "select-me", "-o", "-", "--include-plugin-definitions"},
+			expectedFile:   "testdata/dump/014-custom-plugin-definitions/expected-select-me.yaml",
+			runWhen:        "enterprise",
+			runWhenVersion: ">=3.15.0",
+		},
+		{
+			name:         "dump includes all custom plugin definitions",
+			dumpFlags:    []string{"-o", "-", "--include-plugin-definitions"},
+			expectedFile: "testdata/dump/014-custom-plugin-definitions/expected-konnect.yaml",
+			runWhen:      "konnect",
+		},
+		{
+			name:         "select tags filter custom plugin definitions",
+			dumpFlags:    []string{"--select-tag", "select-me", "-o", "-", "--include-plugin-definitions"},
+			expectedFile: "testdata/dump/014-custom-plugin-definitions/expected-select-me-konnect.yaml",
+			runWhen:      "konnect",
+		},
+	}
+
+	reset(t)
+	require.NoError(t, sync(ctx, "testdata/sync/055-custom-plugin-definitions/kong.yaml", "--include-plugin-definitions"))
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runWhen(t, tc.runWhen, tc.runWhenVersion)
+
+			output, err := dump(tc.dumpFlags...)
+			require.NoError(t, err)
+
+			expected, err := readFile(tc.expectedFile)
+			require.NoError(t, err)
+			assert.Equal(t, expected, output)
+		})
+	}
+}

--- a/tests/integration/sync_test.go
+++ b/tests/integration/sync_test.go
@@ -12426,7 +12426,177 @@ func Test_Sync_ClonedPluginDefinitions(t *testing.T) {
 
 			testKongState(t, client, false, false, tc.expectedState, tc.ignoreFields)
 
-			// // re-sync is idempotent
+			// re-sync is idempotent
+			err = sync(ctx, tc.kongFile, "--include-plugin-definitions")
+			require.NoError(t, err, "re-sync should not error")
+		})
+	}
+}
+
+func Test_Sync_CustomPluginDefinitions(t *testing.T) {
+	runWhen(t, "enterprise", ">=3.15.0")
+	setup(t)
+
+	client, err := getTestClient()
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	const cpdTestdata = "testdata/custom-plugin-definitions"
+	setHeaderHandler := mustReadFile(t, cpdTestdata+"/set-header.handler.lua")
+	setHeaderSchema := mustReadFile(t, cpdTestdata+"/set-header.schema.lua")
+	colDblessHandler := mustReadFile(t, cpdTestdata+"/col-dbless.handler.lua")
+	colDblessSchema := mustReadFile(t, cpdTestdata+"/col-dbless.schema.lua")
+
+	tests := []struct {
+		name          string
+		kongFile      string
+		wantErr       bool
+		expectedState utils.KongRawState
+		ignoreFields  []cmp.Option
+	}{
+		{
+			name:     "creates custom plugin definitions and plugins",
+			kongFile: "testdata/sync/055-custom-plugin-definitions/kong.yaml",
+			expectedState: utils.KongRawState{
+				CustomPluginDefinitions: []*kong.CustomPluginDefinition{
+					{
+						Name:    kong.String("col-dbless"),
+						Handler: kong.String(colDblessHandler),
+						Schema:  kong.String(colDblessSchema),
+						Tags:    kong.StringSlice("tag1", "tag2"),
+					},
+					{
+						Name:    kong.String("set-header"),
+						Handler: kong.String(setHeaderHandler),
+						Schema:  kong.String(setHeaderSchema),
+						Tags:    kong.StringSlice("select-me", "tag1", "tag2"),
+					},
+				},
+				Plugins: []*kong.Plugin{
+					{
+						Name:    kong.String("set-header"),
+						Enabled: kong.Bool(true),
+						Config: kong.Configuration{
+							"name":  string("X-Custom-Header"),
+							"value": string("hello-world"),
+						},
+						Tags: kong.StringSlice("plugin-tag1", "select-me"),
+					},
+				},
+			},
+			ignoreFields: []cmp.Option{
+				cmpopts.IgnoreFields(kong.Plugin{}, "Protocols"),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reset(t)
+
+			err := sync(ctx, tc.kongFile, "--include-plugin-definitions")
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			testKongState(t, client, false, false, tc.expectedState, tc.ignoreFields)
+
+			// re-sync is idempotent
+			err = sync(ctx, tc.kongFile, "--include-plugin-definitions")
+			require.NoError(t, err, "re-sync should not error")
+		})
+	}
+}
+
+// test scope:
+//   - konnect
+func Test_Sync_CustomPluginDefinitions_Konnect(t *testing.T) {
+	runDualTestWithSkipDefaults(t, "Test_Sync_CustomPluginDefinitions_Konnect",
+		testSyncCustomPluginDefinitionsKonnectImpl)
+}
+
+func testSyncCustomPluginDefinitionsKonnectImpl(t *testing.T) {
+	setDefaultKonnectControlPlane(t)
+	runWhenKonnect(t)
+	setup(t)
+
+	client, err := getTestClient()
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	const cpdTestdata = "testdata/custom-plugin-definitions"
+	setHeaderHandler := mustReadFile(t, cpdTestdata+"/set-header.handler.lua")
+	setHeaderSchema := mustReadFile(t, cpdTestdata+"/set-header.schema.lua")
+	colDblessHandler := mustReadFile(t, cpdTestdata+"/col-dbless.handler.lua")
+	colDblessSchema := mustReadFile(t, cpdTestdata+"/col-dbless.schema.lua")
+
+	tests := []struct {
+		name          string
+		kongFile      string
+		wantErr       bool
+		expectedState utils.KongRawState
+		ignoreFields  []cmp.Option
+	}{
+		{
+			name:     "creates custom plugin definitions and plugins",
+			kongFile: "testdata/sync/055-custom-plugin-definitions/kong.yaml",
+			expectedState: utils.KongRawState{
+				CustomPluginDefinitions: []*kong.CustomPluginDefinition{
+					{
+						Name:    kong.String("col-dbless"),
+						Handler: kong.String(colDblessHandler),
+						Schema:  kong.String(colDblessSchema),
+						Tags:    kong.StringSlice("tag1", "tag2"),
+					},
+					{
+						Name:    kong.String("set-header"),
+						Handler: kong.String(setHeaderHandler),
+						Schema:  kong.String(setHeaderSchema),
+						Tags:    kong.StringSlice("select-me", "tag1", "tag2"),
+					},
+				},
+				Plugins: []*kong.Plugin{
+					{
+						Name:    kong.String("set-header"),
+						Enabled: kong.Bool(true),
+						Config: kong.Configuration{
+							"name":  string("X-Custom-Header"),
+							"value": string("hello-world"),
+						},
+						Tags: kong.StringSlice("plugin-tag1", "select-me"),
+					},
+				},
+			},
+			ignoreFields: []cmp.Option{
+				cmpopts.IgnoreFields(kong.Plugin{}, "Protocols"),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reset(t)
+
+			// In skip-defaults mode, deck fetches plugin schemas from Konnect to
+			// remove defaults from the target state. Custom plugin schemas aren't
+			// available until after their definitions are synced, so we must sync
+			// the CPD-only file first to register the schemas, then sync the full
+			// config that includes plugin instances.
+			cpdOnlyFile := "testdata/apply/014-custom-plugin-definitions/initial-cpd-only.yaml"
+			require.NoError(t, sync(ctx, cpdOnlyFile, "--include-plugin-definitions"))
+
+			err := sync(ctx, tc.kongFile, "--include-plugin-definitions")
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			testKongState(t, client, true, false, tc.expectedState, tc.ignoreFields)
+
+			// re-sync is idempotent
 			err = sync(ctx, tc.kongFile, "--include-plugin-definitions")
 			require.NoError(t, err, "re-sync should not error")
 		})

--- a/tests/integration/test_utils.go
+++ b/tests/integration/test_utils.go
@@ -212,6 +212,10 @@ func sortSlices(x, y interface{}) bool {
 		yEntity := y.(*kong.ClonedPluginDefinition)
 		xName = *xEntity.Name
 		yName = *yEntity.Name
+	case *kong.CustomPluginDefinition:
+		yEntity := y.(*kong.CustomPluginDefinition)
+		xName = *xEntity.Name
+		yName = *yEntity.Name
 	}
 
 	return xName < yName
@@ -269,6 +273,7 @@ func testKongState(t *testing.T, client *kong.Client, isKonnect bool,
 		cmpopts.IgnoreFields(kong.KeySet{}, "ID", "CreatedAt", "UpdatedAt"),
 		cmpopts.IgnoreFields(kong.Partial{}, "ID", "CreatedAt", "UpdatedAt"),
 		cmpopts.IgnoreFields(kong.ClonedPluginDefinition{}, "ID", "CreatedAt", "UpdatedAt"),
+		cmpopts.IgnoreFields(kong.CustomPluginDefinition{}, "ID", "CreatedAt", "UpdatedAt"),
 		cmpopts.SortSlices(sortSlices),
 		cmpopts.SortSlices(func(a, b *string) bool { return *a < *b }),
 		cmpopts.EquateEmpty(),
@@ -320,6 +325,15 @@ func readFile(filepath string) (string, error) {
 		return "", err
 	}
 	return string(content), nil
+}
+
+// mustReadFile reads a file and returns its content as a string, failing the
+// test immediately if the file cannot be read.
+func mustReadFile(t *testing.T, filepath string) string {
+	t.Helper()
+	content, err := os.ReadFile(filepath)
+	require.NoError(t, err)
+	return string(content)
 }
 
 // setup sets deck env variable to prevent analytics in tests and registers reset

--- a/tests/integration/testdata/apply/014-custom-plugin-definitions/initial-cpd-only.yaml
+++ b/tests/integration/testdata/apply/014-custom-plugin-definitions/initial-cpd-only.yaml
@@ -1,0 +1,37 @@
+_format_version: "3.0"
+custom_plugins:
+- name: set-header
+  handler: |
+    return {
+      VERSION = "1.0,0",
+      PRIORITY = 500,
+      access = function(self, config)
+        kong.service.request.set_header(config.name, config.value)
+      end
+    }
+  schema: |
+    return {
+      name = "set-header",
+      fields = {
+        { protocols = require("kong.db.schema.typedefs").protocols_http },
+        {
+          config = {
+            type = "record",
+            fields = {
+              { name = { description = "The name of the header to set.", type = "string", required = true, }, },
+              { value = { description = "The value for the header.", type = "string", required = true, }, },
+            },
+          },
+        },
+      },
+    }
+  tags:
+  - tag1
+  - tag2
+  - select-me
+- name: col-dbless
+  handler: 'return { PRIORITY = 1000, VERSION = "1.0.0" }'
+  schema: 'return { name = "col-dbless", fields = { { config = { type = "record", fields = {} } } } }'
+  tags:
+  - tag1
+  - tag2

--- a/tests/integration/testdata/apply/014-custom-plugin-definitions/initial-with-plugins.yaml
+++ b/tests/integration/testdata/apply/014-custom-plugin-definitions/initial-with-plugins.yaml
@@ -1,0 +1,47 @@
+_format_version: "3.0"
+custom_plugins:
+- name: set-header
+  handler: |
+    return {
+      VERSION = "1.0,0",
+      PRIORITY = 500,
+      access = function(self, config)
+        kong.service.request.set_header(config.name, config.value)
+      end
+    }
+  schema: |
+    return {
+      name = "set-header",
+      fields = {
+        { protocols = require("kong.db.schema.typedefs").protocols_http },
+        {
+          config = {
+            type = "record",
+            fields = {
+              { name = { description = "The name of the header to set.", type = "string", required = true, }, },
+              { value = { description = "The value for the header.", type = "string", required = true, }, },
+            },
+          },
+        },
+      },
+    }
+  tags:
+  - tag1
+  - tag2
+  - select-me
+- name: col-dbless
+  handler: 'return { PRIORITY = 1000, VERSION = "1.0.0" }'
+  schema: 'return { name = "col-dbless", fields = { { config = { type = "record", fields = {} } } } }'
+  tags:
+  - tag1
+  - tag2
+
+plugins:
+- name: set-header
+  config:
+    name: X-Custom-Header
+    value: hello-world
+  enabled: true
+  tags:
+  - plugin-tag1
+  - select-me

--- a/tests/integration/testdata/apply/014-custom-plugin-definitions/update-cpd.yaml
+++ b/tests/integration/testdata/apply/014-custom-plugin-definitions/update-cpd.yaml
@@ -1,0 +1,38 @@
+_format_version: "3.0"
+custom_plugins:
+- name: set-header
+  handler: |
+    return {
+      VERSION = "1.0,0",
+      PRIORITY = 500,
+      access = function(self, config)
+        kong.service.request.set_header(config.name, config.value)
+      end
+    }
+  schema: |
+    return {
+      name = "set-header",
+      fields = {
+        { protocols = require("kong.db.schema.typedefs").protocols_http },
+        {
+          config = {
+            type = "record",
+            fields = {
+              { name = { description = "The name of the header to set.", type = "string", required = true, }, },
+              { value = { description = "The value for the header.", type = "string", required = true, }, },
+            },
+          },
+        },
+      },
+    }
+  tags:
+  - tag1
+  - tag2
+  - select-me
+  - updated-tag
+- name: col-dbless
+  handler: 'return { PRIORITY = 1000, VERSION = "1.0.0" }'
+  schema: 'return { name = "col-dbless", fields = { { config = { type = "record", fields = {} } } } }'
+  tags:
+  - tag1
+  - tag2

--- a/tests/integration/testdata/apply/014-custom-plugin-definitions/update-plugin-config.yaml
+++ b/tests/integration/testdata/apply/014-custom-plugin-definitions/update-plugin-config.yaml
@@ -1,0 +1,11 @@
+_format_version: "3.0"
+plugins:
+- name: set-header
+  config:
+    name: X-Custom-Header
+    value: updated-world
+  enabled: true
+  tags:
+  - plugin-tag1
+  - plugin-tag2
+  - select-me

--- a/tests/integration/testdata/custom-plugin-definitions/col-dbless.handler.lua
+++ b/tests/integration/testdata/custom-plugin-definitions/col-dbless.handler.lua
@@ -1,0 +1,1 @@
+return { PRIORITY = 1000, VERSION = "1.0.0" }

--- a/tests/integration/testdata/custom-plugin-definitions/col-dbless.schema.lua
+++ b/tests/integration/testdata/custom-plugin-definitions/col-dbless.schema.lua
@@ -1,0 +1,1 @@
+return { name = "col-dbless", fields = { { config = { type = "record", fields = {} } } } }

--- a/tests/integration/testdata/custom-plugin-definitions/set-header.handler.lua
+++ b/tests/integration/testdata/custom-plugin-definitions/set-header.handler.lua
@@ -1,0 +1,7 @@
+return {
+  VERSION = "1.0,0",
+  PRIORITY = 500,
+  access = function(self, config)
+    kong.service.request.set_header(config.name, config.value)
+  end
+}

--- a/tests/integration/testdata/custom-plugin-definitions/set-header.schema.lua
+++ b/tests/integration/testdata/custom-plugin-definitions/set-header.schema.lua
@@ -1,0 +1,15 @@
+return {
+  name = "set-header",
+  fields = {
+    { protocols = require("kong.db.schema.typedefs").protocols_http },
+    {
+      config = {
+        type = "record",
+        fields = {
+          { name = { description = "The name of the header to set.", type = "string", required = true, }, },
+          { value = { description = "The value for the header.", type = "string", required = true, }, },
+        },
+      },
+    },
+  },
+}

--- a/tests/integration/testdata/dump/014-custom-plugin-definitions/expected-konnect.yaml
+++ b/tests/integration/testdata/dump/014-custom-plugin-definitions/expected-konnect.yaml
@@ -1,9 +1,9 @@
 _format_version: "3.0"
-_konnect:
-  control_plane_name: default
 _info:
   defaults: {}
   include_plugin_definitions: true
+_konnect:
+  control_plane_name: default
 custom_plugins:
 - handler: return { PRIORITY = 1000, VERSION = "1.0.0" }
   name: col-dbless

--- a/tests/integration/testdata/dump/014-custom-plugin-definitions/expected-konnect.yaml
+++ b/tests/integration/testdata/dump/014-custom-plugin-definitions/expected-konnect.yaml
@@ -1,0 +1,57 @@
+_format_version: "3.0"
+_konnect:
+  control_plane_name: default
+_info:
+  defaults: {}
+  include_plugin_definitions: true
+custom_plugins:
+- handler: return { PRIORITY = 1000, VERSION = "1.0.0" }
+  name: col-dbless
+  schema: return { name = "col-dbless", fields = { { config = { type = "record", fields
+    = {} } } } }
+  tags:
+  - tag1
+  - tag2
+- handler: |
+    return {
+      VERSION = "1.0,0",
+      PRIORITY = 500,
+      access = function(self, config)
+        kong.service.request.set_header(config.name, config.value)
+      end
+    }
+  name: set-header
+  schema: |
+    return {
+      name = "set-header",
+      fields = {
+        { protocols = require("kong.db.schema.typedefs").protocols_http },
+        {
+          config = {
+            type = "record",
+            fields = {
+              { name = { description = "The name of the header to set.", type = "string", required = true, }, },
+              { value = { description = "The value for the header.", type = "string", required = true, }, },
+            },
+          },
+        },
+      },
+    }
+  tags:
+  - tag1
+  - tag2
+  - select-me
+plugins:
+- config:
+    name: X-Custom-Header
+    value: hello-world
+  enabled: true
+  name: set-header
+  protocols:
+  - grpc
+  - grpcs
+  - http
+  - https
+  tags:
+  - plugin-tag1
+  - select-me

--- a/tests/integration/testdata/dump/014-custom-plugin-definitions/expected-select-me-konnect.yaml
+++ b/tests/integration/testdata/dump/014-custom-plugin-definitions/expected-select-me-konnect.yaml
@@ -1,11 +1,11 @@
 _format_version: "3.0"
-_konnect:
-  control_plane_name: default
 _info:
   defaults: {}
   include_plugin_definitions: true
   select_tags:
   - select-me
+_konnect:
+  control_plane_name: default
 custom_plugins:
 - handler: |
     return {

--- a/tests/integration/testdata/dump/014-custom-plugin-definitions/expected-select-me-konnect.yaml
+++ b/tests/integration/testdata/dump/014-custom-plugin-definitions/expected-select-me-konnect.yaml
@@ -1,0 +1,52 @@
+_format_version: "3.0"
+_konnect:
+  control_plane_name: default
+_info:
+  defaults: {}
+  include_plugin_definitions: true
+  select_tags:
+  - select-me
+custom_plugins:
+- handler: |
+    return {
+      VERSION = "1.0,0",
+      PRIORITY = 500,
+      access = function(self, config)
+        kong.service.request.set_header(config.name, config.value)
+      end
+    }
+  name: set-header
+  schema: |
+    return {
+      name = "set-header",
+      fields = {
+        { protocols = require("kong.db.schema.typedefs").protocols_http },
+        {
+          config = {
+            type = "record",
+            fields = {
+              { name = { description = "The name of the header to set.", type = "string", required = true, }, },
+              { value = { description = "The value for the header.", type = "string", required = true, }, },
+            },
+          },
+        },
+      },
+    }
+  tags:
+  - tag1
+  - tag2
+  - select-me
+plugins:
+- config:
+    name: X-Custom-Header
+    value: hello-world
+  enabled: true
+  name: set-header
+  protocols:
+  - grpc
+  - grpcs
+  - http
+  - https
+  tags:
+  - plugin-tag1
+  - select-me

--- a/tests/integration/testdata/dump/014-custom-plugin-definitions/expected-select-me.yaml
+++ b/tests/integration/testdata/dump/014-custom-plugin-definitions/expected-select-me.yaml
@@ -1,0 +1,50 @@
+_format_version: "3.0"
+_info:
+  defaults: {}
+  include_plugin_definitions: true
+  select_tags:
+  - select-me
+custom_plugins:
+- handler: |
+    return {
+      VERSION = "1.0,0",
+      PRIORITY = 500,
+      access = function(self, config)
+        kong.service.request.set_header(config.name, config.value)
+      end
+    }
+  name: set-header
+  schema: |
+    return {
+      name = "set-header",
+      fields = {
+        { protocols = require("kong.db.schema.typedefs").protocols_http },
+        {
+          config = {
+            type = "record",
+            fields = {
+              { name = { description = "The name of the header to set.", type = "string", required = true, }, },
+              { value = { description = "The value for the header.", type = "string", required = true, }, },
+            },
+          },
+        },
+      },
+    }
+  tags:
+  - tag1
+  - tag2
+  - select-me
+plugins:
+- config:
+    name: X-Custom-Header
+    value: hello-world
+  enabled: true
+  name: set-header
+  protocols:
+  - grpc
+  - grpcs
+  - http
+  - https
+  tags:
+  - plugin-tag1
+  - select-me

--- a/tests/integration/testdata/dump/014-custom-plugin-definitions/expected.yaml
+++ b/tests/integration/testdata/dump/014-custom-plugin-definitions/expected.yaml
@@ -1,0 +1,55 @@
+_format_version: "3.0"
+_info:
+  defaults: {}
+  include_plugin_definitions: true
+custom_plugins:
+- handler: return { PRIORITY = 1000, VERSION = "1.0.0" }
+  name: col-dbless
+  schema: return { name = "col-dbless", fields = { { config = { type = "record", fields
+    = {} } } } }
+  tags:
+  - tag1
+  - tag2
+- handler: |
+    return {
+      VERSION = "1.0,0",
+      PRIORITY = 500,
+      access = function(self, config)
+        kong.service.request.set_header(config.name, config.value)
+      end
+    }
+  name: set-header
+  schema: |
+    return {
+      name = "set-header",
+      fields = {
+        { protocols = require("kong.db.schema.typedefs").protocols_http },
+        {
+          config = {
+            type = "record",
+            fields = {
+              { name = { description = "The name of the header to set.", type = "string", required = true, }, },
+              { value = { description = "The value for the header.", type = "string", required = true, }, },
+            },
+          },
+        },
+      },
+    }
+  tags:
+  - tag1
+  - tag2
+  - select-me
+plugins:
+- config:
+    name: X-Custom-Header
+    value: hello-world
+  enabled: true
+  name: set-header
+  protocols:
+  - grpc
+  - grpcs
+  - http
+  - https
+  tags:
+  - plugin-tag1
+  - select-me

--- a/tests/integration/testdata/sync/055-custom-plugin-definitions/kong.yaml
+++ b/tests/integration/testdata/sync/055-custom-plugin-definitions/kong.yaml
@@ -1,0 +1,47 @@
+_format_version: "3.0"
+custom_plugins:
+- name: set-header
+  handler: |
+    return {
+      VERSION = "1.0,0",
+      PRIORITY = 500,
+      access = function(self, config)
+        kong.service.request.set_header(config.name, config.value)
+      end
+    }
+  schema: |
+    return {
+      name = "set-header",
+      fields = {
+        { protocols = require("kong.db.schema.typedefs").protocols_http },
+        {
+          config = {
+            type = "record",
+            fields = {
+              { name = { description = "The name of the header to set.", type = "string", required = true, }, },
+              { value = { description = "The value for the header.", type = "string", required = true, }, },
+            },
+          },
+        },
+      },
+    }
+  tags:
+  - tag1
+  - tag2
+  - select-me
+- name: col-dbless
+  handler: 'return { PRIORITY = 1000, VERSION = "1.0.0" }'
+  schema: 'return { name = "col-dbless", fields = { { config = { type = "record", fields = {} } } } }'
+  tags:
+  - tag1
+  - tag2
+
+plugins:
+- name: set-header
+  config:
+    name: X-Custom-Header
+    value: hello-world
+  enabled: true
+  tags:
+  - plugin-tag1
+  - select-me


### PR DESCRIPTION
Gateway 3.15 is adding support for custom-plugin definitions.
This change ensures that we can manage these entities declaratively
in deck.
For: https://github.com/Kong/deck/issues/2073

Integration tests for gateway and Konnect are added.

Test run for gateway: https://github.com/Kong/deck/actions/runs/26928254826/job/79444308415 (some other tests are failing due to schema changes)
(Search via string CustomPluginDefinitions)

Related:
gdr: https://github.com/Kong/go-database-reconciler/pull/477
go-kong: https://github.com/Kong/go-kong/pull/619