### PR TITLE
feat(tests): add tests for handling empty array plugin configurations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/fatih/color v1.19.0
 	github.com/google/go-cmp v0.7.0
 	github.com/kong/go-apiops v0.4.5
-	github.com/kong/go-database-reconciler v1.42.0
+	github.com/kong/go-database-reconciler v1.42.1
 	github.com/kong/go-kong v0.77.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kong/go-apiops v0.4.5 h1:9b41aJ5LKlVR+RaspviTE6nBD9oZRTltw+tRA2k9k7g=
 github.com/kong/go-apiops v0.4.5/go.mod h1:Xt99d90LallLVwYJAGaufiNbBdsK0KKboe7gR4Ryths=
-github.com/kong/go-database-reconciler v1.42.0 h1:NyS8/x0EmWkAghU3PHZM3tquDWHYysa5yCWy3dOWXS8=
-github.com/kong/go-database-reconciler v1.42.0/go.mod h1:AYYSt3TBXL8QMa1IZwqj4BhSxKMkFXama5ObtgWPoMc=
+github.com/kong/go-database-reconciler v1.42.1 h1:1F4XhhJcnK5ixmeeZ973N4pjIkmnf9xlIejdq6+TZMs=
+github.com/kong/go-database-reconciler v1.42.1/go.mod h1:AYYSt3TBXL8QMa1IZwqj4BhSxKMkFXama5ObtgWPoMc=
 github.com/kong/go-kong v0.77.0 h1:bANx78/pE+kbKnL1ssa24Si4xbyBjhkUxwTOI+MrnnI=
 github.com/kong/go-kong v0.77.0/go.mod h1:Wx5aTcMjyUnIF94M5NYFWb/EnuEkqB5STrWvybFSYYQ=
 github.com/kong/go-slugify v1.0.0 h1:vCFAyf2sdoSlBtLcrmDWUFn0ohlpKiKvQfXZkO5vSKY=

--- a/tests/integration/diff_test.go
+++ b/tests/integration/diff_test.go
@@ -1072,17 +1072,17 @@ func Test_Diff_EmptyArrayPluginConfig_NoPerpetualDiff(t *testing.T) {
 
 			if isKonnect {
 				runDualTestWithSkipDefaults(t, tc.name, func(t *testing.T) {
-					testDiffEmptyArrayPluginConfigNoPerpetualDiffImpl(t, ctx, tc.stateFile)
+					testDiffEmptyArrayPluginConfigNoPerpetualDiffImpl(ctx, t, tc.stateFile)
 				})
 			} else {
 				// for enterprise run once
-				testDiffEmptyArrayPluginConfigNoPerpetualDiffImpl(t, ctx, tc.stateFile)
+				testDiffEmptyArrayPluginConfigNoPerpetualDiffImpl(ctx, t, tc.stateFile)
 			}
 		})
 	}
 }
 
