### PR TITLE
chore: update base image from static-debian12 to static-debian13 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o deck \
 
 FROM ghcr.io/jqlang/jq:1.8.2@sha256:b9c68867e5766576263a222e91db3de422d802069c7af70440e667a95344e486 AS jq
 
-FROM gcr.io/distroless/static-debian12:nonroot@sha256:37d3baf4e657ce79c144b69b69f60b8542f366a64fb7a49bd99f5444ef008bb0
+FROM gcr.io/distroless/static-debian13:nonroot@sha256:f7f8f729987ad0fdf6b05eeeae94b26e6a0f613bdf46feea7fc40f7bd72953e6
 
 ARG COMMIT
 ARG TAG


### PR DESCRIPTION
Upgrade Debian Linux to version 13 as version 12 is no longer receiving security updates since 2026-07-11