### PR TITLE
fix: reset without skip should delete plugin defs

### DIFF
--- a/cmd/gateway_reset.go
+++ b/cmd/gateway_reset.go
@@ -35,7 +35,9 @@ func executeReset(cmd *cobra.Command, _ []string) error {
 		if !ok {
 			return nil
 		}
-	} else if resetCmdForce && !skipPluginDefinitions {
+	}
+
+	if !skipPluginDefinitions {
 		dumpConfig.IncludePluginDefinitions = true
 	}
 

--- a/tests/integration/reset_test.go
+++ b/tests/integration/reset_test.go
@@ -278,9 +278,9 @@ func Test_Reset_SkipPluginDefinitions(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name                string
-		resetFlags          []string
-		expectPluginsExist  bool
+		name               string
+		resetFlags         []string
+		expectPluginsExist bool
 	}{
 		{
 			name:               "reset without --skip-plugin-definitions deletes cloned and custom plugins",

--- a/tests/integration/reset_test.go
+++ b/tests/integration/reset_test.go
@@ -268,3 +268,64 @@ func Test_Reset_KonnectWorkspace_AllWorkspaces(t *testing.T) {
 	assert.NotContains(t, output2, "route-workspace2",
 		"workspace2 entity should be deleted after --all-workspaces reset")
 }
+
+// test scope:
+// - enterprise >=3.15.0
+func Test_Reset_SkipPluginDefinitions(t *testing.T) {
+	runWhen(t, "enterprise", ">=3.15.0")
+	setup(t)
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name                string
+		resetFlags          []string
+		expectPluginsExist  bool
+	}{
+		{
+			name:               "reset without --skip-plugin-definitions deletes cloned and custom plugins",
+			resetFlags:         []string{},
+			expectPluginsExist: false,
+		},
+		{
+			name:               "reset with --skip-plugin-definitions preserves cloned and custom plugins",
+			resetFlags:         []string{"--skip-plugin-definitions"},
+			expectPluginsExist: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reset(t)
+			require.NoError(t, sync(ctx,
+				"testdata/reset/003-skip-plugin-definitions/kong.yaml",
+				"--include-plugin-definitions"))
+
+			// Verify both plugin definitions exist before reset
+			output, err := dump("-o", "-", "--include-plugin-definitions")
+			require.NoError(t, err)
+			assert.Contains(t, output, "reset-test-file-log",
+				"cloned plugin should exist before reset")
+			assert.Contains(t, output, "reset-set-header",
+				"custom plugin should exist before reset")
+
+			// Perform reset with the specified flags
+			reset(t, tc.resetFlags...)
+
+			// Verify plugin definition state after reset
+			output, err = dump("-o", "-", "--include-plugin-definitions")
+			require.NoError(t, err)
+			if tc.expectPluginsExist {
+				assert.Contains(t, output, "reset-test-file-log",
+					"cloned plugin should still exist after reset with --skip-plugin-definitions")
+				assert.Contains(t, output, "reset-set-header",
+					"custom plugin should still exist after reset with --skip-plugin-definitions")
+			} else {
+				assert.NotContains(t, output, "reset-test-file-log",
+					"cloned plugin should be deleted after reset without --skip-plugin-definitions")
+				assert.NotContains(t, output, "reset-set-header",
+					"custom plugin should be deleted after reset without --skip-plugin-definitions")
+			}
+		})
+	}
+}

--- a/tests/integration/testdata/reset/003-skip-plugin-definitions/kong.yaml
+++ b/tests/integration/testdata/reset/003-skip-plugin-definitions/kong.yaml
@@ -1,0 +1,9 @@
+_format_version: "3.0"
+cloned_plugins:
+- name: reset-test-file-log
+  ref: file-log
+  priority: 100
+custom_plugins:
+- name: reset-set-header
+  handler: 'return { VERSION = "1.0.0", PRIORITY = 500, access = function(self, config) kong.service.request.set_header(config.name, config.value) end }'
+  schema: 'return { name = "reset-set-header", fields = { { protocols = require("kong.db.schema.typedefs").protocols_http }, { config = { type = "record", fields = { { name = { type = "string", required = true } }, { value = { type = "string", required = true } } } } } } }'


### PR DESCRIPTION
Resetting state for the gateway should delete plugin-definitions,
if `skip-plugin-definitions` flag is unset.

Test run: https://github.com/Kong/deck/actions/runs/27003177875/job/79688265690
Search via Test_Reset_SkipPluginDefinitions

Added integration tests for the same.