### PR TITLE
chore: release v1.65.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [v1.65.0](#v1650)
 - [v1.64.0](#v1640)
 - [v1.63.0](#v1630)
 - [v1.62.1](#v1621)
@@ -144,6 +145,19 @@
 - [v0.2.0](#v020)
 - [v0.1.0](#v010)
 
+
+## [v1.65.0]
+> Release date: 2026/06/28
+
+### Added
+- Added support for configuring AI Gateway using commands `deck file ai2kong`, `deck ai sync` and `deck ai dump`. [#2137](https://github.com/Kong/deck/pull/2137) [go-database-reconciler #496](https://github.com/Kong/go-database-reconciler/pull/496) [go-kong #624](https://github.com/Kong/go-kong/pull/624)
+
+### Fixed
+- Fixed `deck file openapi2mcp` to skip emitting `conversion-listener` mode attributes in `conversion` mode. [#2161](https://github.com/Kong/deck/pull/2161) [go-apiops #300](https://github.com/Kong/go-apiops/pull/300)
+- Fixed drift when headers are set to empty object in routes. [#2163](https://github.com/Kong/deck/pull/2163) [go-database-reconciler #500](https://github.com/Kong/go-database-reconciler/pull/500)
+
+### Chores
+- Added OCI metadata to the docker image
 
 ## [v1.64.0]
 > Release date: 2026/06/29
@@ -2681,6 +2695,7 @@ No breaking changes have been introduced in this release.
 ### Summary
 
 Debut release of decK
+[v1.65.0]: https://github.com/Kong/deck/compare/v1.64.0...v1.65.0
 [v1.64.0]: https://github.com/Kong/deck/compare/v1.63.0...v1.64.0
 [v1.63.0]: https://github.com/Kong/deck/compare/v1.62.1...v1.63.0
 [v1.62.1]: https://github.com/Kong/deck/compare/v1.62.0...v1.62.1

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ the GitHub [release page](https://github.com/kong/deck/releases)
 or install by downloading the binary:
 
 ```shell
-$ curl -sL https://github.com/kong/deck/releases/download/v1.64.0/deck_1.64.0_linux_amd64.tar.gz -o deck.tar.gz
+$ curl -sL https://github.com/kong/deck/releases/download/v1.65.0/deck_1.65.0_linux_amd64.tar.gz -o deck.tar.gz
 $ tar -xf deck.tar.gz -C /tmp
 $ sudo cp /tmp/deck /usr/local/bin/
 ```
@@ -84,7 +84,7 @@ If you are on Windows, you can download the binary from the GitHub
 [release page](https://github.com/kong/deck/releases) or via PowerShell:
 
 ```shell
-$ curl -sL https://github.com/kong/deck/releases/download/v1.64.0/deck_1.64.0_windows_amd64.tar.gz -o deck.tar.gz
+$ curl -sL https://github.com/kong/deck/releases/download/v1.65.0/deck_1.65.0_windows_amd64.tar.gz -o deck.tar.gz
 $ tar -xzvf deck.tar.gz
 ```
 


### PR DESCRIPTION
Releases DecK v1.65.0 with support for AI Gateway, and a few bug fixes.

Faraday cage analysis: https://github.com/Kong/deck-private/actions/runs/30256439173 (no new network calls - all calls made by deck are on Port 53 (DNS) and 8001 (gateway).

Diff:
https://github.com/Kong/deck/compare/v1.64.0...main
https://github.com/Kong/go-database-reconciler/compare/v1.40.3...v1.41.1
https://github.com/Kong/go-kong/compare/v0.76.1...v0.77.0
https://github.com/Kong/go-apiops/compare/v0.4.4...v0.4.5