-func testDiffEmptyArrayPluginConfigNoPerpetualDiffImpl(t *testing.T, ctx context.Context, stateFile string) {
+func testDiffEmptyArrayPluginConfigNoPerpetualDiffImpl(ctx context.Context, t *testing.T, stateFile string) {
 	setup(t)
 
 	// A perpetual diff only surfaces across convergence cycles, so sync then diff twice: the second

--- a/tests/integration/diff_test.go
+++ b/tests/integration/diff_test.go
@@ -528,7 +528,7 @@ Summary:
   Updated: 1
   Deleted: 0
 `
-	expectedKonnectWorkspaceMismatchDiff = `Creating workspace 
+	expectedKonnectWorkspaceMismatchDiff = `Creating workspace
 creating route route-diff1
 Summary:
   Created: 1
@@ -1066,18 +1066,33 @@ func Test_Diff_EmptyArrayPluginConfig_NoPerpetualDiff(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.runWhen(t)
-			setup(t)
 
-			// A perpetual diff only surfaces across convergence cycles, so sync then diff twice: the second
-			// cycle proves the first sync wrote nothing that diffs dirty again. Diff alone writes nothing.
-			for i := range 2 {
-				require.NoError(t, sync(ctx, tc.stateFile))
+			// Check if running against Konnect for dual testing
+			isKonnect := os.Getenv("DECK_KONNECT_TOKEN") != ""
 
-				out, err := diff(tc.stateFile)
-				require.NoError(t, err)
-				require.Equal(t, emptyOutput, out, "diff after sync %d reported changes", i+1)
+			if isKonnect {
+				runDualTestWithSkipDefaults(t, tc.name, func(t *testing.T) {
+					testDiffEmptyArrayPluginConfigNoPerpetualDiffImpl(t, ctx, tc.stateFile)
+				})
+			} else {
+				// for enterprise run once
+				testDiffEmptyArrayPluginConfigNoPerpetualDiffImpl(t, ctx, tc.stateFile)
 			}
 		})
+	}
+}
+
+func testDiffEmptyArrayPluginConfigNoPerpetualDiffImpl(t *testing.T, ctx context.Context, stateFile string) {
+	setup(t)
+
+	// A perpetual diff only surfaces across convergence cycles, so sync then diff twice: the second
+	// cycle proves the first sync wrote nothing that diffs dirty again. Diff alone writes nothing.
+	for i := range 2 {
+		require.NoError(t, sync(ctx, stateFile))
+
+		out, err := diff(stateFile)
+		require.NoError(t, err)
+		require.Equal(t, emptyOutput, out, "diff after sync %d reported changes", i+1)
 	}
 }
 
@@ -1086,6 +1101,20 @@ func Test_Diff_EmptyArrayPluginConfig_NoPerpetualDiff(t *testing.T) {
 func Test_Diff_EmptyArrayPluginConfig_RealChangeStillDetected(t *testing.T) {
 	// the fixtures set plugin instance_name, which Kong only supports from 3.2.0.
 	runWhenKongOrKonnect(t, ">=3.2.0")
+
+	// Check if running against Konnect for dual testing
+	isKonnect := os.Getenv("DECK_KONNECT_TOKEN") != ""
+
+	if isKonnect {
+		runDualTestWithSkipDefaults(t, "Test_Diff_EmptyArrayPluginConfig_RealChangeStillDetected",
+			testDiffEmptyArrayPluginConfigRealChangeStillDetectedImpl)
+	} else {
+		// for enterprise run once
+		testDiffEmptyArrayPluginConfigRealChangeStillDetectedImpl(t)
+	}
+}
+
+func testDiffEmptyArrayPluginConfigRealChangeStillDetectedImpl(t *testing.T) {
 	setup(t)
 	ctx := context.Background()
 
@@ -1096,15 +1125,15 @@ func Test_Diff_EmptyArrayPluginConfig_RealChangeStillDetected(t *testing.T) {
 	assert.NotEqual(t, emptyOutput, out)
 	assert.Contains(t, out, "updating plugin zipkin")
 
-	// once applied, the populated state diffs clean too.
+	// once applied, the populated state diffs clean
 	require.NoError(t, sync(ctx, "testdata/diff/010-empty-array-plugin-config/kong-populated.yaml"))
 
 	out, err = diff("testdata/diff/010-empty-array-plugin-config/kong-populated.yaml")
 	require.NoError(t, err)
 	assert.Equal(t, emptyOutput, out)
 
-	// the reverse direction (populated -> []) is the one normalization could plausibly swallow; it must still be
-	// reported and must diff clean once applied.
+	// the reverse direction (populated -> []) is the one normalization could swallow, it must be
+	// reported and must diff clean
 	out, err = diff("testdata/diff/010-empty-array-plugin-config/kong.yaml")
 	require.NoError(t, err)
 	assert.NotEqual(t, emptyOutput, out, "populated -> [] must still be reported")
@@ -1119,6 +1148,15 @@ func Test_Diff_EmptyArrayPluginConfig_RealChangeStillDetected(t *testing.T) {
 
 // Test_Diff_EmptyArrayPluginConfig_OmittedFieldMatchesEmptyArray pins down that omitting an array field entirely
 // is indistinguishable from setting it to [], since decK fills both sides with nil before comparing.
+//
+// NOTE: Deliberately NOT wrapped in runDualTestWithSkipDefaults, unlike the two tests above. That helper runs the same
+// body twice to assert a behavior is invariant across DECK_SKIP_DEFAULTS_FILL; the behavior pinned here is
+// precisely the one that is *not* invariant. Schema-default filling is what turns an omitted array field into an
+// explicit nil, which is what then compares equal to the [] the gateway stores. Skip the filling and the omitted
+// field stays absent, the distinction survives, and diff correctly reports one update (verified against Konnect:
+// the update is real, it writes null over the stored [], and converges once applied). Asserting emptyOutput under
+// both modes therefore fails the skip-defaults run. Branching the assertion on the env var inside a single body
+// would defeat the point of the helper, so the skip-defaults semantics are pinned by their own test instead.
 func Test_Diff_EmptyArrayPluginConfig_OmittedFieldMatchesEmptyArray(t *testing.T) {
 	// the fixtures set plugin instance_name, which Kong only supports from 3.2.0.
 	runWhenKongOrKonnect(t, ">=3.2.0")

--- a/tests/integration/diff_test.go
+++ b/tests/integration/diff_test.go
@@ -528,7 +528,7 @@ Summary:
   Updated: 1
   Deleted: 0
 `
-	expectedKonnectWorkspaceMismatchDiff = `Creating workspace
+	expectedKonnectWorkspaceMismatchDiff = `Creating workspace 
 creating route route-diff1
 Summary:
   Created: 1

--- a/tests/integration/diff_test.go
+++ b/tests/integration/diff_test.go
@@ -1027,6 +1027,111 @@ func Test_Diff_PluginConfigReorderArraySetValues(t *testing.T) {
 	}
 }
 
+// Test_Diff_EmptyArrayPluginConfig_NoPerpetualDiff asserts that a plugin config field explicitly set to an empty
+// array does not produce a diff that never goes away, at any depth of the config tree.
+func Test_Diff_EmptyArrayPluginConfig_NoPerpetualDiff(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		stateFile string
+		runWhen   func(t *testing.T)
+	}{
+		{
+			// the fixtures set plugin instance_name, which Kong only supports from 3.2.0.
+			name:      "top-level empty array field",
+			stateFile: "testdata/diff/010-empty-array-plugin-config/kong.yaml",
+			runWhen:   func(t *testing.T) { runWhenKongOrKonnect(t, ">=3.2.0") },
+		},
+		{
+			name:      "empty array field nested inside a record field",
+			stateFile: "testdata/diff/010-empty-array-plugin-config/kong-nested.yaml",
+			runWhen:   func(t *testing.T) { runWhenKongOrKonnect(t, ">=3.6.0") },
+		},
+		{
+			// injection-protection was introduced in 3.9.0.
+			name:      "empty array field on an enterprise plugin",
+			stateFile: "testdata/diff/010-empty-array-plugin-config/kong-enterprise.yaml",
+			runWhen:   func(t *testing.T) { runWhen(t, "enterprise", ">=3.9.0") },
+		},
+		{
+			// Control: string arrays take a different schema-default-filling path than arrays of records; kept
+			// in its own file so failures aren't misattributed. compound_identifier was introduced in 3.9.0.
+			name:      "empty string-array field on an enterprise plugin",
+			stateFile: "testdata/diff/010-empty-array-plugin-config/kong-enterprise-string-arrays.yaml",
+			runWhen:   func(t *testing.T) { runWhen(t, "enterprise", ">=3.9.0") },
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.runWhen(t)
+			setup(t)
+
+			// A perpetual diff only surfaces across convergence cycles, so sync then diff twice: the second
+			// cycle proves the first sync wrote nothing that diffs dirty again. Diff alone writes nothing.
+			for i := range 2 {
+				require.NoError(t, sync(ctx, tc.stateFile))
+
+				out, err := diff(tc.stateFile)
+				require.NoError(t, err)
+				require.Equal(t, emptyOutput, out, "diff after sync %d reported changes", i+1)
+			}
+		})
+	}
+}
+
+// Test_Diff_EmptyArrayPluginConfig_RealChangeStillDetected guards the other direction: normalizing empty arrays
+// must not swallow a genuine change from an empty array to a populated one.
+func Test_Diff_EmptyArrayPluginConfig_RealChangeStillDetected(t *testing.T) {
+	// the fixtures set plugin instance_name, which Kong only supports from 3.2.0.
+	runWhenKongOrKonnect(t, ">=3.2.0")
+	setup(t)
+	ctx := context.Background()
+
+	require.NoError(t, sync(ctx, "testdata/diff/010-empty-array-plugin-config/kong.yaml"))
+
+	out, err := diff("testdata/diff/010-empty-array-plugin-config/kong-populated.yaml")
+	require.NoError(t, err)
+	assert.NotEqual(t, emptyOutput, out)
+	assert.Contains(t, out, "updating plugin zipkin")
+
+	// once applied, the populated state diffs clean too.
+	require.NoError(t, sync(ctx, "testdata/diff/010-empty-array-plugin-config/kong-populated.yaml"))
+
+	out, err = diff("testdata/diff/010-empty-array-plugin-config/kong-populated.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, emptyOutput, out)
+
+	// the reverse direction (populated -> []) is the one normalization could plausibly swallow; it must still be
+	// reported and must diff clean once applied.
+	out, err = diff("testdata/diff/010-empty-array-plugin-config/kong.yaml")
+	require.NoError(t, err)
+	assert.NotEqual(t, emptyOutput, out, "populated -> [] must still be reported")
+	assert.Contains(t, out, "updating plugin zipkin")
+
+	require.NoError(t, sync(ctx, "testdata/diff/010-empty-array-plugin-config/kong.yaml"))
+
+	out, err = diff("testdata/diff/010-empty-array-plugin-config/kong.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, emptyOutput, out)
+}
+
+// Test_Diff_EmptyArrayPluginConfig_OmittedFieldMatchesEmptyArray pins down that omitting an array field entirely
+// is indistinguishable from setting it to [], since decK fills both sides with nil before comparing.
+func Test_Diff_EmptyArrayPluginConfig_OmittedFieldMatchesEmptyArray(t *testing.T) {
+	// the fixtures set plugin instance_name, which Kong only supports from 3.2.0.
+	runWhenKongOrKonnect(t, ">=3.2.0")
+	setup(t)
+	ctx := context.Background()
+
+	require.NoError(t, sync(ctx, "testdata/diff/010-empty-array-plugin-config/kong.yaml"))
+
+	out, err := diff("testdata/diff/010-empty-array-plugin-config/kong-omitted.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, emptyOutput, out)
+}
+
 func Test_Diff_Konnect_Workspace(t *testing.T) {
 	runWhenKonnect(t)
 	setup(t)

--- a/tests/integration/testdata/diff/010-empty-array-plugin-config/kong-enterprise-string-arrays.yaml
+++ b/tests/integration/testdata/diff/010-empty-array-plugin-config/kong-enterprise-string-arrays.yaml
@@ -13,5 +13,7 @@ plugins:
       limit:
         - 10
       strategy: local
+      # must be explicit: 3.9 coerces it to -1 for strategy=local, 3.10+ leaves it null
+      sync_rate: -1
       window_size:
         - 60

--- a/tests/integration/testdata/diff/010-empty-array-plugin-config/kong-enterprise-string-arrays.yaml
+++ b/tests/integration/testdata/diff/010-empty-array-plugin-config/kong-enterprise-string-arrays.yaml
@@ -1,0 +1,17 @@
+_format_version: "3.0"
+plugins:
+  - name: rate-limiting-advanced
+    enabled: true
+    instance_name: rate-limiting-advanced-empty-array
+    protocols:
+      - http
+      - https
+    config:
+      compound_identifier: []
+      identifier: consumer
+      namespace: empty-array-test
+      limit:
+        - 10
+      strategy: local
+      window_size:
+        - 60

--- a/tests/integration/testdata/diff/010-empty-array-plugin-config/kong-enterprise.yaml
+++ b/tests/integration/testdata/diff/010-empty-array-plugin-config/kong-enterprise.yaml
@@ -1,0 +1,16 @@
+_format_version: "3.0"
+# injection-protection.config.custom_injections is an array-of-records field explicitly set to [], which used to
+# overwrite as nil during schema-default filling and never diff clean.
+plugins:
+  - name: injection-protection
+    enabled: true
+    instance_name: injection-protection-empty-array
+    protocols:
+      - http
+      - https
+    config:
+      custom_injections: []
+      injection_types:
+        - sql
+      locations:
+        - path_and_query

--- a/tests/integration/testdata/diff/010-empty-array-plugin-config/kong-nested.yaml
+++ b/tests/integration/testdata/diff/010-empty-array-plugin-config/kong-nested.yaml
@@ -1,0 +1,15 @@
+_format_version: "3.0"
+# Same scenario as kong.yaml, but the empty array (config.prompts.prepend) is nested inside a record field rather than at the top level.
+plugins:
+  - name: ai-prompt-decorator
+    enabled: true
+    instance_name: ai-prompt-decorator-empty-array
+    protocols:
+      - http
+      - https
+    config:
+      prompts:
+        prepend: []
+        append:
+          - role: system
+            content: Be concise.

--- a/tests/integration/testdata/diff/010-empty-array-plugin-config/kong-omitted.yaml
+++ b/tests/integration/testdata/diff/010-empty-array-plugin-config/kong-omitted.yaml
@@ -1,0 +1,11 @@
+_format_version: "3.0"
+# Same plugin as kong.yaml with config.static_tags omitted entirely rather than set to []; must diff clean against a gateway synced from kong.yaml.
+plugins:
+  - name: zipkin
+    enabled: true
+    instance_name: zipkin-empty-array
+    protocols:
+      - http
+      - https
+    config:
+      http_endpoint: http://localhost:9411/api/v2/spans

--- a/tests/integration/testdata/diff/010-empty-array-plugin-config/kong-populated.yaml
+++ b/tests/integration/testdata/diff/010-empty-array-plugin-config/kong-populated.yaml
@@ -1,0 +1,14 @@
+_format_version: "3.0"
+# Same plugin as kong.yaml with config.static_tags populated, to assert normalization doesn't swallow a genuine [] -> non-empty change.
+plugins:
+  - name: zipkin
+    enabled: true
+    instance_name: zipkin-empty-array
+    protocols:
+      - http
+      - https
+    config:
+      http_endpoint: http://localhost:9411/api/v2/spans
+      static_tags:
+        - name: environment
+          value: test

--- a/tests/integration/testdata/diff/010-empty-array-plugin-config/kong.yaml
+++ b/tests/integration/testdata/diff/010-empty-array-plugin-config/kong.yaml
@@ -1,0 +1,12 @@
+_format_version: "3.0"
+# config.static_tags is a top-level array-of-records field explicitly set to [], which used to overwrite as nil during schema-default filling and never diff clean.
+plugins:
+  - name: zipkin
+    enabled: true
+    instance_name: zipkin-empty-array
+    protocols:
+      - http
+      - https
+    config:
+      http_endpoint: http://localhost:9411/api/v2/spans
+      static_tags: []


### PR DESCRIPTION
Add integration tests to verify decK correctly handles plugin configurations with explicitly empty arrays, preventing perpetual diffs that never converge. Tests cover various scenarios top-level and nested empty arrays, enterprise plugins, and string arrays. Also validates that genuine changes from empty to populated arrays are still detected, and that omitted fields match empty arrays.


An unintended side effect was discovered and has been documented here: #2188 