### PR TITLE
chore: bumped go-apiops version to v0.4.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/ettle/strcase v0.2.0
 	github.com/fatih/color v1.19.0
 	github.com/google/go-cmp v0.7.0
-	github.com/kong/go-apiops v0.4.3
+	github.com/kong/go-apiops v0.4.4
 	github.com/kong/go-database-reconciler v1.40.0
 	github.com/kong/go-kong v0.76.1
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -223,8 +223,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/kong/go-apiops v0.4.3 h1:ky0D4gYlcAvNF/KFdNBUwvf9T/Pda8+smPjd2SY1Og8=
-github.com/kong/go-apiops v0.4.3/go.mod h1:Xt99d90LallLVwYJAGaufiNbBdsK0KKboe7gR4Ryths=
+github.com/kong/go-apiops v0.4.4 h1:16raOAuErHV32OuLwQEO46CBZ86OGMmTdEHatZ5nJB0=
+github.com/kong/go-apiops v0.4.4/go.mod h1:Xt99d90LallLVwYJAGaufiNbBdsK0KKboe7gR4Ryths=
 github.com/kong/go-database-reconciler v1.40.0 h1:/1KmnpxBm5/Fr2z3Ma/21q68brMx6YyslCGKPukxYx0=
 github.com/kong/go-database-reconciler v1.40.0/go.mod h1:I9bCWQ3LJ8tHVZ6mA2NwerhujW9zoFduEypD8XIK5w0=
 github.com/kong/go-kong v0.76.1 h1:lImAHvog7ehm4XL2rs8ZyCx98k56ihNazLG55bvHgVM=


### PR DESCRIPTION
bumped go-apiops with a new version for below two PRs
https://github.com/Kong/go-apiops/pull/299
https://github.com/Kong/go-apiops/pull/298