### PR TITLE
Fix/dump with degraphql referring different workspace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/fatih/color v1.19.0
 	github.com/google/go-cmp v0.7.0
 	github.com/kong/go-apiops v0.4.6
-	github.com/kong/go-database-reconciler v1.42.2
+	github.com/kong/go-database-reconciler v1.42.3
 	github.com/kong/go-kong v0.77.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kong/go-apiops v0.4.6 h1:sQkTievX92AT5PZNZcUFbm7inysBVeZIIagXN8MWnP8=
 github.com/kong/go-apiops v0.4.6/go.mod h1:Xt99d90LallLVwYJAGaufiNbBdsK0KKboe7gR4Ryths=
-github.com/kong/go-database-reconciler v1.42.2 h1:yhakTDbcBLYKon/8+XVALIMWdCiUumzumLeNUBwaqHA=
-github.com/kong/go-database-reconciler v1.42.2/go.mod h1:AYYSt3TBXL8QMa1IZwqj4BhSxKMkFXama5ObtgWPoMc=
+github.com/kong/go-database-reconciler v1.42.3 h1:4L1uLDZb/BHnszlDg/SgqOZw8LPFbS+OZ/BHqcFfpUE=
+github.com/kong/go-database-reconciler v1.42.3/go.mod h1:AYYSt3TBXL8QMa1IZwqj4BhSxKMkFXama5ObtgWPoMc=
 github.com/kong/go-kong v0.77.0 h1:bANx78/pE+kbKnL1ssa24Si4xbyBjhkUxwTOI+MrnnI=
 github.com/kong/go-kong v0.77.0/go.mod h1:Wx5aTcMjyUnIF94M5NYFWb/EnuEkqB5STrWvybFSYYQ=
 github.com/kong/go-slugify v1.0.0 h1:vCFAyf2sdoSlBtLcrmDWUFn0ohlpKiKvQfXZkO5vSKY=

--- a/tests/integration/dump_test.go
+++ b/tests/integration/dump_test.go
@@ -1351,6 +1351,43 @@ func Test_Dump_GraphqlRateLimitingCostDecorations_Konnect(t *testing.T) {
 	}
 }
 
+// test scope:
+//   - enterprise, workspaces
+func Test_Dump_DegraphqlRoute_CrossWorkspaceService(t *testing.T) {
+	runWhen(t, "enterprise", "=3.4.3.25 || =3.10.0.10 || =3.11.0.9 || =3.12.0.5 || =3.13.0.3"+
+		" || >=3.14.0.2")
+	setup(t)
+	t.Cleanup(func() {
+		reset(t, "--all-workspaces")
+	})
+
+	ctx := context.Background()
+
+	// workspace test-b: create an unrelated service. This runs before test-a is
+	// populated below: since degraphql_routes/cost decorations are global
+	// entities (see below), a `sync` against test-b done *after* they exist
+	// would fetch them as part of its "current state" and, not finding them in
+	// this file, delete them as part of its normal reconciliation.
+	require.NoError(t, sync(ctx,
+		"testdata/dump/015-degraphql-cross-workspace-service/workspace-b-service.yaml"))
+
+	// workspace test-a: create a service, plus a degraphql route and a graphql
+	// ratelimiting cost decoration that reference it.
+	require.NoError(t, sync(ctx,
+		"testdata/dump/015-degraphql-cross-workspace-service/workspace-a-initial.yaml"))
+
+	// degraphql_routes and graphql_ratelimiting_cost_decorations are global
+	// entities in Kong: they aren't scoped to the workspace they were created
+	// in, so dumping test-b also picks up test-a's route and decoration. Their
+	// "service" can't be resolved against test-b's own state, since that
+	// service lives in test-a. That must produce a warning, not an error.
+	output, err := dump("-o", "-", "--workspace", "test-b")
+	require.NoError(t, err)
+
+	assert.Contains(t, output, "1a111111-1111-4111-8111-111111111111",
+		"the cross-workspace service id should still be present in the dump")
+}
+
 func Test_Dump_KonnectWorkspace(t *testing.T) {
 	runWhenKonnect(t)
 	setup(t)

--- a/tests/integration/dump_test.go
+++ b/tests/integration/dump_test.go
@@ -1353,7 +1353,7 @@ func Test_Dump_GraphqlRateLimitingCostDecorations_Konnect(t *testing.T) {
 
 // test scope:
 //   - enterprise, workspaces
-func Test_Dump_DegraphqlRoute_CrossWorkspaceService(t *testing.T) {
+func Test_Dump_CustomEntities_CrossWorkspaceService(t *testing.T) {
 	runWhen(t, "enterprise", "=3.4.3.25 || =3.10.0.10 || =3.11.0.9 || =3.12.0.5 || =3.13.0.3"+
 		" || >=3.14.0.2")
 	setup(t)

--- a/tests/integration/testdata/dump/015-degraphql-cross-workspace-service/workspace-a-initial.yaml
+++ b/tests/integration/testdata/dump/015-degraphql-cross-workspace-service/workspace-a-initial.yaml
@@ -1,0 +1,27 @@
+_format_version: "3.0"
+_workspace: test-a
+services:
+  - id: 1a111111-1111-4111-8111-111111111111
+    connect_timeout: 60000
+    host: mockbin.org
+    name: svc-a
+    port: 80
+    protocol: http
+    read_timeout: 60000
+    retries: 5
+    write_timeout: 60000
+custom_entities:
+  - type: degraphql_routes
+    id: 2b222222-2222-4222-8222-222222222222
+    fields:
+      uri: "/users"
+      query: "query{ users { id name } }"
+      service:
+        id: 1a111111-1111-4111-8111-111111111111
+  - type: graphql_ratelimiting_cost_decorations
+    id: 3c333333-3333-4333-8333-333333333333
+    fields:
+      service:
+        id: 1a111111-1111-4111-8111-111111111111
+      type_path: "Query.users"
+      add_constant: 1.0

--- a/tests/integration/testdata/dump/015-degraphql-cross-workspace-service/workspace-b-service.yaml
+++ b/tests/integration/testdata/dump/015-degraphql-cross-workspace-service/workspace-b-service.yaml
@@ -1,0 +1,12 @@
+_format_version: "3.0"
+_workspace: test-b
+services:
+  - id: 4d444444-4444-4444-8444-444444444444
+    connect_timeout: 60000
+    host: mockbin.org
+    name: test-service
+    port: 80
+    protocol: http
+    read_timeout: 60000
+    retries: 5
+    write_timeout: 60000


### PR DESCRIPTION
### Summary
While building state for degraphql routes and cost decoration - we were ensuring that the service they are attached to is present in state. However, this leads to a problem - since these two custom entities are global, they are present in dump of every workspace - and any workspace not containing the service they are linked to ends up erroring out during dump - effectively blocking the users.

Fix: Relax the constraint to avoid erroring out if service is not in state, and instead print a warning instead - same as we do for plugin partials when not in state.

### Tests added
- Dump a different workspace when custom entities are configured

Fixes https://github.com/Kong/deck/issues/2180
GDR PR: https://github.com/Kong/go-database-reconciler/pull/511