### PR TITLE
fix: fill schema defaults on current partial before diffing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/fatih/color v1.19.0
 	github.com/google/go-cmp v0.7.0
 	github.com/kong/go-apiops v0.4.6
-	github.com/kong/go-database-reconciler v1.42.4
+	github.com/kong/go-database-reconciler v1.42.5-0.20260910123708-de3744ec50a3
 	github.com/kong/go-kong v0.78.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kong/go-apiops v0.4.6 h1:sQkTievX92AT5PZNZcUFbm7inysBVeZIIagXN8MWnP8=
 github.com/kong/go-apiops v0.4.6/go.mod h1:Xt99d90LallLVwYJAGaufiNbBdsK0KKboe7gR4Ryths=
-github.com/kong/go-database-reconciler v1.42.4 h1:CxeipG/dWIHi73bztg6BU7lIwotOKP1FUmfbz7sp6PE=
-github.com/kong/go-database-reconciler v1.42.4/go.mod h1:/lEPLhpDI1x+OOhQ+JeY3OsxvXYN04o12AmqzN7llRQ=
+github.com/kong/go-database-reconciler v1.42.5-0.20260910123708-de3744ec50a3 h1:lyOdsCUS4gDB4SOpzH2HZQT9qMP8k4iU6EVv+3SXDEE=
+github.com/kong/go-database-reconciler v1.42.5-0.20260910123708-de3744ec50a3/go.mod h1:/lEPLhpDI1x+OOhQ+JeY3OsxvXYN04o12AmqzN7llRQ=
 github.com/kong/go-kong v0.78.0 h1:VK5g26BCeF+l9o3j3pgU3BOuOdmTd9Vj33x29mKGtkg=
 github.com/kong/go-kong v0.78.0/go.mod h1:Wx5aTcMjyUnIF94M5NYFWb/EnuEkqB5STrWvybFSYYQ=
 github.com/kong/go-slugify v1.0.0 h1:vCFAyf2sdoSlBtLcrmDWUFn0ohlpKiKvQfXZkO5vSKY=


### PR DESCRIPTION
Fill schema defaults on partials before diffing, preventing spurious update diffs.


Fixes Issue: #2199

Corresponding GDR PR: https://github.com/Kong/go-database-reconciler/pull/527