### PR TITLE
Quality: Biased random string due to duplicate character in charset

### DIFF
--- a/convert/utils.go
+++ b/convert/utils.go
@@ -12,7 +12,7 @@ import (
 )
 
 func randomString(n int) (string, error) {
-	const charset = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzj"
+	const charset = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 	charsetLength := big.NewInt(int64(len(charset)))
 
 	ret := make([]byte, n)


### PR DESCRIPTION
## Problem

The charset constant has the letter 'j' appearing twice — once within the normal alphabetical sequence and once appended at the end:
"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzj"
                                                                 ^

This gives 'j' twice the probability of being selected (2/63 ≈ 3.17%) compared to all other characters (1/63 ≈ 1.59%). If this function is used for generating IDs, tokens, or any value where uniform distribution matters, the output is biased, reducing effective entropy and potentially causing subtle correctness or security issues.


**Severity**: `medium`
**File**: `convert/utils.go`

## Solution

Remove the trailing duplicate 'j' from the charset:


## Changes

- `convert/utils.go` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
