### PR TITLE
style: fix lint

### DIFF
--- a/convert/utils.go
+++ b/convert/utils.go
@@ -42,7 +42,7 @@ func isEmpty(v interface{}) bool {
 
 	rv := reflect.ValueOf(v)
 
-	switch rv.Kind() { //nolint:exhaustive
+	switch rv.Kind() {
 	case reflect.Slice, reflect.Array, reflect.Map:
 		return rv.Len() == 0
 	}


### PR DESCRIPTION
DecK lint step on CI started failing on `main` today - even though linter version is pinned on CI.
I'm fixing the offending line, but we don't know why this failure occurred (not intermittent, verified by retrying)

We need to find out if the tag of linter got reassigned to a new commit / why the version pinning did not prevent this.