### PR TITLE
Release v1.66.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [v1.66.0](#v1660)
 - [v1.65.3](#v1653)
 - [v1.65.2](#v1652)
 - [v1.65.1](#v1651)
@@ -147,6 +148,13 @@
 - [v0.2.0](#v020)
 - [v0.1.0](#v010)
 
+
+## [v1.66.0]
+> Release date: 2026/09/01
+
+### Features
+- Added support for new AI Gateway 2.0 entities such as `certificate`, `ca_certificate` and `sni`
+[#2217](https://github.com/Kong/deck/pull/2217)
 
 ## [v1.65.3]
 > Release date: 2026/08/27
@@ -2728,6 +2736,7 @@ No breaking changes have been introduced in this release.
 ### Summary
 
 Debut release of decK
+[v1.66.0]: https://github.com/Kong/deck/compare/v1.65.3...v1.66.0
 [v1.65.3]: https://github.com/Kong/deck/compare/v1.65.2...v1.65.3
 [v1.65.2]: https://github.com/Kong/deck/compare/v1.65.1...v1.65.2
 [v1.65.1]: https://github.com/Kong/deck/compare/v1.64.0...v1.65.1

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ the GitHub [release page](https://github.com/kong/deck/releases)
 or install by downloading the binary:
 
 ```shell
-$ curl -sL https://github.com/kong/deck/releases/download/v1.65.3/deck_1.65.3_linux_amd64.tar.gz -o deck.tar.gz
+$ curl -sL https://github.com/kong/deck/releases/download/v1.66.0/deck_1.66.0_linux_amd64.tar.gz -o deck.tar.gz
 $ tar -xf deck.tar.gz -C /tmp
 $ sudo cp /tmp/deck /usr/local/bin/
 ```
@@ -84,7 +84,7 @@ If you are on Windows, you can download the binary from the GitHub
 [release page](https://github.com/kong/deck/releases) or via PowerShell:
 
 ```shell
-$ curl -sL https://github.com/kong/deck/releases/download/v1.65.3/deck_1.65.3_windows_amd64.tar.gz -o deck.tar.gz
+$ curl -sL https://github.com/kong/deck/releases/download/v1.66.0/deck_1.66.0_windows_amd64.tar.gz -o deck.tar.gz
 $ tar -xzvf deck.tar.gz
 ```
 


### PR DESCRIPTION
Releases deck `v1.66.0` with support for new entities in AI Gateway 2.0

Diff:
Deck: https://github.com/Kong/deck/compare/v1.65.3...main
ai-deck-converter: https://github.com/Kong/ai-deck-converter/compare/v0.12.1...v0.17.1