### PR TITLE
Bumps go-apiops to v0.4.6 

### DIFF
--- a/cmd/file_openapi2mcp.go
+++ b/cmd/file_openapi2mcp.go
@@ -129,7 +129,7 @@ Security extensions:
 	openapi2mcpCmd.Flags().BoolVar(&cmdO2MskipID, "no-id", false,
 		"Do not generate UUIDs for entities.")
 	openapi2mcpCmd.Flags().StringVarP(&cmdO2Mmode, "mode", "m", openapi2mcp.ModeConversionListener,
-		"ai-mcp-proxy mode: 'conversion' (client mode) or 'conversion-listener' (server mode).")
+		"ai-mcp-proxy mode: 'passthrough-listener', 'conversion-listener', 'conversion-only', or 'listener'.")
 	openapi2mcpCmd.Flags().StringVarP(&cmdO2MpathPrefix, "path-prefix", "p", "",
 		"Custom path prefix for the MCP route (default: /{service-name}-mcp).")
 	openapi2mcpCmd.Flags().BoolVar(&cmdO2MincludeDirectRoute, "include-direct-route", false,

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/ettle/strcase v0.2.0
 	github.com/fatih/color v1.19.0
 	github.com/google/go-cmp v0.7.0
-	github.com/kong/go-apiops v0.4.5
+	github.com/kong/go-apiops v0.4.6
 	github.com/kong/go-database-reconciler v1.42.1
 	github.com/kong/go-kong v0.77.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -254,8 +254,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/kong/go-apiops v0.4.5 h1:9b41aJ5LKlVR+RaspviTE6nBD9oZRTltw+tRA2k9k7g=
-github.com/kong/go-apiops v0.4.5/go.mod h1:Xt99d90LallLVwYJAGaufiNbBdsK0KKboe7gR4Ryths=
+github.com/kong/go-apiops v0.4.6 h1:sQkTievX92AT5PZNZcUFbm7inysBVeZIIagXN8MWnP8=
+github.com/kong/go-apiops v0.4.6/go.mod h1:Xt99d90LallLVwYJAGaufiNbBdsK0KKboe7gR4Ryths=
 github.com/kong/go-database-reconciler v1.42.1 h1:1F4XhhJcnK5ixmeeZ973N4pjIkmnf9xlIejdq6+TZMs=
 github.com/kong/go-database-reconciler v1.42.1/go.mod h1:AYYSt3TBXL8QMa1IZwqj4BhSxKMkFXama5ObtgWPoMc=
 github.com/kong/go-kong v0.77.0 h1:bANx78/pE+kbKnL1ssa24Si4xbyBjhkUxwTOI+MrnnI=


### PR DESCRIPTION
 ### Summary
Bumps go-apiops to v0.4.6, which fixes the mode values the openapi2mcp converter accepts. 

### Full changelog

* [Fix] deck's own --mode flag description still advertised "conversion" (never a real mode) and omitted conversion-only, listener, and passthrough-listener.

### Issues resolved

[Fix] https://github.com/Kong/deck/issues/2175](https://github.com/Kong/deck/issues/2181

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
