### PR TITLE
docs: release v1.66.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,7 +159,7 @@
 [go-database-reconciler #516](https://github.com/Kong/go-database-reconciler/pull/516)
 
 ### Chores
-- Release binaries are now signed and notarized.
+- Release binarie for MacOS are now signed and notarized.
 [#2227](https://github.com/Kong/deck/pull/2227)
 
 ## [v1.66.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Table of Contents
 
+- [v1.66.1](#v1661)
 - [v1.66.0](#v1660)
 - [v1.65.3](#v1653)
 - [v1.65.2](#v1652)
@@ -148,6 +149,18 @@
 - [v0.2.0](#v020)
 - [v0.1.0](#v010)
 
+
+## [v1.66.1]
+> Release date: 2026/09/08
+
+### Fixed
+- Fixed env var masking for `PEM` during `deck gateway diff` to correctly detect certificates/keys that contain indentation.
+[#2218](https://github.com/Kong/deck/pull/2218)
+[go-database-reconciler #516](https://github.com/Kong/go-database-reconciler/pull/516)
+
+### Chores
+- Release binaries are now signed and notarized.
+[#2227](https://github.com/Kong/deck/pull/2227)
 
 ## [v1.66.0]
 > Release date: 2026/09/01
@@ -2736,6 +2749,7 @@ No breaking changes have been introduced in this release.
 ### Summary
 
 Debut release of decK
+[v1.66.1]: https://github.com/Kong/deck/compare/v1.66.0...v1.66.1
 [v1.66.0]: https://github.com/Kong/deck/compare/v1.65.3...v1.66.0
 [v1.65.3]: https://github.com/Kong/deck/compare/v1.65.2...v1.65.3
 [v1.65.2]: https://github.com/Kong/deck/compare/v1.65.1...v1.65.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,12 +154,12 @@
 > Release date: 2026/09/08
 
 ### Fixed
-- Fixed env var masking for `PEM` during `deck gateway diff` to correctly detect certificates/keys that contain indentation.
+- Fixed env var masking for `PEM` during `deck gateway diff`, `deck gateway apply` and `deck gateway sync` by correctly detecting certificates/keys that contain indentation.
 [#2218](https://github.com/Kong/deck/pull/2218)
 [go-database-reconciler #516](https://github.com/Kong/go-database-reconciler/pull/516)
 
 ### Chores
-- Release binarie for MacOS are now signed and notarized.
+- Release binaries for MacOS are now signed and notarized.
 [#2227](https://github.com/Kong/deck/pull/2227)
 
 ## [v1.66.0]

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ the GitHub [release page](https://github.com/kong/deck/releases)
 or install by downloading the binary:
 
 ```shell
-$ curl -sL https://github.com/kong/deck/releases/download/v1.66.0/deck_1.66.0_linux_amd64.tar.gz -o deck.tar.gz
+$ curl -sL https://github.com/kong/deck/releases/download/v1.66.1/deck_1.66.1_linux_amd64.tar.gz -o deck.tar.gz
 $ tar -xf deck.tar.gz -C /tmp
 $ sudo cp /tmp/deck /usr/local/bin/
 ```
@@ -84,7 +84,7 @@ If you are on Windows, you can download the binary from the GitHub
 [release page](https://github.com/kong/deck/releases) or via PowerShell:
 
 ```shell
-$ curl -sL https://github.com/kong/deck/releases/download/v1.66.0/deck_1.66.0_windows_amd64.tar.gz -o deck.tar.gz
+$ curl -sL https://github.com/kong/deck/releases/download/v1.66.1/deck_1.66.1_windows_amd64.tar.gz -o deck.tar.gz
 $ tar -xzvf deck.tar.gz
 ```
 


### PR DESCRIPTION
Releasing `v1.66.1` with - 
1. Signing and notarization for macos build (dry run and build available [here](https://github.com/Kong/deck/actions/runs/34182608893/job/101924553295))
2. PEM env var masking fix

Diff:
DecK: https://github.com/Kong/deck/compare/v1.66.0...main
GDR: https://github.com/Kong/go-database-reconciler/compare/v1.42.3...v1.42.4