### PR TITLE
Feat/support json and multi file sync

### DIFF
--- a/cmd/ai_dump.go
+++ b/cmd/ai_dump.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	ai2kong "github.com/Kong/ai-deck-converter/revert"
+	"github.com/kong/go-apiops/filebasics"
 	"github.com/kong/go-database-reconciler/pkg/file"
 	"github.com/kong/go-database-reconciler/pkg/state"
 	"github.com/kong/go-database-reconciler/pkg/utils"
@@ -15,7 +17,7 @@ import (
 )
 
 var (
-	aiDumpCmdStateFormat = "yaml" // default to yaml
+	aiDumpCmdStateFormat string
 	aiDumpCmdOutputFile  string
 	aiDumpWorkspace      string
 )
@@ -23,7 +25,9 @@ var (
 func executeAiDump(cmd *cobra.Command, _ []string) error {
 	ctx := cmd.Context()
 
-	if yes, err := utils.ConfirmFileOverwrite(aiDumpCmdOutputFile, aiDumpCmdStateFormat, assumeYes); err != nil {
+	format := strings.ToLower(getFormatFlagValue(cmd, aiDumpCmdStateFormat))
+
+	if yes, err := utils.ConfirmFileOverwrite(aiDumpCmdOutputFile, format, assumeYes); err != nil {
 		return err
 	} else if !yes {
 		return nil
@@ -93,6 +97,11 @@ func executeAiDump(cmd *cobra.Command, _ []string) error {
 
 	printAIWarnings(os.Stderr, warnings)
 
+	outputBytes, err := aiDumpOutput(aiGatewayYAML, format)
+	if err != nil {
+		return err
+	}
+
 	// Write output
 	var output io.Writer = os.Stdout
 	if aiDumpCmdOutputFile != "" && aiDumpCmdOutputFile != "-" {
@@ -104,12 +113,30 @@ func executeAiDump(cmd *cobra.Command, _ []string) error {
 		output = outFile
 	}
 
-	_, err = output.Write(aiGatewayYAML)
+	_, err = output.Write(outputBytes)
 	if err != nil {
 		return fmt.Errorf("failed to write output: %w", err)
 	}
 
 	return nil
+}
+
+// aiDumpOutput returns the AI Gateway configuration serialized in the requested
+// format. revert.Revert always produces YAML, so YAML is returned verbatim (to
+// preserve the library's formatting) while JSON is produced by re-serializing.
+func aiDumpOutput(aiGatewayYAML []byte, format string) ([]byte, error) {
+	if strings.ToLower(format) != "json" {
+		return aiGatewayYAML, nil
+	}
+	m, err := filebasics.Deserialize(aiGatewayYAML)
+	if err != nil {
+		return nil, fmt.Errorf("parsing reverted configuration: %w", err)
+	}
+	out, err := filebasics.Serialize(m, filebasics.OutputFormatJSON)
+	if err != nil {
+		return nil, fmt.Errorf("serializing configuration to JSON: %w", err)
+	}
+	return out, nil
 }
 
 // kongsStateToYAML converts Kong state to YAML bytes
@@ -129,7 +156,9 @@ func newAiDumpCmd() *cobra.Command {
 		Long: `The ai dump command reads AI Gateway entities (tagged with 'managed_by:deck-ai')
 from Kong and writes them to a local file in AI Gateway format.
 
-The command exports only entities that have the 'managed_by:deck-ai' tag.`,
+The command exports only entities that have the 'managed_by:deck-ai' tag.
+
+The output can be written as either YAML or JSON, controlled by the --format flag.`,
 		Args: validateNoArgs,
 		RunE: executeAiDump,
 	}
@@ -138,6 +167,8 @@ The command exports only entities that have the 'managed_by:deck-ai' tag.`,
 		"", "dump configuration of a specific Workspace (Kong Enterprise only).")
 	aiDumpCmd.Flags().StringVarP(&aiDumpCmdOutputFile, "output-file", "o",
 		"-", "file to which to write AI Gateway configuration. Use `-` to write to stdout.")
+	aiDumpCmd.Flags().StringVar(&aiDumpCmdStateFormat, "format",
+		"yaml", "output file format: json or yaml.")
 	aiDumpCmd.Flags().BoolVar(&assumeYes, "yes",
 		false, "assume `yes` to prompts and run non-interactively.")
 

--- a/cmd/ai_dump.go
+++ b/cmd/ai_dump.go
@@ -122,21 +122,27 @@ func executeAiDump(cmd *cobra.Command, _ []string) error {
 }
 
 // aiDumpOutput returns the AI Gateway configuration serialized in the requested
-// format. revert.Revert always produces YAML, so YAML is returned verbatim (to
-// preserve the library's formatting) while JSON is produced by re-serializing.
+// format, which is expected to be lower-cased by the caller. revert.Revert
+// always produces YAML, so YAML is returned verbatim (to preserve the library's
+// formatting) while JSON is produced by re-serializing.
 func aiDumpOutput(aiGatewayYAML []byte, format string) ([]byte, error) {
-	if strings.ToLower(format) != "json" {
+	switch filebasics.OutputFormat(format) {
+	case filebasics.OutputFormatYaml:
 		return aiGatewayYAML, nil
+	case filebasics.OutputFormatJSON:
+		m, err := filebasics.Deserialize(aiGatewayYAML)
+		if err != nil {
+			return nil, fmt.Errorf("parsing reverted configuration: %w", err)
+		}
+		out, err := filebasics.Serialize(m, filebasics.OutputFormatJSON)
+		if err != nil {
+			return nil, fmt.Errorf("serializing configuration to JSON: %w", err)
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("expected format to be either %q or %q, got: %q",
+			filebasics.OutputFormatYaml, filebasics.OutputFormatJSON, format)
 	}
-	m, err := filebasics.Deserialize(aiGatewayYAML)
-	if err != nil {
-		return nil, fmt.Errorf("parsing reverted configuration: %w", err)
-	}
-	out, err := filebasics.Serialize(m, filebasics.OutputFormatJSON)
-	if err != nil {
-		return nil, fmt.Errorf("serializing configuration to JSON: %w", err)
-	}
-	return out, nil
 }
 
 // kongsStateToYAML converts Kong state to YAML bytes
@@ -168,7 +174,7 @@ The output can be written as either YAML or JSON, controlled by the --format fla
 	aiDumpCmd.Flags().StringVarP(&aiDumpCmdOutputFile, "output-file", "o",
 		"-", "file to which to write AI Gateway configuration. Use `-` to write to stdout.")
 	aiDumpCmd.Flags().StringVar(&aiDumpCmdStateFormat, "format",
-		"yaml", "output file format: json or yaml.")
+		string(filebasics.OutputFormatYaml), "output file format: json or yaml.")
 	aiDumpCmd.Flags().BoolVar(&assumeYes, "yes",
 		false, "assume `yes` to prompts and run non-interactively.")
 

--- a/cmd/ai_sync.go
+++ b/cmd/ai_sync.go
@@ -8,7 +8,7 @@ import (
 	"slices"
 
 	"dario.cat/mergo"
-	"github.com/Kong/ai-deck-converter/convert"
+	ai2kong "github.com/Kong/ai-deck-converter/convert"
 	"github.com/kong/go-database-reconciler/pkg/cprint"
 	"github.com/kong/go-database-reconciler/pkg/file"
 	"github.com/kong/go-database-reconciler/pkg/utils"
@@ -16,11 +16,10 @@ import (
 )
 
 var (
-	aiSyncSourceFiles   []string
-	aiSyncWorkspace     string
-	aiSyncParallelism   int
-	aiSyncDBUpdateDelay int
-	aiSyncJSONOutput    bool
+	aiSyncSourceFiles []string
+	aiSyncWorkspace   string
+	aiSyncParallelism int
+	aiSyncJSONOutput  bool
 )
 
 func executeAiSync(cmd *cobra.Command, _ []string) error {
@@ -53,7 +52,7 @@ func buildAiSyncTargetContent(filenames []string) (*file.Content, error) {
 
 	var merged file.Content
 	for _, src := range sources {
-		convertedYAML, warnings, err := convert.Convert(src.content, convert.Options{})
+		convertedYAML, warnings, err := ai2kong.Convert(src.content, ai2kong.Options{})
 		if err != nil {
 			return nil, fmt.Errorf("converting %s: %w", src.name, err)
 		}

--- a/cmd/ai_sync.go
+++ b/cmd/ai_sync.go
@@ -7,17 +7,20 @@ import (
 	"os"
 	"slices"
 
-	ai2kong "github.com/Kong/ai-deck-converter/convert"
+	"dario.cat/mergo"
+	"github.com/Kong/ai-deck-converter/convert"
 	"github.com/kong/go-database-reconciler/pkg/cprint"
 	"github.com/kong/go-database-reconciler/pkg/file"
+	"github.com/kong/go-database-reconciler/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
 var (
-	aiSyncSourceFile  string
-	aiSyncWorkspace   string
-	aiSyncParallelism int
-	aiSyncJSONOutput  bool
+	aiSyncSourceFiles   []string
+	aiSyncWorkspace     string
+	aiSyncParallelism   int
+	aiSyncDBUpdateDelay int
+	aiSyncJSONOutput    bool
 )
 
 func executeAiSync(cmd *cobra.Command, _ []string) error {
@@ -27,20 +30,9 @@ func executeAiSync(cmd *cobra.Command, _ []string) error {
 		initJSONOutput()
 	}
 
-	sourceContent, err := readAiSyncSource(aiSyncSourceFile)
+	targetContent, err := buildAiSyncTargetContent(aiSyncSourceFiles)
 	if err != nil {
 		return err
-	}
-
-	convertedYAML, warnings, err := ai2kong.Convert(sourceContent, ai2kong.Options{})
-	if err != nil {
-		return fmt.Errorf("conversion failed: %w", err)
-	}
-	reportAiConversionWarnings(warnings, aiSyncJSONOutput)
-
-	targetContent, err := file.GetContentFromReader(bytes.NewReader(convertedYAML), file.EnvVarsSkip)
-	if err != nil {
-		return fmt.Errorf("parsing converted configuration: %w", err)
 	}
 
 	injectmanagedByAIDeckTag(targetContent)
@@ -49,21 +41,83 @@ func executeAiSync(cmd *cobra.Command, _ []string) error {
 		aiSyncWorkspace, aiSyncJSONOutput, ApplyTypeFull)
 }
 
-// readAiSyncSource reads the AI Gateway source configuration from filename,
-// or from stdin when filename is "-".
-func readAiSyncSource(filename string) ([]byte, error) {
-	if filename == "-" {
-		content, err := io.ReadAll(os.Stdin)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read from stdin: %w", err)
-		}
-		return content, nil
-	}
-	content, err := os.ReadFile(filename)
+// buildAiSyncTargetContent reads every AI Gateway source referenced by
+// filenames (files, directories, or "-" for stdin), converts each to a decK
+// configuration, and merges the results into a single target content. This
+// mirrors how `gateway sync` reads and merges multiple state files.
+func buildAiSyncTargetContent(filenames []string) (*file.Content, error) {
+	sources, err := readAiSyncSources(filenames)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read source file: %w", err)
+		return nil, err
 	}
-	return content, nil
+
+	var merged file.Content
+	for _, src := range sources {
+		convertedYAML, warnings, err := convert.Convert(src.content, convert.Options{})
+		if err != nil {
+			return nil, fmt.Errorf("converting %s: %w", src.name, err)
+		}
+		reportAiConversionWarnings(warnings, aiSyncJSONOutput)
+
+		content, err := file.GetContentFromReader(bytes.NewReader(convertedYAML), file.EnvVarsSkip)
+		if err != nil {
+			return nil, fmt.Errorf("parsing converted configuration from %s: %w", src.name, err)
+		}
+		if err := mergo.Merge(&merged, content, mergo.WithAppendSlice); err != nil {
+			return nil, fmt.Errorf("merging converted configuration from %s: %w", src.name, err)
+		}
+	}
+
+	return &merged, nil
+}
+
+// aiSyncSource pairs a source's raw bytes with a human-readable name used in
+// error messages ("stdin" or the file path).
+type aiSyncSource struct {
+	name    string
+	content []byte
+}
+
+// readAiSyncSources expands each entry in filenames into the AI Gateway source
+// documents it refers to. An entry may be "-" (stdin), a single file, or a
+// directory (in which case every YAML/JSON config file within it is read),
+// matching the file resolution done by `gateway sync`.
+func readAiSyncSources(filenames []string) ([]aiSyncSource, error) {
+	var sources []aiSyncSource
+	for _, fileOrDir := range filenames {
+		if fileOrDir == "-" {
+			content, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read from stdin: %w", err)
+			}
+			sources = append(sources, aiSyncSource{name: "stdin", content: content})
+			continue
+		}
+
+		finfo, err := os.Stat(fileOrDir)
+		if err != nil {
+			return nil, fmt.Errorf("reading source file: %w", err)
+		}
+
+		var files []string
+		if finfo.IsDir() {
+			files, err = utils.ConfigFilesInDir(fileOrDir)
+			if err != nil {
+				return nil, fmt.Errorf("getting files from directory: %w", err)
+			}
+		} else {
+			files = []string{fileOrDir}
+		}
+
+		for _, f := range files {
+			content, err := os.ReadFile(f)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read source file %s: %w", f, err)
+			}
+			sources = append(sources, aiSyncSource{name: f, content: content})
+		}
+	}
+	return sources, nil
 }
 
 // injectmanagedByAIDeckTag ensures the AI-managed select tag is present in
@@ -82,21 +136,23 @@ func injectmanagedByAIDeckTag(content *file.Content) {
 
 func newAiSyncCmd() *cobra.Command {
 	aiSyncCmd := &cobra.Command{
-		Use:   "sync [flags] [ai-gateway-state-file]",
+		Use:   "sync [flags] [ai-gateway-state-files...]",
 		Short: "Sync AI Gateway configuration to Kong",
-		Long: `The ai sync command reads an AI Gateway configuration file and syncs it to Kong AI Gateway,
+		Long: `The ai sync command reads AI Gateway configuration files and syncs them to Kong AI Gateway,
 tagging every managed entity with 'managed_by:deck-ai'.
 
-The AI Gateway state file is provided as a positional argument. Use '-' to read
-from stdin (the default when no argument is given).
+The AI Gateway state files are provided as positional arguments. Multiple files
+and/or directories may be given; directories are searched for YAML and JSON
+config files, and the contents of all sources are merged. Use '-' to read from
+stdin (the default when no argument is given).
 
 This is the direct equivalent of running 'deck file ai2kong' followed by
 'deck gateway sync' on the result.`,
-		Args: cobra.MaximumNArgs(1),
+		Args: cobra.MinimumNArgs(0),
 		PreRunE: func(_ *cobra.Command, args []string) error {
-			aiSyncSourceFile = "-"
-			if len(args) > 0 {
-				aiSyncSourceFile = args[0]
+			aiSyncSourceFiles = args
+			if len(aiSyncSourceFiles) == 0 {
+				aiSyncSourceFiles = []string{"-"}
 			}
 			return checkParallelism(aiSyncParallelism)
 		},

--- a/cmd/ai_test.go
+++ b/cmd/ai_test.go
@@ -7,10 +7,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/Kong/ai-deck-converter/convert"
+	ai2kong "github.com/Kong/ai-deck-converter/convert"
 	"github.com/kong/go-database-reconciler/pkg/file"
 	"github.com/kong/go-kong/kong"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 )
@@ -61,7 +60,7 @@ func assertHasAITag(t *testing.T, doc map[string]interface{}) {
 	require.True(t, ok, "_info section should be present")
 	tags, ok := info["select_tags"].([]interface{})
 	require.True(t, ok, "_info.select_tags should be present")
-	assert.Contains(t, tags, managedByAIDeckTag)
+	require.Contains(t, tags, managedByAIDeckTag)
 }
 
 func TestContentHasmanagedByAIDeckTag(t *testing.T) {
@@ -256,7 +255,7 @@ func TestContentHasmanagedByAIDeckTag(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, contentHasmanagedByAIDeckTag(tt.content))
+			require.Equal(t, tt.want, contentHasmanagedByAIDeckTag(tt.content))
 		})
 	}
 }
@@ -268,12 +267,12 @@ func TestAiConvertJSONInputParity(t *testing.T) {
 	jsonSource, err := yaml.YAMLToJSON([]byte(aiGatewaySourceYAML))
 	require.NoError(t, err)
 
-	fromYAML, _, err := convert.Convert([]byte(aiGatewaySourceYAML), convert.Options{OutputMode: "deck"})
+	fromYAML, _, err := ai2kong.Convert([]byte(aiGatewaySourceYAML), ai2kong.Options{OutputMode: "deck"})
 	require.NoError(t, err)
-	fromJSON, _, err := convert.Convert(jsonSource, convert.Options{OutputMode: "deck"})
+	fromJSON, _, err := ai2kong.Convert(jsonSource, ai2kong.Options{OutputMode: "deck"})
 	require.NoError(t, err)
 
-	assert.True(t, bytes.Equal(fromYAML, fromJSON),
+	require.True(t, bytes.Equal(fromYAML, fromJSON),
 		"JSON and YAML inputs should convert to identical decK output")
 }
 
@@ -320,6 +319,32 @@ func TestAi2KongOutputFormats(t *testing.T) {
 
 	t.Run("unknown format errors", func(t *testing.T) {
 		err := runAi2Kong(t, srcYAML, filepath.Join(dir, "out.xml"), "xml")
-		assert.Error(t, err)
+		require.Error(t, err)
+	})
+}
+
+// TestAiDumpOutput verifies that aiDumpOutput returns YAML verbatim, produces
+// valid JSON on request, and rejects any other format rather than silently
+// falling back to YAML.
+func TestAiDumpOutput(t *testing.T) {
+	reverted := []byte("_info:\n  select_tags:\n  - " + managedByAIDeckTag + "\n")
+
+	t.Run("yaml returns input verbatim", func(t *testing.T) {
+		out, err := aiDumpOutput(reverted, "yaml")
+		require.NoError(t, err)
+		require.Equal(t, reverted, out)
+	})
+
+	t.Run("json re-serializes to valid JSON", func(t *testing.T) {
+		out, err := aiDumpOutput(reverted, "json")
+		require.NoError(t, err)
+		var doc map[string]interface{}
+		require.NoError(t, json.Unmarshal(out, &doc), "output should be valid JSON")
+		assertHasAITag(t, doc)
+	})
+
+	t.Run("unknown format errors", func(t *testing.T) {
+		_, err := aiDumpOutput(reverted, "xml")
+		require.Error(t, err)
 	})
 }

--- a/cmd/ai_test.go
+++ b/cmd/ai_test.go
@@ -277,24 +277,6 @@ func TestAiConvertJSONInputParity(t *testing.T) {
 		"JSON and YAML inputs should convert to identical decK output")
 }
 
-func TestAddDefaultSelectTags(t *testing.T) {
-	t.Run("creates _info when absent", func(t *testing.T) {
-		doc, err := addDefaultSelectTags([]byte("services: []\n"))
-		require.NoError(t, err)
-		info, ok := doc["_info"].(map[string]interface{})
-		require.True(t, ok, "_info should be created")
-		assert.Equal(t, []string{managedByAIDeckTag}, info["select_tags"])
-	})
-
-	t.Run("overwrites select_tags when _info present", func(t *testing.T) {
-		doc, err := addDefaultSelectTags([]byte("_info:\n  select_tags: [existing]\nservices: []\n"))
-		require.NoError(t, err)
-		info, ok := doc["_info"].(map[string]interface{})
-		require.True(t, ok)
-		assert.Equal(t, []string{managedByAIDeckTag}, info["select_tags"])
-	})
-}
-
 // TestAi2KongOutputFormats drives the ai2kong command end-to-end with JSON input
 // and asserts both YAML (default) and JSON output are valid and carry the AI tag,
 // and that an unknown format is rejected.
@@ -339,26 +321,5 @@ func TestAi2KongOutputFormats(t *testing.T) {
 	t.Run("unknown format errors", func(t *testing.T) {
 		err := runAi2Kong(t, srcYAML, filepath.Join(dir, "out.xml"), "xml")
 		assert.Error(t, err)
-	})
-}
-
-// TestAiDumpOutput verifies the format handling of ai dump: YAML is returned
-// verbatim and JSON is an equivalent re-serialization.
-func TestAiDumpOutput(t *testing.T) {
-	yamlIn := []byte("_info:\n  select_tags:\n  - managed_by:deck-ai\nmodels:\n- name: gpt-4o\n  type: model\n")
-
-	t.Run("yaml returns verbatim", func(t *testing.T) {
-		out, err := aiDumpOutput(yamlIn, "yaml")
-		require.NoError(t, err)
-		assert.True(t, bytes.Equal(yamlIn, out), "yaml output should be returned verbatim")
-	})
-
-	t.Run("json is equivalent", func(t *testing.T) {
-		out, err := aiDumpOutput(yamlIn, "json")
-		require.NoError(t, err)
-		var jsonDoc, yamlDoc map[string]interface{}
-		require.NoError(t, json.Unmarshal(out, &jsonDoc), "output should be valid JSON")
-		require.NoError(t, yaml.Unmarshal(yamlIn, &yamlDoc))
-		assert.Equal(t, yamlDoc, jsonDoc)
 	})
 }

--- a/cmd/ai_test.go
+++ b/cmd/ai_test.go
@@ -1,12 +1,68 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/Kong/ai-deck-converter/convert"
 	"github.com/kong/go-database-reconciler/pkg/file"
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
+
+// aiGatewaySourceYAML is a minimal but complete AI Gateway 2.0 source document
+// used to exercise the JSON/YAML input and output paths.
+const aiGatewaySourceYAML = `models:
+  - type: model
+    display_name: gpt-4o
+    name: gpt-4o
+    capabilities: [generate]
+    formats:
+      - type: openai
+    targets:
+      - name: gpt-4o
+        weight: 100
+        provider: openai-main
+        config:
+          type: openai
+          temperature: 0.7
+    policies: []
+    acls: {allow: [], deny: []}
+    config:
+      route:
+        paths: [/ai]
+      model:
+        alias: "@openai/gpt-4o"
+      balancer:
+        algorithm: round-robin
+        slots: 10000
+providers:
+  - type: openai
+    display_name: OpenAI Main
+    name: openai-main
+    config:
+      auth:
+        type: basic
+        headers:
+          - name: Authorization
+            value: "{vault://env/openai-key}"
+`
+
+// assertHasAITag verifies the decoded decK document carries the AI-managed
+// select tag in its _info section.
+func assertHasAITag(t *testing.T, doc map[string]interface{}) {
+	t.Helper()
+	info, ok := doc["_info"].(map[string]interface{})
+	require.True(t, ok, "_info section should be present")
+	tags, ok := info["select_tags"].([]interface{})
+	require.True(t, ok, "_info.select_tags should be present")
+	assert.Contains(t, tags, managedByAIDeckTag)
+}
 
 func TestContentHasmanagedByAIDeckTag(t *testing.T) {
 	otherTag := "team-a"
@@ -203,4 +259,106 @@ func TestContentHasmanagedByAIDeckTag(t *testing.T) {
 			assert.Equal(t, tt.want, contentHasmanagedByAIDeckTag(tt.content))
 		})
 	}
+}
+
+// TestAiConvertJSONInputParity verifies that a JSON source produces exactly the
+// same converted decK output as the equivalent YAML source. This covers JSON
+// input support for both `file ai2kong` and `ai sync`, which share convert.Convert.
+func TestAiConvertJSONInputParity(t *testing.T) {
+	jsonSource, err := yaml.YAMLToJSON([]byte(aiGatewaySourceYAML))
+	require.NoError(t, err)
+
+	fromYAML, _, err := convert.Convert([]byte(aiGatewaySourceYAML), convert.Options{OutputMode: "deck"})
+	require.NoError(t, err)
+	fromJSON, _, err := convert.Convert(jsonSource, convert.Options{OutputMode: "deck"})
+	require.NoError(t, err)
+
+	assert.True(t, bytes.Equal(fromYAML, fromJSON),
+		"JSON and YAML inputs should convert to identical decK output")
+}
+
+func TestAddDefaultSelectTags(t *testing.T) {
+	t.Run("creates _info when absent", func(t *testing.T) {
+		doc, err := addDefaultSelectTags([]byte("services: []\n"))
+		require.NoError(t, err)
+		info, ok := doc["_info"].(map[string]interface{})
+		require.True(t, ok, "_info should be created")
+		assert.Equal(t, []string{managedByAIDeckTag}, info["select_tags"])
+	})
+
+	t.Run("overwrites select_tags when _info present", func(t *testing.T) {
+		doc, err := addDefaultSelectTags([]byte("_info:\n  select_tags: [existing]\nservices: []\n"))
+		require.NoError(t, err)
+		info, ok := doc["_info"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, []string{managedByAIDeckTag}, info["select_tags"])
+	})
+}
+
+// TestAi2KongOutputFormats drives the ai2kong command end-to-end with JSON input
+// and asserts both YAML (default) and JSON output are valid and carry the AI tag,
+// and that an unknown format is rejected.
+func TestAi2KongOutputFormats(t *testing.T) {
+	disableAnalytics = true
+
+	dir := t.TempDir()
+	jsonSource, err := yaml.YAMLToJSON([]byte(aiGatewaySourceYAML))
+	require.NoError(t, err)
+	srcJSON := filepath.Join(dir, "input.json")
+	require.NoError(t, os.WriteFile(srcJSON, jsonSource, 0o600))
+	srcYAML := filepath.Join(dir, "input.yaml")
+	require.NoError(t, os.WriteFile(srcYAML, []byte(aiGatewaySourceYAML), 0o600))
+
+	runAi2Kong := func(t *testing.T, source, output, format string) error {
+		t.Helper()
+		cmd := newAi2KongCmd()
+		cmd.SetArgs([]string{"--source", source, "--output-file", output, "--format", format})
+		return cmd.Execute()
+	}
+
+	t.Run("json input, json output", func(t *testing.T) {
+		out := filepath.Join(dir, "out.json")
+		require.NoError(t, runAi2Kong(t, srcJSON, out, "json"))
+		data, err := os.ReadFile(out)
+		require.NoError(t, err)
+		var doc map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &doc), "output should be valid JSON")
+		assertHasAITag(t, doc)
+	})
+
+	t.Run("yaml input, yaml output", func(t *testing.T) {
+		out := filepath.Join(dir, "out.yaml")
+		require.NoError(t, runAi2Kong(t, srcYAML, out, "yaml"))
+		data, err := os.ReadFile(out)
+		require.NoError(t, err)
+		var doc map[string]interface{}
+		require.NoError(t, yaml.Unmarshal(data, &doc))
+		assertHasAITag(t, doc)
+	})
+
+	t.Run("unknown format errors", func(t *testing.T) {
+		err := runAi2Kong(t, srcYAML, filepath.Join(dir, "out.xml"), "xml")
+		assert.Error(t, err)
+	})
+}
+
+// TestAiDumpOutput verifies the format handling of ai dump: YAML is returned
+// verbatim and JSON is an equivalent re-serialization.
+func TestAiDumpOutput(t *testing.T) {
+	yamlIn := []byte("_info:\n  select_tags:\n  - managed_by:deck-ai\nmodels:\n- name: gpt-4o\n  type: model\n")
+
+	t.Run("yaml returns verbatim", func(t *testing.T) {
+		out, err := aiDumpOutput(yamlIn, "yaml")
+		require.NoError(t, err)
+		assert.True(t, bytes.Equal(yamlIn, out), "yaml output should be returned verbatim")
+	})
+
+	t.Run("json is equivalent", func(t *testing.T) {
+		out, err := aiDumpOutput(yamlIn, "json")
+		require.NoError(t, err)
+		var jsonDoc, yamlDoc map[string]interface{}
+		require.NoError(t, json.Unmarshal(out, &jsonDoc), "output should be valid JSON")
+		require.NoError(t, yaml.Unmarshal(yamlIn, &yamlDoc))
+		assert.Equal(t, yamlDoc, jsonDoc)
+	})
 }

--- a/cmd/file_ai2kong.go
+++ b/cmd/file_ai2kong.go
@@ -35,7 +35,8 @@ func newAi2KongCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&convertSourceFile, "source", "s", "", "AI Gateway source file (required)")
 	cmd.Flags().StringVarP(&convertOutputFile, "output-file", "o", "",
 		"Output Kong decK file (optional, defaults to stdout)")
-	cmd.Flags().StringVarP(&convertOutputFormat, "format", "", "yaml", "output format: yaml or json")
+	cmd.Flags().StringVar(&convertOutputFormat, "format",
+		string(filebasics.OutputFormatYaml), "output format: yaml or json")
 
 	return cmd
 }

--- a/cmd/file_ai2kong.go
+++ b/cmd/file_ai2kong.go
@@ -2,17 +2,19 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"os"
+	"strings"
 
 	ai2kong "github.com/Kong/ai-deck-converter/convert"
+	"github.com/kong/go-apiops/filebasics"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 )
 
 var (
-	convertSourceFile string
-	convertOutputFile string
+	convertSourceFile   string
+	convertOutputFile   string
+	convertOutputFormat string
 )
 
 const managedByAIDeckTag = "managed_by:deck-ai"
@@ -22,7 +24,9 @@ func newAi2KongCmd() *cobra.Command {
 		Use:   "ai2kong",
 		Short: "Generate Kong configuration from AI Gateway configuration",
 		Long: `This command takes an AI Gateway 2.0 entity model and converts it to a standard decK state file.` +
-			` It also adds the 'managed_by:deck-ai' tag which is used internally to all entities by default.`,
+			` It also adds the 'managed_by:deck-ai' tag which is used internally to all entities by default.` +
+			"\n\nThe source file may be provided in either YAML or JSON; the format is auto-detected." +
+			" The output format is controlled by the --format flag.",
 		Args:    validateNoArgs,
 		PreRunE: validateAi2KongFlags,
 		RunE:    execute,
@@ -30,7 +34,8 @@ func newAi2KongCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&convertSourceFile, "source", "s", "", "AI Gateway source file (required)")
 	cmd.Flags().StringVarP(&convertOutputFile, "output-file", "o", "",
-		"Output Kong decK YAML file (optional, defaults to stdout)")
+		"Output Kong decK file (optional, defaults to stdout)")
+	cmd.Flags().StringVarP(&convertOutputFormat, "format", "", "yaml", "output format: yaml or json")
 
 	return cmd
 }
@@ -42,10 +47,13 @@ func validateAi2KongFlags(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
-func execute(_ *cobra.Command, _ []string) error {
+func execute(cmd *cobra.Command, _ []string) error {
 	_ = sendAnalytics("file-ai2kong", "", modeAIGateway)
-	// Read source file
-	sourceContent, err := os.ReadFile(convertSourceFile)
+
+	format := strings.ToLower(getFormatFlagValue(cmd, convertOutputFormat))
+
+	// Read source file (auto-detects YAML or JSON).
+	sourceContent, err := filebasics.ReadFile(convertSourceFile)
 	if err != nil {
 		return fmt.Errorf("failed to read source file: %w", err)
 	}
@@ -60,26 +68,18 @@ func execute(_ *cobra.Command, _ []string) error {
 	printAIWarnings(os.Stderr, warnings)
 
 	// Add the default select_tags to the converted document's _info section
-	output, err := addDefaultSelectTags(converted)
+	doc, err := addDefaultSelectTags(converted)
 	if err != nil {
 		return err
 	}
 
-	// Write output
-	var outputWriter io.Writer
-	outputWriter = os.Stdout
-
-	if convertOutputFile != "" {
-		outFile, err := os.Create(convertOutputFile)
-		if err != nil {
-			return fmt.Errorf("failed to create output file: %w", err)
-		}
-		defer outFile.Close()
-		outputWriter = outFile
+	// Write output in the requested format. An empty output file means stdout,
+	// which filebasics represents as "-".
+	outputFile := convertOutputFile
+	if outputFile == "" {
+		outputFile = "-"
 	}
-
-	_, err = outputWriter.Write(output)
-	if err != nil {
+	if err := filebasics.WriteSerializedFile(outputFile, doc, filebasics.OutputFormat(format)); err != nil {
 		return fmt.Errorf("failed to write output: %w", err)
 	}
 
@@ -88,34 +88,22 @@ func execute(_ *cobra.Command, _ []string) error {
 
 // addDefaultSelectTags parses the converted YAML and ensures the _info section
 // carries the default select_tags, creating _info if it is absent. It returns
-// the re-marshaled YAML.
-func addDefaultSelectTags(converted []byte) ([]byte, error) {
-	var doc interface{}
-	if err := yaml.Unmarshal(converted, &doc); err != nil {
-		return nil, fmt.Errorf("failed to parse converted YAML: %w", err)
+// the mutated document as a map ready for serialization.
+func addDefaultSelectTags(converted []byte) (map[string]interface{}, error) {
+	var docMap map[string]interface{}
+	if err := yaml.Unmarshal(converted, &docMap); err != nil {
+		return nil, fmt.Errorf("failed to parse converted config: %w", err)
 	}
 
-	// Ensure the document is a map and add select_tags to _info
-	if docMap, ok := doc.(map[string]interface{}); ok {
-		if infoMap, ok := docMap["_info"].(map[string]interface{}); ok {
-			// _info exists, update select_tags
-			infoMap["select_tags"] = []string{managedByAIDeckTag}
-		} else {
-			// _info doesn't exist, create it with select_tags
-			docMap["_info"] = map[string]interface{}{
-				"select_tags": []string{managedByAIDeckTag},
-			}
+	if infoMap, ok := docMap["_info"].(map[string]interface{}); ok {
+		// _info exists, update select_tags
+		infoMap["select_tags"] = []string{managedByAIDeckTag}
+	} else {
+		// _info doesn't exist, create it with select_tags
+		docMap["_info"] = map[string]interface{}{
+			"select_tags": []string{managedByAIDeckTag},
 		}
 	}
 
-	output, err := marshalToYAML(doc)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal modified document: %w", err)
-	}
-	return output, nil
-}
-
-// marshalToYAML encodes v as YAML using a two-space indent.
-func marshalToYAML(v interface{}) ([]byte, error) {
-	return yaml.Marshal(v)
+	return docMap, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ replace github.com/yudai/gojsondiff v1.0.0 => github.com/Kong/gojsondiff v1.3.0
 replace gopkg.in/yaml.v3 v3.0.1 => github.com/Kong/yaml v1.0.0
 
 require (
+	dario.cat/mergo v1.0.2
 	github.com/Kong/ai-deck-converter v0.3.0
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/blang/semver/v4 v4.0.0
@@ -155,7 +156,6 @@ require (
 )
 
 require (
-	dario.cat/mergo v1.0.2 // indirect
 	github.com/Kong/go-diff v1.2.2 // indirect
 	github.com/Kong/gojsondiff v1.3.2 // indirect
 	github.com/adrg/strutil v0.3.0 // indirect


### PR DESCRIPTION
# Summary
This PR adds two features -
1. Input and Output support for JSON - for output, json can be picked using `--format json`
2. Syncing multiple files using `deck ai sync`

In deck ai sync - we are reading the files one by one, converting them and merging the `file.Content`