### PR TITLE
ci: updated codecov action and no ci fail if uploads fail

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Run tests with Coverage
         run: make coverage
       - name: Upload Code Coverage
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         continue-on-error: true
         with:
           name: codecov-deck

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,7 @@ jobs:
         run: make coverage
       - name: Upload Code Coverage
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        continue-on-error: true
         with:
           name: codecov-deck
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Codecov Upload report step was failing in CI due to missing
public key error. This is due to some internal migrations issues
with keybase at codecov
Ref: https://github.com/codecov/codecov-action/releases

- Updating the codecov upload action to v6.0.2 that fixes the key issue.
- Added `continue-on-error: true` in CI as an upload-report failure shouldn't stall the pipeline.