### PR TITLE
chore(deps): update go-database-reconciler and go-kong

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,8 @@ require (
 	github.com/fatih/color v1.19.0
 	github.com/google/go-cmp v0.7.0
 	github.com/kong/go-apiops v0.4.5
-	github.com/kong/go-database-reconciler v1.40.3
-	github.com/kong/go-kong v0.76.1
+	github.com/kong/go-database-reconciler v1.41.1
+	github.com/kong/go-kong v0.77.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -254,10 +254,10 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kong/go-apiops v0.4.5 h1:9b41aJ5LKlVR+RaspviTE6nBD9oZRTltw+tRA2k9k7g=
 github.com/kong/go-apiops v0.4.5/go.mod h1:Xt99d90LallLVwYJAGaufiNbBdsK0KKboe7gR4Ryths=
-github.com/kong/go-database-reconciler v1.40.3 h1:myK/p/BjWgKwhLbbuHY3//Q9Ui2YPtR0mkXc7A96XL0=
-github.com/kong/go-database-reconciler v1.40.3/go.mod h1:YlfE6omuZS9Xbm+IlfprZExA1BFESejy4CJhwvWBvKo=
-github.com/kong/go-kong v0.76.1 h1:lImAHvog7ehm4XL2rs8ZyCx98k56ihNazLG55bvHgVM=
-github.com/kong/go-kong v0.76.1/go.mod h1:Wx5aTcMjyUnIF94M5NYFWb/EnuEkqB5STrWvybFSYYQ=
+github.com/kong/go-database-reconciler v1.41.1 h1:QWxz0YuF/dDzuhSrQPNSurWUgHQygf7yCT+G7LmNHKM=
+github.com/kong/go-database-reconciler v1.41.1/go.mod h1:AYYSt3TBXL8QMa1IZwqj4BhSxKMkFXama5ObtgWPoMc=
+github.com/kong/go-kong v0.77.0 h1:bANx78/pE+kbKnL1ssa24Si4xbyBjhkUxwTOI+MrnnI=
+github.com/kong/go-kong v0.77.0/go.mod h1:Wx5aTcMjyUnIF94M5NYFWb/EnuEkqB5STrWvybFSYYQ=
 github.com/kong/go-slugify v1.0.0 h1:vCFAyf2sdoSlBtLcrmDWUFn0ohlpKiKvQfXZkO5vSKY=
 github.com/kong/go-slugify v1.0.0/go.mod h1:dbR2h3J2QKXQ1k0aww6cN7o4cIcwlWflr6RKRdcoaiw=
 github.com/kong/kubernetes-configuration v1.5.3 h1:4Hh2ZAT5zjHHqx07VVMF5lIUZ7c2RAOUpIINpOsduZs=


### PR DESCRIPTION
Update `go-database-reconciler` to `v1.41.1` to fix the issue #2147 

Includes changes from the following PR:
https://github.com/Kong/go-database-reconciler/pull/500